### PR TITLE
Add Array Support

### DIFF
--- a/array.go
+++ b/array.go
@@ -1,0 +1,488 @@
+package tiledb
+
+/*
+#cgo LDFLAGS: -ltiledb
+#include <tiledb/tiledb.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+// Array is tiledb array
+type Array struct {
+	tiledbArray *C.tiledb_array_t
+	context     *Context
+	uri         string
+}
+
+// NewArray alloc a new array
+func NewArray(ctx *Context, uri string) (*Array, error) {
+	curi := C.CString(uri)
+	defer C.free(unsafe.Pointer(curi))
+	array := Array{context: ctx, uri: uri}
+	ret := C.tiledb_array_alloc(array.context.tiledbContext, curi, &array.tiledbArray)
+	if ret == C.TILEDB_ERR {
+		return nil, fmt.Errorf("Error creating tiledb array: %s", array.context.GetLastError())
+	}
+
+	// Set finalizer for free C pointer on gc
+	runtime.SetFinalizer(&array, func(array *Array) {
+		array.Free()
+	})
+
+	return &array, nil
+}
+
+// Free tiledb_domain_t that was allocated on heap in c
+func (a *Array) Free() {
+	if a.tiledbArray != nil {
+		C.tiledb_array_free(&a.tiledbArray)
+	}
+}
+
+// Open a tiledb array
+func (a *Array) Open(queryType QueryType) error {
+	ret := C.tiledb_array_open(a.context.tiledbContext, a.tiledbArray, C.tiledb_query_type_t(queryType))
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error opening tiledb array for querying: %s", a.context.GetLastError())
+	}
+	return nil
+}
+
+// Reopen a tiledb array, useful when an array is updated
+func (a *Array) Reopen() error {
+	ret := C.tiledb_array_reopen(a.context.tiledbContext, a.tiledbArray)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error reopening tiledb array for querying: %s", a.context.GetLastError())
+	}
+	return nil
+}
+
+// Close a tiledb array
+func (a *Array) Close() error {
+	ret := C.tiledb_array_close(a.context.tiledbContext, a.tiledbArray)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error closing tiledb array for querying: %s", a.context.GetLastError())
+	}
+	return nil
+}
+
+// Create a tiledb array
+func (a *Array) Create(arraySchema *ArraySchema) error {
+	curi := C.CString(a.uri)
+	defer C.free(unsafe.Pointer(curi))
+	ret := C.tiledb_array_create(a.context.tiledbContext, curi, arraySchema.tiledbArraySchema)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error creating tiledb array: %s", a.context.GetLastError())
+	}
+	return nil
+}
+
+// Consolidate the fragements of an array into a single fragement
+func (a *Array) Consolidate() error {
+	curi := C.CString(a.uri)
+	defer C.free(unsafe.Pointer(curi))
+	ret := C.tiledb_array_consolidate(a.context.tiledbContext, curi)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error consolidating tiledb array: %s", a.context.GetLastError())
+	}
+	return nil
+}
+
+// Schema returns the ArraySchema
+func (a *Array) Schema() (*ArraySchema, error) {
+	arraySchema := ArraySchema{context: a.context}
+	ret := C.tiledb_array_get_schema(a.context.tiledbContext, a.tiledbArray, &arraySchema.tiledbArraySchema)
+	if ret != C.TILEDB_OK {
+		return nil, fmt.Errorf("Error getting schema for tiledb array: %s", a.context.GetLastError())
+	}
+	return &arraySchema, nil
+}
+
+// QueryType return the current query type of an open array
+func (a *Array) QueryType() (QueryType, error) {
+	var queryType C.tiledb_query_type_t
+	ret := C.tiledb_array_get_query_type(a.context.tiledbContext, a.tiledbArray, &queryType)
+	if ret != C.TILEDB_OK {
+		return -1, fmt.Errorf("Error getting QueryType for tiledb array: %s", a.context.GetLastError())
+	}
+	return QueryType(queryType), nil
+}
+
+// NonEmptyDomain retrieves the non-empty domain from an array
+// This returns the bounding coordinates for each dimension
+func (a *Array) NonEmptyDomain() ([]map[string]interface{}, bool, error) {
+	nonEmptyDomains := make([]map[string]interface{}, 1)
+	schema, err := a.Schema()
+	if err != nil {
+		return nil, false, err
+	}
+
+	domain, err := schema.Domain()
+	if err != nil {
+		return nil, false, err
+	}
+
+	domainType, err := domain.Type()
+	if err != nil {
+		return nil, false, err
+	}
+
+	ndims, err := domain.NDim()
+	if err != nil {
+		return nil, false, err
+	}
+
+	var ret C.int
+	var isEmpty C.int
+	switch domainType {
+
+	case TILEDB_INT8:
+		tmpDomain := make([]int8, 2*ndims)
+		ret = C.tiledb_array_get_non_empty_domain(a.context.tiledbContext, a.tiledbArray, unsafe.Pointer(&tmpDomain[0]), &isEmpty)
+		if ret != C.TILEDB_OK {
+			return nil, false, fmt.Errorf("Error in getting non empty domain for array: %s", a.context.GetLastError())
+		}
+		if isEmpty == 0 {
+			for i := uint(0); i < ndims; i++ {
+				dimension, err := domain.DimensionFromIndex(i)
+				if err != nil {
+					return nil, false, err
+				}
+
+				name, err := dimension.Name()
+				if err != nil {
+					return nil, false, err
+				}
+				tmpMap := map[string]interface{}{name: []int8{tmpDomain[i*2], tmpDomain[(i*2)+1]}}
+				nonEmptyDomains = append(nonEmptyDomains, tmpMap)
+			}
+		}
+	case TILEDB_INT16:
+		tmpDomain := make([]int16, 2*ndims)
+		ret = C.tiledb_array_get_non_empty_domain(a.context.tiledbContext, a.tiledbArray, unsafe.Pointer(&tmpDomain[0]), &isEmpty)
+		if ret != C.TILEDB_OK {
+			return nil, false, fmt.Errorf("Error in getting non empty domain for array: %s", a.context.GetLastError())
+		}
+		if isEmpty == 0 {
+			for i := uint(0); i < ndims; i++ {
+				dimension, err := domain.DimensionFromIndex(i)
+				if err != nil {
+					return nil, false, err
+				}
+
+				name, err := dimension.Name()
+				if err != nil {
+					return nil, false, err
+				}
+				tmpMap := map[string]interface{}{name: []int16{tmpDomain[i*2], tmpDomain[(i*2)+1]}}
+				nonEmptyDomains = append(nonEmptyDomains, tmpMap)
+			}
+		}
+	case TILEDB_INT32:
+		tmpDomain := make([]int32, 2*ndims)
+		ret = C.tiledb_array_get_non_empty_domain(a.context.tiledbContext, a.tiledbArray, unsafe.Pointer(&tmpDomain[0]), &isEmpty)
+		if ret != C.TILEDB_OK {
+			return nil, false, fmt.Errorf("Error in getting non empty domain for array: %s", a.context.GetLastError())
+		}
+		if isEmpty == 0 {
+			for i := uint(0); i < ndims; i++ {
+				dimension, err := domain.DimensionFromIndex(i)
+				if err != nil {
+					return nil, false, err
+				}
+
+				name, err := dimension.Name()
+				if err != nil {
+					return nil, false, err
+				}
+				tmpMap := map[string]interface{}{name: []int32{tmpDomain[i*2], tmpDomain[(i*2)+1]}}
+				nonEmptyDomains = append(nonEmptyDomains, tmpMap)
+			}
+		}
+	case TILEDB_INT64:
+		tmpDomain := make([]int64, 2*ndims)
+		ret = C.tiledb_array_get_non_empty_domain(a.context.tiledbContext, a.tiledbArray, unsafe.Pointer(&tmpDomain[0]), &isEmpty)
+		if ret != C.TILEDB_OK {
+			return nil, false, fmt.Errorf("Error in getting non empty domain for array: %s", a.context.GetLastError())
+		}
+		if isEmpty == 0 {
+			for i := uint(0); i < ndims; i++ {
+				dimension, err := domain.DimensionFromIndex(i)
+				if err != nil {
+					return nil, false, err
+				}
+
+				name, err := dimension.Name()
+				if err != nil {
+					return nil, false, err
+				}
+				tmpMap := map[string]interface{}{name: []int64{tmpDomain[i*2], tmpDomain[(i*2)+1]}}
+				nonEmptyDomains = append(nonEmptyDomains, tmpMap)
+			}
+		}
+	case TILEDB_UINT8:
+		tmpDomain := make([]uint8, 2*ndims)
+		ret = C.tiledb_array_get_non_empty_domain(a.context.tiledbContext, a.tiledbArray, unsafe.Pointer(&tmpDomain[0]), &isEmpty)
+		if ret != C.TILEDB_OK {
+			return nil, false, fmt.Errorf("Error in getting non empty domain for array: %s", a.context.GetLastError())
+		}
+		if isEmpty == 0 {
+			for i := uint(0); i < ndims; i++ {
+				dimension, err := domain.DimensionFromIndex(i)
+				if err != nil {
+					return nil, false, err
+				}
+
+				name, err := dimension.Name()
+				if err != nil {
+					return nil, false, err
+				}
+				tmpMap := map[string]interface{}{name: []uint8{tmpDomain[i*2], tmpDomain[(i*2)+1]}}
+				nonEmptyDomains = append(nonEmptyDomains, tmpMap)
+			}
+		}
+	case TILEDB_UINT16:
+		tmpDomain := make([]uint16, 2*ndims)
+		ret = C.tiledb_array_get_non_empty_domain(a.context.tiledbContext, a.tiledbArray, unsafe.Pointer(&tmpDomain[0]), &isEmpty)
+		if ret != C.TILEDB_OK {
+			return nil, false, fmt.Errorf("Error in getting non empty domain for array: %s", a.context.GetLastError())
+		}
+		if isEmpty == 0 {
+			for i := uint(0); i < ndims; i++ {
+				dimension, err := domain.DimensionFromIndex(i)
+				if err != nil {
+					return nil, false, err
+				}
+
+				name, err := dimension.Name()
+				if err != nil {
+					return nil, false, err
+				}
+				tmpMap := map[string]interface{}{name: []uint16{tmpDomain[i*2], tmpDomain[(i*2)+1]}}
+				nonEmptyDomains = append(nonEmptyDomains, tmpMap)
+			}
+		}
+	case TILEDB_UINT32:
+		tmpDomain := make([]uint32, 2*ndims)
+		ret = C.tiledb_array_get_non_empty_domain(a.context.tiledbContext, a.tiledbArray, unsafe.Pointer(&tmpDomain[0]), &isEmpty)
+		if ret != C.TILEDB_OK {
+			return nil, false, fmt.Errorf("Error in getting non empty domain for array: %s", a.context.GetLastError())
+		}
+		if isEmpty == 0 {
+			for i := uint(0); i < ndims; i++ {
+				dimension, err := domain.DimensionFromIndex(i)
+				if err != nil {
+					return nil, false, err
+				}
+
+				name, err := dimension.Name()
+				if err != nil {
+					return nil, false, err
+				}
+				tmpMap := map[string]interface{}{name: []uint32{tmpDomain[i*2], tmpDomain[(i*2)+1]}}
+				nonEmptyDomains = append(nonEmptyDomains, tmpMap)
+			}
+		}
+	case TILEDB_UINT64:
+		tmpDomain := make([]uint64, 2*ndims)
+		ret = C.tiledb_array_get_non_empty_domain(a.context.tiledbContext, a.tiledbArray, unsafe.Pointer(&tmpDomain[0]), &isEmpty)
+		if ret != C.TILEDB_OK {
+			return nil, false, fmt.Errorf("Error in getting non empty domain for array: %s", a.context.GetLastError())
+		}
+		if isEmpty == 0 {
+			for i := uint(0); i < ndims; i++ {
+				dimension, err := domain.DimensionFromIndex(i)
+				if err != nil {
+					return nil, false, err
+				}
+
+				name, err := dimension.Name()
+				if err != nil {
+					return nil, false, err
+				}
+				tmpMap := map[string]interface{}{name: []uint64{tmpDomain[i*2], tmpDomain[(i*2)+1]}}
+				nonEmptyDomains = append(nonEmptyDomains, tmpMap)
+			}
+		}
+	case TILEDB_FLOAT32:
+		tmpDomain := make([]float32, 2*ndims)
+		ret = C.tiledb_array_get_non_empty_domain(a.context.tiledbContext, a.tiledbArray, unsafe.Pointer(&tmpDomain[0]), &isEmpty)
+		if ret != C.TILEDB_OK {
+			return nil, false, fmt.Errorf("Error in getting non empty domain for array: %s", a.context.GetLastError())
+		}
+		if isEmpty == 0 {
+			for i := uint(0); i < ndims; i++ {
+				dimension, err := domain.DimensionFromIndex(i)
+				if err != nil {
+					return nil, false, err
+				}
+
+				name, err := dimension.Name()
+				if err != nil {
+					return nil, false, err
+				}
+				tmpMap := map[string]interface{}{name: []float32{tmpDomain[i*2], tmpDomain[(i*2)+1]}}
+				nonEmptyDomains = append(nonEmptyDomains, tmpMap)
+			}
+		}
+	case TILEDB_FLOAT64:
+		tmpDomain := make([]float64, 2*ndims)
+		ret = C.tiledb_array_get_non_empty_domain(a.context.tiledbContext, a.tiledbArray, unsafe.Pointer(&tmpDomain[0]), &isEmpty)
+		if ret != C.TILEDB_OK {
+			return nil, false, fmt.Errorf("Error in getting non empty domain for array: %s", a.context.GetLastError())
+		}
+		if isEmpty == 0 {
+			for i := uint(0); i < ndims; i++ {
+				dimension, err := domain.DimensionFromIndex(i)
+				if err != nil {
+					return nil, false, err
+				}
+
+				name, err := dimension.Name()
+				if err != nil {
+					return nil, false, err
+				}
+				tmpMap := map[string]interface{}{name: []float64{tmpDomain[i*2], tmpDomain[(i*2)+1]}}
+				nonEmptyDomains = append(nonEmptyDomains, tmpMap)
+			}
+		}
+	}
+	return nonEmptyDomains, isEmpty == 1, nil
+}
+
+// MaxBufferSize computes the upper bound on the buffer size (inbyte) required for a read query for a given fixed attribute and subarray
+func (a *Array) MaxBufferSize(attributeName string, subarray interface{}) (uint64, error) {
+	// Get Schema
+	schema, err := a.Schema()
+	if err != nil {
+		return 0, err
+	}
+
+	// Get domain from schema
+	domain, err := schema.Domain()
+	if err != nil {
+		return 0, err
+	}
+
+	// Get domain type to switch on
+	domainType, err := domain.Type()
+	if err != nil {
+		return 0, err
+	}
+
+	cAttributeName := C.CString(attributeName)
+	defer C.free(unsafe.Pointer(cAttributeName))
+
+	var bufferSize C.uint64_t
+	var ret C.int
+	// Switch on domain type to cast subarray to proper type
+	switch domainType {
+	case TILEDB_INT8:
+		tmpSubArray := subarray.([]int8)
+		ret = C.tiledb_array_max_buffer_size(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferSize)
+	case TILEDB_INT16:
+		tmpSubArray := subarray.([]int16)
+		ret = C.tiledb_array_max_buffer_size(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferSize)
+	case TILEDB_INT32:
+		tmpSubArray := subarray.([]int32)
+		ret = C.tiledb_array_max_buffer_size(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferSize)
+	case TILEDB_INT64:
+		tmpSubArray := subarray.([]int64)
+		ret = C.tiledb_array_max_buffer_size(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferSize)
+	case TILEDB_UINT8:
+		tmpSubArray := subarray.([]uint8)
+		ret = C.tiledb_array_max_buffer_size(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferSize)
+	case TILEDB_UINT16:
+		tmpSubArray := subarray.([]uint16)
+		ret = C.tiledb_array_max_buffer_size(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferSize)
+	case TILEDB_UINT32:
+		tmpSubArray := subarray.([]uint32)
+		ret = C.tiledb_array_max_buffer_size(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferSize)
+	case TILEDB_UINT64:
+		tmpSubArray := subarray.([]uint64)
+		ret = C.tiledb_array_max_buffer_size(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferSize)
+	case TILEDB_FLOAT32:
+		tmpSubArray := subarray.([]float32)
+		ret = C.tiledb_array_max_buffer_size(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferSize)
+	case TILEDB_FLOAT64:
+		tmpSubArray := subarray.([]float64)
+		ret = C.tiledb_array_max_buffer_size(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferSize)
+	}
+	if ret != C.TILEDB_OK {
+		return 0, fmt.Errorf("Error in getting max buffer size for array: %s", a.context.GetLastError())
+	}
+
+	return uint64(bufferSize), nil
+}
+
+// MaxBufferSizeVar computes the upper bound on the buffer size (inbyte) required for a read query for a given variable sized attribute and subarray
+func (a *Array) MaxBufferSizeVar(attributeName string, subarray interface{}) (uint64, uint64, error) {
+	// Get Schema
+	schema, err := a.Schema()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// Get domain from schema
+	domain, err := schema.Domain()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// Get domain type to switch on
+	domainType, err := domain.Type()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	cAttributeName := C.CString(attributeName)
+	defer C.free(unsafe.Pointer(cAttributeName))
+
+	var bufferValSize C.uint64_t
+	var bufferOffSize C.uint64_t
+	var ret C.int
+	// Switch on domain type to cast subarray to proper type
+	switch domainType {
+	case TILEDB_INT8:
+		tmpSubArray := subarray.([]int8)
+		ret = C.tiledb_array_max_buffer_size_var(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferOffSize, &bufferValSize)
+	case TILEDB_INT16:
+		tmpSubArray := subarray.([]int16)
+		ret = C.tiledb_array_max_buffer_size_var(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferOffSize, &bufferValSize)
+	case TILEDB_INT32:
+		tmpSubArray := subarray.([]int32)
+		ret = C.tiledb_array_max_buffer_size_var(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferOffSize, &bufferValSize)
+	case TILEDB_INT64:
+		tmpSubArray := subarray.([]int64)
+		ret = C.tiledb_array_max_buffer_size_var(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferOffSize, &bufferValSize)
+	case TILEDB_UINT8:
+		tmpSubArray := subarray.([]uint8)
+		ret = C.tiledb_array_max_buffer_size_var(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferOffSize, &bufferValSize)
+	case TILEDB_UINT16:
+		tmpSubArray := subarray.([]uint16)
+		ret = C.tiledb_array_max_buffer_size_var(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferOffSize, &bufferValSize)
+	case TILEDB_UINT32:
+		tmpSubArray := subarray.([]uint32)
+		ret = C.tiledb_array_max_buffer_size_var(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferOffSize, &bufferValSize)
+	case TILEDB_UINT64:
+		tmpSubArray := subarray.([]uint64)
+		ret = C.tiledb_array_max_buffer_size_var(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferOffSize, &bufferValSize)
+	case TILEDB_FLOAT32:
+		tmpSubArray := subarray.([]float32)
+		ret = C.tiledb_array_max_buffer_size_var(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferOffSize, &bufferValSize)
+	case TILEDB_FLOAT64:
+		tmpSubArray := subarray.([]float64)
+		ret = C.tiledb_array_max_buffer_size_var(a.context.tiledbContext, a.tiledbArray, cAttributeName, unsafe.Pointer(&tmpSubArray[0]), &bufferOffSize, &bufferValSize)
+	}
+	if ret != C.TILEDB_OK {
+		return 0, 0, fmt.Errorf("Error in getting max buffer size variable for array: %s", a.context.GetLastError())
+	}
+
+	return uint64(bufferOffSize), uint64(bufferValSize), nil
+}

--- a/array.go
+++ b/array.go
@@ -26,7 +26,7 @@ func NewArray(ctx *Context, uri string) (*Array, error) {
 	defer C.free(unsafe.Pointer(curi))
 	array := Array{context: ctx, uri: uri}
 	ret := C.tiledb_array_alloc(array.context.tiledbContext, curi, &array.tiledbArray)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb array: %s", array.context.GetLastError())
 	}
 

--- a/array_schema.go
+++ b/array_schema.go
@@ -23,7 +23,7 @@ type ArraySchema struct {
 func NewArraySchema(ctx *Context, arrayType ArrayType) (*ArraySchema, error) {
 	arraySchema := ArraySchema{context: ctx}
 	ret := C.tiledb_array_schema_alloc(arraySchema.context.tiledbContext, C.tiledb_array_type_t(arrayType), &arraySchema.tiledbArraySchema)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb arraySchema: %s", arraySchema.context.GetLastError())
 	}
 
@@ -46,7 +46,7 @@ func (a *ArraySchema) Free() {
 func (a *ArraySchema) AddAttributes(attributes ...Attribute) error {
 	for _, attribute := range attributes {
 		ret := C.tiledb_array_schema_add_attribute(a.context.tiledbContext, a.tiledbArraySchema, attribute.tiledbAttribute)
-		if ret == C.TILEDB_ERR {
+		if ret != C.TILEDB_OK {
 			return fmt.Errorf("Error adding attributes to tiledb arraySchema: %s", a.context.GetLastError())
 		}
 	}
@@ -56,7 +56,7 @@ func (a *ArraySchema) AddAttributes(attributes ...Attribute) error {
 // SetDomain sets a ArraySchema's domain
 func (a *ArraySchema) SetDomain(domain *Domain) error {
 	ret := C.tiledb_array_schema_set_domain(a.context.tiledbContext, a.tiledbArraySchema, domain.tiledbDomain)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error setting domain for tiledb arraySchema: %s", a.context.GetLastError())
 	}
 	return nil
@@ -66,7 +66,7 @@ func (a *ArraySchema) SetDomain(domain *Domain) error {
 func (a *ArraySchema) Domain() (*Domain, error) {
 	domain := Domain{context: a.context}
 	ret := C.tiledb_array_schema_get_domain(a.context.tiledbContext, a.tiledbArraySchema, &domain.tiledbDomain)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error setting domain for tiledb arraySchema: %s", a.context.GetLastError())
 	}
 	return &domain, nil
@@ -75,7 +75,7 @@ func (a *ArraySchema) Domain() (*Domain, error) {
 // SetCapacity sets an array's capacity
 func (a *ArraySchema) SetCapacity(capacity uint64) error {
 	ret := C.tiledb_array_schema_set_capacity(a.context.tiledbContext, a.tiledbArraySchema, C.uint64_t(capacity))
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error setting capacity for tiledb arraySchema: %s", a.context.GetLastError())
 	}
 	return nil
@@ -85,7 +85,7 @@ func (a *ArraySchema) SetCapacity(capacity uint64) error {
 func (a *ArraySchema) Capacity() (uint64, error) {
 	var capacity C.uint64_t
 	ret := C.tiledb_array_schema_get_capacity(a.context.tiledbContext, a.tiledbArraySchema, &capacity)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("Error getting capacity for tiledb arraySchema: %s", a.context.GetLastError())
 	}
 	return uint64(capacity), nil
@@ -94,7 +94,7 @@ func (a *ArraySchema) Capacity() (uint64, error) {
 // SetCellOrder sets an array's cell order
 func (a *ArraySchema) SetCellOrder(cellOrder Layout) error {
 	ret := C.tiledb_array_schema_set_cell_order(a.context.tiledbContext, a.tiledbArraySchema, C.tiledb_layout_t(cellOrder))
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error setting cell order for tiledb arraySchema: %s", a.context.GetLastError())
 	}
 	return nil
@@ -104,7 +104,7 @@ func (a *ArraySchema) SetCellOrder(cellOrder Layout) error {
 func (a *ArraySchema) CellOrder() (Layout, error) {
 	var cellOrder C.tiledb_layout_t
 	ret := C.tiledb_array_schema_get_cell_order(a.context.tiledbContext, a.tiledbArraySchema, &cellOrder)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return -1, fmt.Errorf("Error getting cell order for tiledb arraySchema: %s", a.context.GetLastError())
 	}
 	return Layout(cellOrder), nil
@@ -113,7 +113,7 @@ func (a *ArraySchema) CellOrder() (Layout, error) {
 // SetTileOrder sets an array's cell order
 func (a *ArraySchema) SetTileOrder(tileOrder Layout) error {
 	ret := C.tiledb_array_schema_set_tile_order(a.context.tiledbContext, a.tiledbArraySchema, C.tiledb_layout_t(tileOrder))
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error setting cell order for tiledb arraySchema: %s", a.context.GetLastError())
 	}
 	return nil
@@ -123,7 +123,7 @@ func (a *ArraySchema) SetTileOrder(tileOrder Layout) error {
 func (a *ArraySchema) TileOrder() (Layout, error) {
 	var cellOrder C.tiledb_layout_t
 	ret := C.tiledb_array_schema_get_tile_order(a.context.tiledbContext, a.tiledbArraySchema, &cellOrder)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return -1, fmt.Errorf("Error getting cell order for tiledb arraySchema: %s", a.context.GetLastError())
 	}
 	return Layout(cellOrder), nil
@@ -132,7 +132,7 @@ func (a *ArraySchema) TileOrder() (Layout, error) {
 // SetCoordsCompressor sets the compressor used for coordinates
 func (a *ArraySchema) SetCoordsCompressor(compressor Compressor) error {
 	ret := C.tiledb_array_schema_set_coords_compressor(a.context.tiledbContext, a.tiledbArraySchema, C.tiledb_compressor_t(compressor.Compressor), C.int(compressor.Level))
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error setting coordinates compressor for tiledb arraySchema: %s", a.context.GetLastError())
 	}
 	return nil
@@ -143,7 +143,7 @@ func (a *ArraySchema) CoordsCompressor() (*Compressor, error) {
 	var compressorT C.tiledb_compressor_t
 	var level C.int
 	ret := C.tiledb_array_schema_get_coords_compressor(a.context.tiledbContext, a.tiledbArraySchema, &compressorT, &level)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error getting coordinates compressor for tiledb arraySchema: %s", a.context.GetLastError())
 	}
 	compressor := Compressor{Compressor: CompressorType(compressorT), Level: int(level)}
@@ -153,7 +153,7 @@ func (a *ArraySchema) CoordsCompressor() (*Compressor, error) {
 // SetOffsetsCompressor sets the compressor used for coordinates
 func (a *ArraySchema) SetOffsetsCompressor(compressor Compressor) error {
 	ret := C.tiledb_array_schema_set_offsets_compressor(a.context.tiledbContext, a.tiledbArraySchema, C.tiledb_compressor_t(compressor.Compressor), C.int(compressor.Level))
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error setting offsets compressor for tiledb arraySchema: %s", a.context.GetLastError())
 	}
 	return nil
@@ -164,7 +164,7 @@ func (a *ArraySchema) OffsetsCompressor() (*Compressor, error) {
 	var compressorT C.tiledb_compressor_t
 	var level C.int
 	ret := C.tiledb_array_schema_get_offsets_compressor(a.context.tiledbContext, a.tiledbArraySchema, &compressorT, &level)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error getting offsets compressor for tiledb arraySchema: %s", a.context.GetLastError())
 	}
 	compressor := Compressor{Compressor: CompressorType(compressorT), Level: int(level)}
@@ -174,7 +174,7 @@ func (a *ArraySchema) OffsetsCompressor() (*Compressor, error) {
 // Check validates an array schema
 func (a *ArraySchema) Check() error {
 	ret := C.tiledb_array_schema_check(a.context.tiledbContext, a.tiledbArraySchema)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error in checking arraySchema: %s", a.context.GetLastError())
 	}
 	return nil
@@ -186,7 +186,7 @@ func (a *ArraySchema) Load(path string) error {
 	defer C.free(unsafe.Pointer(cpath))
 
 	ret := C.tiledb_array_schema_load(a.context.tiledbContext, cpath, &a.tiledbArraySchema)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error in loading arraySchema from %s: %s", path, a.context.GetLastError())
 	}
 	return nil

--- a/array_schema.go
+++ b/array_schema.go
@@ -53,6 +53,38 @@ func (a *ArraySchema) AddAttributes(attributes ...Attribute) error {
 	return nil
 }
 
+// AttributeNum returns the number of attributes
+func (a *ArraySchema) AttributeNum() (uint, error) {
+	var attrNum C.uint
+	ret := C.tiledb_array_schema_get_attribute_num(a.context.tiledbContext, a.tiledbArraySchema, &attrNum)
+	if ret != C.TILEDB_OK {
+		return 0, fmt.Errorf("Error getting attribute number for tiledb arraySchema: %s", a.context.GetLastError())
+	}
+	return uint(attrNum), nil
+}
+
+// AttributeFromIndex returns the attribute at a given index
+func (a *ArraySchema) AttributeFromIndex(index uint) (*Attribute, error) {
+	attr := Attribute{context: a.context}
+	ret := C.tiledb_array_schema_get_attribute_from_index(a.context.tiledbContext, a.tiledbArraySchema, C.uint(index), &attr.tiledbAttribute)
+	if ret != C.TILEDB_OK {
+		return nil, fmt.Errorf("Error getting attribute %d for tiledb arraySchema: %s", index, a.context.GetLastError())
+	}
+	return &attr, nil
+}
+
+// AttributeFromName returns the attribute at a given index
+func (a *ArraySchema) AttributeFromName(attrName string) (*Attribute, error) {
+	cAttrName := C.CString(attrName)
+	defer C.free(unsafe.Pointer(cAttrName))
+	attr := Attribute{context: a.context}
+	ret := C.tiledb_array_schema_get_attribute_from_name(a.context.tiledbContext, a.tiledbArraySchema, cAttrName, &attr.tiledbAttribute)
+	if ret != C.TILEDB_OK {
+		return nil, fmt.Errorf("Error getting attribute %s for tiledb arraySchema: %s", attrName, a.context.GetLastError())
+	}
+	return &attr, nil
+}
+
 // SetDomain sets a ArraySchema's domain
 func (a *ArraySchema) SetDomain(domain *Domain) error {
 	ret := C.tiledb_array_schema_set_domain(a.context.tiledbContext, a.tiledbArraySchema, domain.tiledbDomain)

--- a/array_schema.go
+++ b/array_schema.go
@@ -1,0 +1,193 @@
+package tiledb
+
+/*
+#cgo LDFLAGS: -ltiledb
+#include <tiledb/tiledb.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+// ArraySchema is tiledb array_schema
+type ArraySchema struct {
+	tiledbArraySchema *C.tiledb_array_schema_t
+	context           *Context
+}
+
+// NewArraySchema alloc a new array_schema
+func NewArraySchema(ctx *Context, arrayType ArrayType) (*ArraySchema, error) {
+	arraySchema := ArraySchema{context: ctx}
+	ret := C.tiledb_array_schema_alloc(arraySchema.context.tiledbContext, C.tiledb_array_type_t(arrayType), &arraySchema.tiledbArraySchema)
+	if ret == C.TILEDB_ERR {
+		return nil, fmt.Errorf("Error creating tiledb arraySchema: %s", arraySchema.context.GetLastError())
+	}
+
+	// Set finalizer for free C pointer on gc
+	runtime.SetFinalizer(&arraySchema, func(arraySchema *ArraySchema) {
+		arraySchema.Free()
+	})
+
+	return &arraySchema, nil
+}
+
+// Free tiledb_domain_t that was allocated on heap in c
+func (a *ArraySchema) Free() {
+	if a.tiledbArraySchema != nil {
+		C.tiledb_array_schema_free(&a.tiledbArraySchema)
+	}
+}
+
+// AddAttributes add one or more attributes
+func (a *ArraySchema) AddAttributes(attributes ...Attribute) error {
+	for _, attribute := range attributes {
+		ret := C.tiledb_array_schema_add_attribute(a.context.tiledbContext, a.tiledbArraySchema, attribute.tiledbAttribute)
+		if ret == C.TILEDB_ERR {
+			return fmt.Errorf("Error adding attributes to tiledb arraySchema: %s", a.context.GetLastError())
+		}
+	}
+	return nil
+}
+
+// SetDomain sets a ArraySchema's domain
+func (a *ArraySchema) SetDomain(domain *Domain) error {
+	ret := C.tiledb_array_schema_set_domain(a.context.tiledbContext, a.tiledbArraySchema, domain.tiledbDomain)
+	if ret == C.TILEDB_ERR {
+		return fmt.Errorf("Error setting domain for tiledb arraySchema: %s", a.context.GetLastError())
+	}
+	return nil
+}
+
+// Domain returns an ArraySchema's domain
+func (a *ArraySchema) Domain() (*Domain, error) {
+	domain := Domain{context: a.context}
+	ret := C.tiledb_array_schema_get_domain(a.context.tiledbContext, a.tiledbArraySchema, &domain.tiledbDomain)
+	if ret == C.TILEDB_ERR {
+		return nil, fmt.Errorf("Error setting domain for tiledb arraySchema: %s", a.context.GetLastError())
+	}
+	return &domain, nil
+}
+
+// SetCapacity sets an array's capacity
+func (a *ArraySchema) SetCapacity(capacity uint64) error {
+	ret := C.tiledb_array_schema_set_capacity(a.context.tiledbContext, a.tiledbArraySchema, C.uint64_t(capacity))
+	if ret == C.TILEDB_ERR {
+		return fmt.Errorf("Error setting capacity for tiledb arraySchema: %s", a.context.GetLastError())
+	}
+	return nil
+}
+
+// Capacity gets an array's capacity
+func (a *ArraySchema) Capacity() (uint64, error) {
+	var capacity C.uint64_t
+	ret := C.tiledb_array_schema_get_capacity(a.context.tiledbContext, a.tiledbArraySchema, &capacity)
+	if ret == C.TILEDB_ERR {
+		return 0, fmt.Errorf("Error getting capacity for tiledb arraySchema: %s", a.context.GetLastError())
+	}
+	return uint64(capacity), nil
+}
+
+// SetCellOrder sets an array's cell order
+func (a *ArraySchema) SetCellOrder(cellOrder Layout) error {
+	ret := C.tiledb_array_schema_set_cell_order(a.context.tiledbContext, a.tiledbArraySchema, C.tiledb_layout_t(cellOrder))
+	if ret == C.TILEDB_ERR {
+		return fmt.Errorf("Error setting cell order for tiledb arraySchema: %s", a.context.GetLastError())
+	}
+	return nil
+}
+
+// CellOrder gets an array's capacity
+func (a *ArraySchema) CellOrder() (Layout, error) {
+	var cellOrder C.tiledb_layout_t
+	ret := C.tiledb_array_schema_get_cell_order(a.context.tiledbContext, a.tiledbArraySchema, &cellOrder)
+	if ret == C.TILEDB_ERR {
+		return -1, fmt.Errorf("Error getting cell order for tiledb arraySchema: %s", a.context.GetLastError())
+	}
+	return Layout(cellOrder), nil
+}
+
+// SetTileOrder sets an array's cell order
+func (a *ArraySchema) SetTileOrder(tileOrder Layout) error {
+	ret := C.tiledb_array_schema_set_tile_order(a.context.tiledbContext, a.tiledbArraySchema, C.tiledb_layout_t(tileOrder))
+	if ret == C.TILEDB_ERR {
+		return fmt.Errorf("Error setting cell order for tiledb arraySchema: %s", a.context.GetLastError())
+	}
+	return nil
+}
+
+// TileOrder gets an array's capacity
+func (a *ArraySchema) TileOrder() (Layout, error) {
+	var cellOrder C.tiledb_layout_t
+	ret := C.tiledb_array_schema_get_tile_order(a.context.tiledbContext, a.tiledbArraySchema, &cellOrder)
+	if ret == C.TILEDB_ERR {
+		return -1, fmt.Errorf("Error getting cell order for tiledb arraySchema: %s", a.context.GetLastError())
+	}
+	return Layout(cellOrder), nil
+}
+
+// SetCoordsCompressor sets the compressor used for coordinates
+func (a *ArraySchema) SetCoordsCompressor(compressor Compressor) error {
+	ret := C.tiledb_array_schema_set_coords_compressor(a.context.tiledbContext, a.tiledbArraySchema, C.tiledb_compressor_t(compressor.Compressor), C.int(compressor.Level))
+	if ret == C.TILEDB_ERR {
+		return fmt.Errorf("Error setting coordinates compressor for tiledb arraySchema: %s", a.context.GetLastError())
+	}
+	return nil
+}
+
+// CoordsCompressor gets the compressor used for coordinates
+func (a *ArraySchema) CoordsCompressor() (*Compressor, error) {
+	var compressorT C.tiledb_compressor_t
+	var level C.int
+	ret := C.tiledb_array_schema_get_coords_compressor(a.context.tiledbContext, a.tiledbArraySchema, &compressorT, &level)
+	if ret == C.TILEDB_ERR {
+		return nil, fmt.Errorf("Error getting coordinates compressor for tiledb arraySchema: %s", a.context.GetLastError())
+	}
+	compressor := Compressor{Compressor: CompressorType(compressorT), Level: int(level)}
+	return &compressor, nil
+}
+
+// SetOffsetsCompressor sets the compressor used for coordinates
+func (a *ArraySchema) SetOffsetsCompressor(compressor Compressor) error {
+	ret := C.tiledb_array_schema_set_offsets_compressor(a.context.tiledbContext, a.tiledbArraySchema, C.tiledb_compressor_t(compressor.Compressor), C.int(compressor.Level))
+	if ret == C.TILEDB_ERR {
+		return fmt.Errorf("Error setting offsets compressor for tiledb arraySchema: %s", a.context.GetLastError())
+	}
+	return nil
+}
+
+// OffsetsCompressor gets the compressor used for coordinates
+func (a *ArraySchema) OffsetsCompressor() (*Compressor, error) {
+	var compressorT C.tiledb_compressor_t
+	var level C.int
+	ret := C.tiledb_array_schema_get_offsets_compressor(a.context.tiledbContext, a.tiledbArraySchema, &compressorT, &level)
+	if ret == C.TILEDB_ERR {
+		return nil, fmt.Errorf("Error getting offsets compressor for tiledb arraySchema: %s", a.context.GetLastError())
+	}
+	compressor := Compressor{Compressor: CompressorType(compressorT), Level: int(level)}
+	return &compressor, nil
+}
+
+// Check validates an array schema
+func (a *ArraySchema) Check() error {
+	ret := C.tiledb_array_schema_check(a.context.tiledbContext, a.tiledbArraySchema)
+	if ret == C.TILEDB_ERR {
+		return fmt.Errorf("Error in checking arraySchema: %s", a.context.GetLastError())
+	}
+	return nil
+}
+
+// Load reads a directory for a ArraySchema
+func (a *ArraySchema) Load(path string) error {
+	cpath := C.CString(path)
+	defer C.free(unsafe.Pointer(cpath))
+
+	ret := C.tiledb_array_schema_load(a.context.tiledbContext, cpath, &a.tiledbArraySchema)
+	if ret == C.TILEDB_ERR {
+		return fmt.Errorf("Error in loading arraySchema from %s: %s", path, a.context.GetLastError())
+	}
+	return nil
+}

--- a/array_schema.go
+++ b/array_schema.go
@@ -180,14 +180,14 @@ func (a *ArraySchema) Check() error {
 	return nil
 }
 
-// Load reads a directory for a ArraySchema
-func (a *ArraySchema) Load(path string) error {
+// LoadArraySchema reads a directory for a ArraySchema
+func LoadArraySchema(context *Context, path string) (*ArraySchema, error) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
-
+	a := ArraySchema{context: context}
 	ret := C.tiledb_array_schema_load(a.context.tiledbContext, cpath, &a.tiledbArraySchema)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error in loading arraySchema from %s: %s", path, a.context.GetLastError())
+		return nil, fmt.Errorf("Error in loading arraySchema from %s: %s", path, a.context.GetLastError())
 	}
-	return nil
+	return &a, nil
 }

--- a/array_schema_test.go
+++ b/array_schema_test.go
@@ -74,7 +74,7 @@ func TestArraySchema(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Test create dimension
-	dimension, err := NewDimension(context, "dim1", []int32{1, 10}, 5)
+	dimension, err := NewDimension(context, "dim1", []int32{1, 10}, int32(5))
 	assert.Nil(t, err)
 	assert.NotNil(t, dimension)
 

--- a/array_schema_test.go
+++ b/array_schema_test.go
@@ -1,8 +1,9 @@
 package tiledb
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func ExampleNewArraySchema() {
@@ -99,6 +100,26 @@ func TestArraySchema(t *testing.T) {
 	// Add Attribute
 	err = arraySchema.AddAttributes(*attribute)
 	assert.Nil(t, err)
+
+	attrNum, err := arraySchema.AttributeNum()
+	assert.Nil(t, err)
+	assert.Equal(t, uint(1), attrNum)
+
+	attrFromIndex, err := arraySchema.AttributeFromIndex(0)
+	assert.Nil(t, err)
+	assert.NotNil(t, attrFromIndex)
+
+	attrName, err := attrFromIndex.Name()
+	assert.Nil(t, err)
+	assert.Equal(t, "a1", attrName)
+
+	attrFromName, err := arraySchema.AttributeFromName(attrName)
+	assert.Nil(t, err)
+	assert.NotNil(t, attrFromName)
+
+	attrName2, err := attrFromName.Name()
+	assert.Nil(t, err)
+	assert.Equal(t, "a1", attrName2)
 
 	// Set Capacity
 	err = arraySchema.SetCapacity(100)

--- a/array_schema_test.go
+++ b/array_schema_test.go
@@ -1,0 +1,169 @@
+package tiledb
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func ExampleNewArraySchema() {
+	// Create Config, this is optional
+	config, err := NewConfig()
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Test context with config
+	context, err := NewContext(config)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Create Dimension
+	dimension, err := NewDimension(context, "test", []int32{1, 10}, 5)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Create Domain
+	domain, err := NewDomain(context)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Add dimension to domain
+	err = domain.AddDimension(*dimension)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	arraySchema, err := NewArraySchema(context, TILEDB_DENSE)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Crete attribute to add to schema
+	attribute, err := NewAttribute(context, "a1", TILEDB_INT32)
+
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	err = arraySchema.AddAttributes(*attribute)
+	if err != nil {
+		// Handle error
+		return
+	}
+}
+
+// TestArraySchema tests creating a new dimension
+func TestArraySchema(t *testing.T) {
+	// Create configuration
+	config, err := NewConfig()
+	assert.Nil(t, err)
+
+	// Test context with config
+	context, err := NewContext(config)
+	assert.Nil(t, err)
+
+	// Test create dimension
+	dimension, err := NewDimension(context, "dim1", []int32{1, 10}, 5)
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+
+	// Test creating domain
+	domain, err := NewDomain(context)
+	assert.Nil(t, err)
+	assert.NotNil(t, domain)
+
+	// Add dimension
+	err = domain.AddDimension(*dimension)
+	assert.Nil(t, err)
+
+	// Create array schema
+	arraySchema, err := NewArraySchema(context, TILEDB_DENSE)
+	assert.Nil(t, err)
+	assert.NotNil(t, arraySchema)
+
+	// Crete attribute to add to schema
+	attribute, err := NewAttribute(context, "a1", TILEDB_INT32)
+	assert.Nil(t, err)
+	assert.NotNil(t, attribute)
+
+	// Add Attribute
+	err = arraySchema.AddAttributes(*attribute)
+	assert.Nil(t, err)
+
+	// Set Capacity
+	err = arraySchema.SetCapacity(100)
+	assert.Nil(t, err)
+
+	// Get Capacity
+	capacity, err := arraySchema.Capacity()
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(100), capacity)
+
+	err = arraySchema.SetDomain(domain)
+	assert.Nil(t, err)
+
+	// Test getting domain
+	domain, err = arraySchema.Domain()
+	assert.Nil(t, err)
+	assert.NotNil(t, domain)
+	assert.NotNil(t, domain.tiledbDomain)
+
+	// Validate returned domains have equal type and number
+	domainNdim, err := domain.NDim()
+	assert.Nil(t, err)
+	assert.NotZero(t, domainNdim)
+
+	domainDatatype, err := domain.Type()
+	assert.Nil(t, err)
+	assert.True(t, domainDatatype > -1)
+
+	// Set Cell Order
+	err = arraySchema.SetCellOrder(TILEDB_GLOBAL_ORDER)
+	assert.Nil(t, err)
+
+	cellOrder, err := arraySchema.CellOrder()
+	assert.Nil(t, err)
+	assert.Equal(t, TILEDB_GLOBAL_ORDER, cellOrder)
+
+	// Set Tile Order
+	err = arraySchema.SetTileOrder(TILEDB_COL_MAJOR)
+	assert.Nil(t, err)
+
+	tileOrder, err := arraySchema.TileOrder()
+	assert.Nil(t, err)
+	assert.Equal(t, TILEDB_COL_MAJOR, tileOrder)
+
+	// Set Coordinates Compressor
+	c := Compressor{Compressor: TILEDB_BZIP2, Level: -1}
+	err = arraySchema.SetCoordsCompressor(c)
+	assert.Nil(t, err)
+
+	compressor, err := arraySchema.CoordsCompressor()
+	assert.Nil(t, err)
+	assert.NotNil(t, compressor)
+	assert.EqualValues(t, c, *compressor)
+
+	// Set Offsets Compressor
+	err = arraySchema.SetOffsetsCompressor(c)
+	assert.Nil(t, err)
+
+	compressor, err = arraySchema.OffsetsCompressor()
+	assert.Nil(t, err)
+	assert.NotNil(t, compressor)
+	assert.EqualValues(t, c, *compressor)
+
+	err = arraySchema.Check()
+	assert.Nil(t, err)
+
+	arraySchema.Free()
+}

--- a/array_test.go
+++ b/array_test.go
@@ -1,9 +1,10 @@
 package tiledb
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func ExampleNewArray() {
@@ -186,6 +187,10 @@ func TestArray(t *testing.T) {
 	// Close the array
 	err = array.Close()
 	assert.Nil(t, err)
+
+	arraySchemaLoaded, err := LoadArraySchema(context, tmpArrayPath)
+	assert.Nil(t, err)
+	assert.NotNil(t, arraySchemaLoaded)
 
 	array.Free()
 }

--- a/array_test.go
+++ b/array_test.go
@@ -1,0 +1,191 @@
+package tiledb
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func ExampleNewArray() {
+	// Create Config, this is optional
+	config, err := NewConfig()
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Test context with config
+	context, err := NewContext(config)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Create Dimension
+	dimension, err := NewDimension(context, "test", []int32{1, 10}, 5)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Create Domain
+	domain, err := NewDomain(context)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Add dimension to domain
+	err = domain.AddDimension(*dimension)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	arraySchema, err := NewArraySchema(context, TILEDB_DENSE)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Crete attribute to add to schema
+	attribute, err := NewAttribute(context, "a1", TILEDB_INT32)
+
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	err = arraySchema.AddAttributes(*attribute)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	array, err := NewArray(context, "my_array")
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	err = array.Create(arraySchema)
+	if err != nil {
+		// Handle error
+		return
+	}
+}
+
+// TestArray tests creating a new dimension
+func TestArray(t *testing.T) {
+	// Create configuration
+	config, err := NewConfig()
+	assert.Nil(t, err)
+
+	// Test context with config
+	context, err := NewContext(config)
+	assert.Nil(t, err)
+
+	// Test create dimension
+	dimension, err := NewDimension(context, "dim1", []int8{1, 10}, 5)
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+
+	// Test creating domain
+	domain, err := NewDomain(context)
+	assert.Nil(t, err)
+	assert.NotNil(t, domain)
+
+	// Add dimension
+	err = domain.AddDimension(*dimension)
+	assert.Nil(t, err)
+
+	// Create array schema
+	arraySchema, err := NewArraySchema(context, TILEDB_DENSE)
+	assert.Nil(t, err)
+	assert.NotNil(t, arraySchema)
+
+	// Crete attribute to add to schema
+	attribute, err := NewAttribute(context, "a1", TILEDB_INT32)
+	assert.Nil(t, err)
+	assert.NotNil(t, attribute)
+
+	// Crete attribute to add to schema
+	attribute2, err := NewAttribute(context, "a2", TILEDB_STRING_ASCII)
+	assert.Nil(t, err)
+	assert.NotNil(t, attribute2)
+
+	err = attribute2.SetCellValNum(TILEDB_VAR_NUM)
+	assert.Nil(t, err)
+
+	// Add Attribute
+	err = arraySchema.AddAttributes(*attribute, *attribute2)
+	assert.Nil(t, err)
+
+	err = arraySchema.SetDomain(domain)
+	assert.Nil(t, err)
+
+	// create temp group name
+	tmpArrayPath := os.TempDir() + string(os.PathSeparator) + "tiledb_test_array"
+	// Cleanup group when test ends
+	defer os.RemoveAll(tmpArrayPath)
+	if _, err = os.Stat(tmpArrayPath); err == nil {
+		os.RemoveAll(tmpArrayPath)
+	}
+	// Create new array struct
+	array, err := NewArray(context, tmpArrayPath)
+	assert.Nil(t, err)
+	assert.NotNil(t, array)
+
+	// Create array on disk
+	err = array.Create(arraySchema)
+	assert.Nil(t, err)
+
+	//err = array.Consolidate()
+	//assert.Nil(t, err)
+
+	// Open array for reading
+	err = array.Open(TILEDB_READ)
+	assert.Nil(t, err)
+
+	// Test re-opening
+	err = array.Reopen()
+	assert.Nil(t, err)
+
+	// Get the array schema
+	arraySchema, err = array.Schema()
+	assert.Nil(t, err)
+	assert.NotNil(t, arraySchema)
+
+	// Validate array schema is usable
+	tileOrder, err := arraySchema.TileOrder()
+	assert.Nil(t, err)
+	assert.Equal(t, TILEDB_ROW_MAJOR, tileOrder)
+
+	queryType, err := array.QueryType()
+	assert.Nil(t, err)
+	assert.Equal(t, TILEDB_READ, queryType)
+
+	// Get non empty domain, which is none since no data has been written
+	nonEmptyDomain, isEmpty, err := array.NonEmptyDomain()
+	assert.Nil(t, err)
+	assert.NotNil(t, nonEmptyDomain)
+	assert.True(t, isEmpty)
+	//assert.EqualValues(t, []map[string]interface{}{{"dim1": []int8{1, 10}}}, nonEmptyDomain)
+
+	// Get MaxBufferSize, which is 0 because array is empty
+	maxBufferSize, err := array.MaxBufferSize("a1", []int8{1, 6})
+	assert.Nil(t, err)
+	assert.Zero(t, maxBufferSize)
+
+	// Get MaxBufferSizeVar, which is 0 because array is empty
+	maxBufferOffSize, maxBufferValSize, err := array.MaxBufferSizeVar("a2", []int8{1, 6})
+	assert.Nil(t, err)
+	assert.Zero(t, maxBufferOffSize)
+	assert.Zero(t, maxBufferValSize)
+
+	// Close the array
+	err = array.Close()
+	assert.Nil(t, err)
+
+	array.Free()
+}

--- a/array_test.go
+++ b/array_test.go
@@ -87,7 +87,7 @@ func TestArray(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Test create dimension
-	dimension, err := NewDimension(context, "dim1", []int8{1, 10}, 5)
+	dimension, err := NewDimension(context, "dim1", []int8{1, 10}, int8(5))
 	assert.Nil(t, err)
 	assert.NotNil(t, dimension)
 

--- a/attribute.go
+++ b/attribute.go
@@ -1,0 +1,108 @@
+package tiledb
+
+/*
+#cgo LDFLAGS: -ltiledb
+#include <tiledb/tiledb.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+// Attribute is tiledb attribute
+type Attribute struct {
+	tiledbAttribute *C.tiledb_attribute_t
+	context         *Context
+}
+
+// NewAttribute alloc a new attribute
+func NewAttribute(context *Context, name string, datatype Datatype) (*Attribute, error) {
+	attribute := Attribute{context: context}
+	var cname *C.char = C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+
+	ret := C.tiledb_attribute_alloc(context.tiledbContext, cname, C.tiledb_datatype_t(datatype), &attribute.tiledbAttribute)
+	if ret == C.TILEDB_ERR {
+		return nil, fmt.Errorf("Error creating tiledb attribute: %s", context.GetLastError())
+	}
+
+	// Set finalizer for free C pointer on gc
+	runtime.SetFinalizer(&attribute, func(attribute *Attribute) {
+		attribute.Free()
+	})
+
+	return &attribute, nil
+}
+
+// Free tiledb_attribute_t that was allocated on heap in c
+func (a *Attribute) Free() {
+	if a.tiledbAttribute != nil {
+		C.tiledb_attribute_free(&a.tiledbAttribute)
+	}
+}
+
+// SetCompressor for attribute
+func (a *Attribute) SetCompressor(compressor Compressor) error {
+	ret := C.tiledb_attribute_set_compressor(a.context.tiledbContext, a.tiledbAttribute, C.tiledb_compressor_t(compressor.Compressor), C.int(compressor.Level))
+	if ret == C.TILEDB_ERR {
+		return fmt.Errorf("Error setting tiledb attribute compressor: %s", a.context.GetLastError())
+	}
+	return nil
+}
+
+// Compressor returns compressor for attribute
+func (a *Attribute) Compressor() (*Compressor, error) {
+	var compressor_t C.tiledb_compressor_t
+	var clevel C.int
+	ret := C.tiledb_attribute_get_compressor(a.context.tiledbContext, a.tiledbAttribute, &compressor_t, &clevel)
+	if ret == C.TILEDB_ERR {
+		return nil, fmt.Errorf("Error getting tiledb attribute compressor: %s", a.context.GetLastError())
+	}
+
+	return &Compressor{Compressor: CompressorType(compressor_t), Level: int(clevel)}, nil
+}
+
+func (a *Attribute) SetCellValNum(val uint) error {
+	ret := C.tiledb_attribute_set_cell_val_num(a.context.tiledbContext, a.tiledbAttribute, C.uint(val))
+	if ret == C.TILEDB_ERR {
+		return fmt.Errorf("Error setting tiledb attribute cell val num: %s", a.context.GetLastError())
+	}
+	return nil
+}
+
+// CellValNum returns compressor for attribute
+func (a *Attribute) CellValNum() (uint, error) {
+	var cellValNum C.uint
+	ret := C.tiledb_attribute_get_cell_val_num(a.context.tiledbContext, a.tiledbAttribute, &cellValNum)
+	if ret == C.TILEDB_ERR {
+		return 0, fmt.Errorf("Error getting tiledb attribute cell val num: %s", a.context.GetLastError())
+	}
+
+	return uint(cellValNum), nil
+}
+
+// Name returns name of attribute
+func (a *Attribute) Name() (string, error) {
+	var cName *C.char
+	defer C.free(unsafe.Pointer(cName))
+	ret := C.tiledb_attribute_get_name(a.context.tiledbContext, a.tiledbAttribute, &cName)
+	if ret == C.TILEDB_ERR {
+		return "", fmt.Errorf("Error getting tiledb attribute name: %s", a.context.GetLastError())
+	}
+
+	return C.GoString(cName), nil
+}
+
+// Type returns the attribute datatype
+func (a *Attribute) Type() (Datatype, error) {
+	var attrType C.tiledb_datatype_t
+	ret := C.tiledb_attribute_get_type(a.context.tiledbContext, a.tiledbAttribute, &attrType)
+	if ret == C.TILEDB_ERR {
+		return 0, fmt.Errorf("Error getting tiledb attribute type: %s", a.context.GetLastError())
+	}
+	return Datatype(attrType), nil
+}

--- a/attribute.go
+++ b/attribute.go
@@ -26,7 +26,7 @@ func NewAttribute(context *Context, name string, datatype Datatype) (*Attribute,
 	defer C.free(unsafe.Pointer(cname))
 
 	ret := C.tiledb_attribute_alloc(context.tiledbContext, cname, C.tiledb_datatype_t(datatype), &attribute.tiledbAttribute)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb attribute: %s", context.GetLastError())
 	}
 
@@ -48,7 +48,7 @@ func (a *Attribute) Free() {
 // SetCompressor for attribute
 func (a *Attribute) SetCompressor(compressor Compressor) error {
 	ret := C.tiledb_attribute_set_compressor(a.context.tiledbContext, a.tiledbAttribute, C.tiledb_compressor_t(compressor.Compressor), C.int(compressor.Level))
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error setting tiledb attribute compressor: %s", a.context.GetLastError())
 	}
 	return nil
@@ -59,7 +59,7 @@ func (a *Attribute) Compressor() (*Compressor, error) {
 	var compressor_t C.tiledb_compressor_t
 	var clevel C.int
 	ret := C.tiledb_attribute_get_compressor(a.context.tiledbContext, a.tiledbAttribute, &compressor_t, &clevel)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error getting tiledb attribute compressor: %s", a.context.GetLastError())
 	}
 
@@ -68,7 +68,7 @@ func (a *Attribute) Compressor() (*Compressor, error) {
 
 func (a *Attribute) SetCellValNum(val uint) error {
 	ret := C.tiledb_attribute_set_cell_val_num(a.context.tiledbContext, a.tiledbAttribute, C.uint(val))
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error setting tiledb attribute cell val num: %s", a.context.GetLastError())
 	}
 	return nil
@@ -78,7 +78,7 @@ func (a *Attribute) SetCellValNum(val uint) error {
 func (a *Attribute) CellValNum() (uint, error) {
 	var cellValNum C.uint
 	ret := C.tiledb_attribute_get_cell_val_num(a.context.tiledbContext, a.tiledbAttribute, &cellValNum)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("Error getting tiledb attribute cell val num: %s", a.context.GetLastError())
 	}
 
@@ -90,7 +90,7 @@ func (a *Attribute) Name() (string, error) {
 	var cName *C.char
 	defer C.free(unsafe.Pointer(cName))
 	ret := C.tiledb_attribute_get_name(a.context.tiledbContext, a.tiledbAttribute, &cName)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("Error getting tiledb attribute name: %s", a.context.GetLastError())
 	}
 
@@ -101,7 +101,7 @@ func (a *Attribute) Name() (string, error) {
 func (a *Attribute) Type() (Datatype, error) {
 	var attrType C.tiledb_datatype_t
 	ret := C.tiledb_attribute_get_type(a.context.tiledbContext, a.tiledbAttribute, &attrType)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("Error getting tiledb attribute type: %s", a.context.GetLastError())
 	}
 	return Datatype(attrType), nil

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -1,0 +1,133 @@
+package tiledb
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func ExampleNewAttribute() {
+	// Create Config, this is optional
+	config, err := NewConfig()
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Test context with config
+	context, err := NewContext(config)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Create Attribute
+	attribute, err := NewAttribute(context, "test", TILEDB_INT32)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Set compressor
+	attribute.SetCompressor(Compressor{Compressor: TILEDB_GZIP, Level: -1})
+
+	// Set Cell Value Number
+	err = attribute.SetCellValNum(10)
+	if err != nil {
+		// Handle error
+		return
+	}
+}
+
+//TestNewAttribute tests setting a new context
+func TestNewAttribute(t *testing.T) {
+	// Create configuration
+	config, err := NewConfig()
+	assert.Nil(t, err)
+
+	// Test context with config
+	context, err := NewContext(config)
+	assert.Nil(t, err)
+
+	attribute, err := NewAttribute(context, "test", TILEDB_INT32)
+	assert.Nil(t, err)
+	assert.NotNil(t, attribute)
+
+	attribute.Free()
+}
+
+func ExampleAttribute_SetCompressor() {
+	// Create configuration
+	config, err := NewConfig()
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Test context with config
+	context, err := NewContext(config)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	attribute, err := NewAttribute(context, "test", TILEDB_INT32)
+	if err != nil {
+		// Handle error
+		return
+	}
+	attribute.SetCompressor(Compressor{Compressor: TILEDB_GZIP, Level: -1})
+	compressor, err := attribute.Compressor()
+	if err != nil {
+		// Handle error
+		return
+	}
+	// Output: GZIP
+	fmt.Println(compressor.Str())
+
+}
+
+func TestFullAttribute(t *testing.T) {
+	// Create configuration
+	config, err := NewConfig()
+	assert.Nil(t, err)
+
+	// Test context with config
+	context, err := NewContext(config)
+	assert.Nil(t, err)
+
+	// Create Attribute
+	attribute, err := NewAttribute(context, "test", TILEDB_INT32)
+	assert.Nil(t, err)
+	assert.NotNil(t, attribute)
+
+	// Get Attribute Name
+	name, err := attribute.Name()
+	assert.Nil(t, err)
+	assert.Equal(t, "test", name)
+
+	// Get Attribute Datatype
+	datatype, err := attribute.Type()
+	assert.Nil(t, err)
+	assert.Equal(t, TILEDB_INT32, datatype)
+
+	// Get and set compressor
+	compressor, err := attribute.Compressor()
+	assert.Nil(t, err)
+	assert.NotNil(t, compressor)
+	assert.Equal(t, Compressor{Compressor: TILEDB_NO_COMPRESSION, Level: -1}, *compressor)
+
+	attribute.SetCompressor(Compressor{Compressor: TILEDB_GZIP, Level: -1})
+	compressor, err = attribute.Compressor()
+	assert.Nil(t, err)
+	assert.NotNil(t, compressor)
+	assert.Equal(t, Compressor{Compressor: TILEDB_GZIP, Level: -1}, *compressor)
+
+	// Set Cell Value Number
+	err = attribute.SetCellValNum(10)
+	assert.Nil(t, err)
+
+	cellValNum, err := attribute.CellValNum()
+	assert.Nil(t, err)
+	assert.Equal(t, uint(10), cellValNum)
+}

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -2,8 +2,9 @@ package tiledb
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func ExampleNewAttribute() {

--- a/compressor.go
+++ b/compressor.go
@@ -1,0 +1,39 @@
+package tiledb
+
+// Compressor represents a tiledb compression method
+type Compressor struct {
+	Compressor CompressorType
+	Level      int
+}
+
+func (c *Compressor) Str() string {
+	switch c.Compressor {
+	case TILEDB_NO_COMPRESSION:
+		return "NO_COMPRESSION"
+	case TILEDB_GZIP:
+		return "GZIP"
+	case TILEDB_ZSTD:
+		return "ZSTD"
+	case TILEDB_LZ4:
+		return "LZ4"
+	case TILEDB_BLOSC_LZ:
+		return "BLOSC_LZ"
+	case TILEDB_BLOSC_LZ4:
+		return "BLOSC_LZ4"
+	case TILEDB_BLOSC_LZ4HC:
+		return "BLOSC_LZ4HC"
+	case TILEDB_BLOSC_SNAPPY:
+		return "BLOSC_SNAPPY"
+	case TILEDB_BLOSC_ZLIB:
+		return "BLOSC_ZLIB"
+	case TILEDB_BLOSC_ZSTD:
+		return "BLOSC_ZSTD"
+	case TILEDB_RLE:
+		return "RLE"
+	case TILEDB_BZIP2:
+		return "BZIP2"
+	case TILEDB_DOUBLE_DELTA:
+		return "DOUBLE_DELTA"
+	}
+	return "Invalid"
+}

--- a/config.go
+++ b/config.go
@@ -30,7 +30,6 @@ func NewConfig() (*Config, error) {
 		defer C.tiledb_error_free(&err)
 		return nil, fmt.Errorf("Error creating tiledb config: %s", C.GoString(msg))
 	}
-
 	// Set finalizer for free C pointer on gc
 	runtime.SetFinalizer(&config, func(config *Config) {
 		config.Free()
@@ -42,7 +41,11 @@ func NewConfig() (*Config, error) {
 // Set configuration parameter
 func (c *Config) Set(param string, value string) error {
 	var err *C.tiledb_error_t
-	C.tiledb_config_set(c.tiledbConfig, C.CString(param), C.CString(value), &err)
+	cparam := C.CString(param)
+	defer C.free(unsafe.Pointer(cparam))
+	cvalue := C.CString(value)
+	defer C.free(unsafe.Pointer(cvalue))
+	C.tiledb_config_set(c.tiledbConfig, cparam, cvalue, &err)
 
 	if err != nil {
 		var msg *C.char
@@ -60,7 +63,9 @@ func (c *Config) Get(param string) (string, error) {
 	var err *C.tiledb_error_t
 	var val *C.char
 	defer C.free(unsafe.Pointer(val))
-	C.tiledb_config_get(c.tiledbConfig, C.CString(param), &val, &err)
+	cparam := C.CString(param)
+	defer C.free(unsafe.Pointer(cparam))
+	C.tiledb_config_get(c.tiledbConfig, cparam, &val, &err)
 
 	if err != nil {
 		var msg *C.char
@@ -78,7 +83,9 @@ func (c *Config) Get(param string) (string, error) {
 // Unset sets a parameter back to default value
 func (c *Config) Unset(param string) error {
 	var err *C.tiledb_error_t
-	C.tiledb_config_unset(c.tiledbConfig, C.CString(param), &err)
+	cparam := C.CString(param)
+	defer C.free(unsafe.Pointer(cparam))
+	C.tiledb_config_unset(c.tiledbConfig, cparam, &err)
 
 	if err != nil {
 		var msg *C.char
@@ -91,26 +98,12 @@ func (c *Config) Unset(param string) error {
 	return nil
 }
 
-// LoadFromFile reads a configuration text file
-func (c *Config) LoadFromFile(file string) error {
-	var err *C.tiledb_error_t
-	C.tiledb_config_load_from_file(c.tiledbConfig, C.CString(file), &err)
-
-	if err != nil {
-		var msg *C.char
-		defer C.free(unsafe.Pointer(msg))
-		C.tiledb_error_message(err, &msg)
-		defer C.tiledb_error_free(&err)
-		return fmt.Errorf("Error loading config from file %s: %s", file, C.GoString(msg))
-	}
-
-	return nil
-}
-
 // SaveToFile reads a configuration text file
 func (c *Config) SaveToFile(file string) error {
 	var err *C.tiledb_error_t
-	C.tiledb_config_save_to_file(c.tiledbConfig, C.CString(file), &err)
+	cfile := C.CString(file)
+	defer C.free(unsafe.Pointer(cfile))
+	C.tiledb_config_save_to_file(c.tiledbConfig, cfile, &err)
 
 	if err != nil {
 		var msg *C.char
@@ -121,6 +114,43 @@ func (c *Config) SaveToFile(file string) error {
 	}
 
 	return nil
+}
+
+// LoadConfig reads a configuration from a given uri
+func LoadConfig(uri string) (*Config, error) {
+
+	if uri == "" {
+		return nil, fmt.Errorf("Error loading tiledb config: passed uri is empty")
+	}
+
+	var config Config
+	var err *C.tiledb_error_t
+	C.tiledb_config_alloc(&config.tiledbConfig, &err)
+	if err != nil {
+		var msg *C.char
+		defer C.free(unsafe.Pointer(msg))
+		C.tiledb_error_message(err, &msg)
+		defer C.tiledb_error_free(&err)
+		return nil, fmt.Errorf("Error loading tiledb config: %s", C.GoString(msg))
+	}
+
+	curi := C.CString(uri)
+	defer C.free(unsafe.Pointer(curi))
+	C.tiledb_config_load_from_file(config.tiledbConfig, curi, &err)
+	if err != nil {
+		var msg *C.char
+		defer C.free(unsafe.Pointer(msg))
+		C.tiledb_error_message(err, &msg)
+		defer C.tiledb_error_free(&err)
+		return nil, fmt.Errorf("Error loading config from file %s: %s", uri, C.GoString(msg))
+	}
+
+	// Set finalizer for free C pointer on gc
+	runtime.SetFinalizer(&config, func(config *Config) {
+		config.Free()
+	})
+
+	return &config, nil
 }
 
 // Free tiledb_config_t that was allocated on heap in c

--- a/config_test.go
+++ b/config_test.go
@@ -2,9 +2,10 @@ package tiledb
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func ExampleConfig_Set() {
@@ -100,6 +101,7 @@ func TestUnSettingConfig(t *testing.T) {
 func TestFileConfig(t *testing.T) {
 	config, err := NewConfig()
 	assert.Nil(t, err)
+	assert.NotNil(t, config)
 	err = config.Set("sm.tile_cache_size", "10")
 	assert.Nil(t, err)
 
@@ -116,13 +118,9 @@ func TestFileConfig(t *testing.T) {
 
 	config.SaveToFile(tmpPath)
 
-	config2, err := NewConfig()
-
-	val, err = config2.Get("sm.tile_cache_size")
+	config2, err := LoadConfig(tmpPath)
 	assert.Nil(t, err)
-	assert.Equal(t, "10000000", val)
-
-	config2.LoadFromFile(tmpPath)
+	assert.NotNil(t, config2)
 
 	val, err = config2.Get("sm.tile_cache_size")
 	assert.Nil(t, err)

--- a/context.go
+++ b/context.go
@@ -80,7 +80,7 @@ func (c *Context) GetLastError() error {
 }
 
 // IsFSSupported checks if a given filesystem is supported
-func (c *Context) IsFSSupported(fs TiledbFS) (bool, error) {
+func (c *Context) IsFSSupported(fs FS) (bool, error) {
 	var isSupported C.int
 	ret := C.tiledb_ctx_is_supported_fs(c.tiledbContext, C.tiledb_filesystem_t(fs), &isSupported)
 

--- a/context.go
+++ b/context.go
@@ -57,7 +57,7 @@ func (c *Context) GetConfig() (*Config, error) {
 
 	if ret == C.TILEDB_OOM {
 		return nil, fmt.Errorf("Out of Memory error in GetConfig")
-	} else if ret == C.TILEDB_ERR {
+	} else if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Unknown error in GetConfig")
 	}
 
@@ -84,7 +84,7 @@ func (c *Context) IsFSSupported(fs FS) (bool, error) {
 	var isSupported C.int
 	ret := C.tiledb_ctx_is_supported_fs(c.tiledbContext, C.tiledb_filesystem_t(fs), &isSupported)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("Error in checking FS support")
 	}
 

--- a/dimension.go
+++ b/dimension.go
@@ -1,0 +1,381 @@
+package tiledb
+
+/*
+#cgo LDFLAGS: -ltiledb
+#include <tiledb/tiledb.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"strconv"
+	"unsafe"
+)
+
+// Dimension is tiledb dimension
+type Dimension struct {
+	tiledbDimension *C.tiledb_dimension_t
+	context         *Context
+}
+
+// NewDimension alloc a new dimension
+func NewDimension(context *Context, name string, domain interface{}, extent interface{}) (*Dimension, error) {
+	dimension := Dimension{context: context}
+	var cname *C.char = C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+
+	if reflect.TypeOf(domain).Kind() != reflect.Slice {
+		return nil, fmt.Errorf("Domain passed must be a slice of two integers or two floats, type passed was: %s", reflect.TypeOf(domain).Kind().String())
+	}
+	domainInterfaceVal := reflect.ValueOf(domain)
+
+	if domainInterfaceVal.Len() != 2 {
+		return nil, fmt.Errorf("Domain passed must be a slice of two integers or two floats, size of slice is: %d", domainInterfaceVal.Len())
+	}
+
+	var datatype Datatype
+	var ret C.int
+	var cdomain unsafe.Pointer
+	// Convert domain to type then to void*
+	switch domainInterfaceVal.Index(0).Kind() {
+	case reflect.Int:
+		// Check size of uint on platform
+		if strconv.IntSize == 32 {
+			datatype = TILEDB_INT32
+		} else {
+			datatype = TILEDB_INT64
+		}
+		tmpDomain := domain.([]int)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+	case reflect.Int8:
+		datatype = TILEDB_INT8
+		tmpDomain := domain.([]int8)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+	case reflect.Int16:
+		datatype = TILEDB_INT16
+		tmpDomain := domain.([]int16)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+	case reflect.Int32:
+		datatype = TILEDB_INT32
+		tmpDomain := domain.([]int32)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+	case reflect.Int64:
+		datatype = TILEDB_INT64
+		tmpDomain := domain.([]int64)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+	case reflect.Uint:
+		// Check size of uint on platform
+		if strconv.IntSize == 32 {
+			datatype = TILEDB_UINT32
+		} else {
+			datatype = TILEDB_UINT64
+		}
+		tmpDomain := domain.([]uint)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+	case reflect.Uint8:
+		datatype = TILEDB_UINT8
+		tmpDomain := domain.([]uint8)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+	case reflect.Uint16:
+		datatype = TILEDB_UINT16
+		tmpDomain := domain.([]uint16)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+	case reflect.Uint32:
+		datatype = TILEDB_UINT32
+		tmpDomain := domain.([]uint32)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+	case reflect.Uint64:
+		datatype = TILEDB_UINT64
+		tmpDomain := domain.([]uint64)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+	case reflect.Float32:
+		datatype = TILEDB_FLOAT32
+		tmpDomain := domain.([]float32)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+	case reflect.Float64:
+		datatype = TILEDB_FLOAT64
+		tmpDomain := domain.([]float64)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+	default:
+		return nil, fmt.Errorf("Unrecognized domain type passed: %s", domainInterfaceVal.Index(0).Kind().String())
+	}
+
+	// Convert extent to type then to void*
+	var cextent unsafe.Pointer
+	switch reflect.ValueOf(extent).Kind() {
+	case reflect.Int:
+		tmpExtent := (extent.(int))
+		cextent = unsafe.Pointer(&tmpExtent)
+	case reflect.Int8:
+		tmpExtent := (extent.(int8))
+		cextent = unsafe.Pointer(&tmpExtent)
+	case reflect.Int16:
+		tmpExtent := (extent.(int16))
+		cextent = unsafe.Pointer(&tmpExtent)
+	case reflect.Int32:
+		tmpExtent := (extent.(int32))
+		cextent = unsafe.Pointer(&tmpExtent)
+	case reflect.Int64:
+		tmpExtent := (extent.(int64))
+		cextent = unsafe.Pointer(&tmpExtent)
+	case reflect.Uint:
+		tmpExtent := (extent.(uint))
+		cextent = unsafe.Pointer(&tmpExtent)
+	case reflect.Uint8:
+		tmpExtent := (extent.(uint8))
+		cextent = unsafe.Pointer(&tmpExtent)
+	case reflect.Uint16:
+		tmpExtent := (extent.(uint16))
+		cextent = unsafe.Pointer(&tmpExtent)
+	case reflect.Uint32:
+		tmpExtent := (extent.(uint32))
+		cextent = unsafe.Pointer(&tmpExtent)
+	case reflect.Uint64:
+		tmpExtent := (extent.(uint64))
+		cextent = unsafe.Pointer(&tmpExtent)
+	case reflect.Float32:
+		tmpExtent := (extent.(float32))
+		cextent = unsafe.Pointer(&tmpExtent)
+	case reflect.Float64:
+		tmpExtent := (extent.(float64))
+		cextent = unsafe.Pointer(&tmpExtent)
+	default:
+		return nil, fmt.Errorf("Unrecognized extent type passed: %s", reflect.ValueOf(extent).Kind().String())
+	}
+
+	ret = C.tiledb_dimension_alloc(context.tiledbContext, cname, C.tiledb_datatype_t(datatype), cdomain, cextent, &dimension.tiledbDimension)
+
+	if ret == C.TILEDB_ERR {
+		return nil, fmt.Errorf("Error creating tiledb dimension: %s", context.GetLastError())
+	}
+
+	// Set finalizer for free C pointer on gc
+	runtime.SetFinalizer(&dimension, func(dimension *Dimension) {
+		dimension.Free()
+	})
+
+	return &dimension, nil
+}
+
+// Free tiledb_dimension_t that was allocated on heap in c
+func (d *Dimension) Free() {
+	if d.tiledbDimension != nil {
+		C.tiledb_dimension_free(&d.tiledbDimension)
+	}
+}
+
+// Name returns the name of the dimension
+func (d *Dimension) Name() (string, error) {
+	var cName *C.char
+	defer C.free(unsafe.Pointer(cName))
+	ret := C.tiledb_dimension_get_name(d.context.tiledbContext, d.tiledbDimension, &cName)
+	if ret == C.TILEDB_ERR {
+		return "", fmt.Errorf("Error getting tiledb dimension name: %s", d.context.GetLastError())
+	}
+
+	return C.GoString(cName), nil
+}
+
+// Type returns the type of the dimension
+func (d *Dimension) Type() (Datatype, error) {
+	var cType C.tiledb_datatype_t
+	ret := C.tiledb_dimension_get_type(d.context.tiledbContext, d.tiledbDimension, &cType)
+	if ret == C.TILEDB_ERR {
+		return 0, fmt.Errorf("Error getting tiledb dimension type: %s", d.context.GetLastError())
+	}
+
+	return Datatype(cType), nil
+}
+
+// Domain returns the dimension's domain
+func (d *Dimension) Domain() (interface{}, error) {
+	datatype, err := d.Type()
+	if err != nil {
+		return nil, err
+	}
+
+	var ret C.int
+	var domain interface{}
+	switch datatype {
+	case TILEDB_INT8:
+		cdomain := C.malloc(2 * C.sizeof_int8_t)
+		defer C.free(cdomain)
+		tmpDomain := make([]int8, 2)
+		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
+		tmpslice := (*[1 << 30]C.int8_t)(unsafe.Pointer(cdomain))[:2:2]
+		for i, s := range tmpslice {
+			tmpDomain[i] = int8(s)
+		}
+		domain = tmpDomain
+	case TILEDB_INT16:
+		cdomain := C.malloc(2 * C.sizeof_int16_t)
+		defer C.free(cdomain)
+		tmpDomain := make([]int16, 2)
+		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
+		tmpslice := (*[1 << 30]C.int16_t)(unsafe.Pointer(cdomain))[:2:2]
+		for i, s := range tmpslice {
+			tmpDomain[i] = int16(s)
+		}
+		domain = tmpDomain
+	case TILEDB_INT32:
+		cdomain := C.malloc(2 * C.sizeof_int32_t)
+		defer C.free(cdomain)
+		tmpDomain := make([]int32, 2)
+		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
+		tmpslice := (*[1 << 30]C.int32_t)(unsafe.Pointer(cdomain))[:2:2]
+		for i, s := range tmpslice {
+			tmpDomain[i] = int32(s)
+		}
+		domain = tmpDomain
+	case TILEDB_INT64:
+		cdomain := C.malloc(2 * C.sizeof_int64_t)
+		defer C.free(cdomain)
+		tmpDomain := make([]int64, 2)
+		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
+		tmpslice := (*[1 << 30]C.int64_t)(unsafe.Pointer(cdomain))[:2:2]
+		for i, s := range tmpslice {
+			tmpDomain[i] = int64(s)
+		}
+		domain = tmpDomain
+	case TILEDB_UINT8:
+		cdomain := C.malloc(2 * C.sizeof_uint8_t)
+		defer C.free(cdomain)
+		tmpDomain := make([]uint8, 2)
+		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
+		tmpslice := (*[1 << 30]C.uint8_t)(unsafe.Pointer(cdomain))[:2:2]
+		for i, s := range tmpslice {
+			tmpDomain[i] = uint8(s)
+		}
+		domain = tmpDomain
+	case TILEDB_UINT16:
+		cdomain := C.malloc(2 * C.sizeof_uint16_t)
+		defer C.free(cdomain)
+		tmpDomain := make([]uint16, 2)
+		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
+		tmpslice := (*[1 << 30]C.uint16_t)(unsafe.Pointer(cdomain))[:2:2]
+		for i, s := range tmpslice {
+			tmpDomain[i] = uint16(s)
+		}
+		domain = tmpDomain
+	case TILEDB_UINT32:
+		cdomain := C.malloc(2 * C.sizeof_uint32_t)
+		defer C.free(cdomain)
+		tmpDomain := make([]uint32, 2)
+		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
+		tmpslice := (*[1 << 30]C.uint32_t)(unsafe.Pointer(cdomain))[:2:2]
+		for i, s := range tmpslice {
+			tmpDomain[i] = uint32(s)
+		}
+		domain = tmpDomain
+	case TILEDB_UINT64:
+		cdomain := C.malloc(2 * C.sizeof_uint64_t)
+		defer C.free(cdomain)
+		tmpDomain := make([]uint64, 2)
+		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
+		tmpslice := (*[1 << 30]C.uint64_t)(unsafe.Pointer(cdomain))[:2:2]
+		for i, s := range tmpslice {
+			tmpDomain[i] = uint64(s)
+		}
+		domain = tmpDomain
+	case TILEDB_FLOAT32:
+		cdomain := C.malloc(2 * C.sizeof_float)
+		defer C.free(cdomain)
+		tmpDomain := make([]float32, 2)
+		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
+		tmpslice := (*[1 << 30]C.float)(unsafe.Pointer(cdomain))[:2:2]
+		for i, s := range tmpslice {
+			tmpDomain[i] = float32(s)
+		}
+		domain = tmpDomain
+	case TILEDB_FLOAT64:
+		cdomain := C.malloc(2 * C.sizeof_double)
+		defer C.free(cdomain)
+		tmpDomain := make([]float64, 2)
+		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
+		tmpslice := (*[1 << 30]C.double)(unsafe.Pointer(cdomain))[:2:2]
+		for i, s := range tmpslice {
+			tmpDomain[i] = float64(s)
+		}
+		domain = tmpDomain
+	default:
+		return nil, fmt.Errorf("Unrecognized domain type: %d", datatype)
+	}
+	if ret == C.TILEDB_ERR {
+		return nil, fmt.Errorf("Error getting tiledb dimension's domain: %s", d.context.GetLastError())
+	}
+
+	return domain, nil
+}
+
+// Extent returns the dimension's extent
+func (d *Dimension) Extent() (interface{}, error) {
+	datatype, err := d.Type()
+	if err != nil {
+		return nil, err
+	}
+
+	var ret C.int
+	var extent interface{}
+	switch datatype {
+	case TILEDB_INT8:
+		cextent := C.malloc(C.sizeof_int8_t)
+		defer C.free(cextent)
+		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
+		extent = *(*int8)(unsafe.Pointer(cextent))
+	case TILEDB_INT16:
+		cextent := C.malloc(C.sizeof_int16_t)
+		defer C.free(cextent)
+		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
+		extent = *(*int16)(unsafe.Pointer(cextent))
+	case TILEDB_INT32:
+		cextent := C.malloc(C.sizeof_int32_t)
+		defer C.free(cextent)
+		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
+		extent = *(*int32)(unsafe.Pointer(cextent))
+	case TILEDB_INT64:
+		cextent := C.malloc(C.sizeof_int64_t)
+		defer C.free(cextent)
+		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
+		extent = *(*int64)(unsafe.Pointer(cextent))
+	case TILEDB_UINT8:
+		cextent := C.malloc(C.sizeof_uint8_t)
+		defer C.free(cextent)
+		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
+		extent = *(*uint8)(unsafe.Pointer(cextent))
+	case TILEDB_UINT16:
+		cextent := C.malloc(C.sizeof_uint16_t)
+		defer C.free(cextent)
+		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
+		extent = *(*uint16)(unsafe.Pointer(cextent))
+	case TILEDB_UINT32:
+		cextent := C.malloc(C.sizeof_uint32_t)
+		defer C.free(cextent)
+		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
+		extent = *(*uint32)(unsafe.Pointer(cextent))
+	case TILEDB_UINT64:
+		cextent := C.malloc(C.sizeof_uint64_t)
+		defer C.free(cextent)
+		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
+		extent = *(*uint64)(unsafe.Pointer(cextent))
+	case TILEDB_FLOAT32:
+		cextent := C.malloc(C.sizeof_float)
+		defer C.free(cextent)
+		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
+		extent = *(*float32)(unsafe.Pointer(cextent))
+	case TILEDB_FLOAT64:
+		cextent := C.malloc(C.sizeof_double)
+		defer C.free(cextent)
+		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
+		extent = *(*float64)(unsafe.Pointer(cextent))
+	default:
+		return nil, fmt.Errorf("Unrecognized extent type: %d", datatype)
+	}
+	if ret == C.TILEDB_ERR {
+		return nil, fmt.Errorf("Error getting tiledb dimension's extent: %s", d.context.GetLastError())
+	}
+
+	return extent, nil
+}

--- a/dimension.go
+++ b/dimension.go
@@ -36,36 +36,66 @@ func NewDimension(context *Context, name string, domain interface{}, extent inte
 		return nil, fmt.Errorf("Domain passed must be a slice of two integers or two floats, size of slice is: %d", domainInterfaceVal.Len())
 	}
 
+	domainType := reflect.TypeOf(domain).Elem().Kind()
+	extentType := reflect.TypeOf(extent).Kind()
+	if extentType != domainType {
+		return nil, fmt.Errorf("Domaing and extent do not have the same data types. Domain: %s, Extent: %s", domainType.String(), extentType.String())
+	}
+
 	var datatype Datatype
 	var ret C.int
-	var cdomain unsafe.Pointer
 	// Convert domain to type then to void*
-	switch domainInterfaceVal.Index(0).Kind() {
+	var cdomain unsafe.Pointer
+	// Convert extent to type then to void*
+	var cextent unsafe.Pointer
+	// Switch on domain type to create void* for domain and extent.
+	// Extent has already checked to be same type as domain so this is safe
+	switch domainType {
 	case reflect.Int:
-		// Check size of uint on platform
+		// Check size of int on platform
 		if strconv.IntSize == 32 {
 			datatype = TILEDB_INT32
 		} else {
 			datatype = TILEDB_INT64
 		}
+		// Create domain void*
 		tmpDomain := domain.([]int)
 		cdomain = unsafe.Pointer(&tmpDomain[0])
+		// Create extent void*
+		tmpExtent := (extent.(int))
+		cextent = unsafe.Pointer(&tmpExtent)
 	case reflect.Int8:
 		datatype = TILEDB_INT8
+		// Create domain void*
 		tmpDomain := domain.([]int8)
 		cdomain = unsafe.Pointer(&tmpDomain[0])
+		// Create extent void*
+		tmpExtent := (extent.(int8))
+		cextent = unsafe.Pointer(&tmpExtent)
 	case reflect.Int16:
 		datatype = TILEDB_INT16
+		// Create domain void*
 		tmpDomain := domain.([]int16)
 		cdomain = unsafe.Pointer(&tmpDomain[0])
+		// Create extent void*
+		tmpExtent := (extent.(int16))
+		cextent = unsafe.Pointer(&tmpExtent)
 	case reflect.Int32:
 		datatype = TILEDB_INT32
+		// Create domain void*
 		tmpDomain := domain.([]int32)
 		cdomain = unsafe.Pointer(&tmpDomain[0])
+		// Create extent void*
+		tmpExtent := (extent.(int32))
+		cextent = unsafe.Pointer(&tmpExtent)
 	case reflect.Int64:
 		datatype = TILEDB_INT64
+		// Create domain void*
 		tmpDomain := domain.([]int64)
 		cdomain = unsafe.Pointer(&tmpDomain[0])
+		// Create extent void*
+		tmpExtent := (extent.(int64))
+		cextent = unsafe.Pointer(&tmpExtent)
 	case reflect.Uint:
 		// Check size of uint on platform
 		if strconv.IntSize == 32 {
@@ -73,77 +103,62 @@ func NewDimension(context *Context, name string, domain interface{}, extent inte
 		} else {
 			datatype = TILEDB_UINT64
 		}
+		// Create domain void*
 		tmpDomain := domain.([]uint)
 		cdomain = unsafe.Pointer(&tmpDomain[0])
-	case reflect.Uint8:
-		datatype = TILEDB_UINT8
-		tmpDomain := domain.([]uint8)
-		cdomain = unsafe.Pointer(&tmpDomain[0])
-	case reflect.Uint16:
-		datatype = TILEDB_UINT16
-		tmpDomain := domain.([]uint16)
-		cdomain = unsafe.Pointer(&tmpDomain[0])
-	case reflect.Uint32:
-		datatype = TILEDB_UINT32
-		tmpDomain := domain.([]uint32)
-		cdomain = unsafe.Pointer(&tmpDomain[0])
-	case reflect.Uint64:
-		datatype = TILEDB_UINT64
-		tmpDomain := domain.([]uint64)
-		cdomain = unsafe.Pointer(&tmpDomain[0])
-	case reflect.Float32:
-		datatype = TILEDB_FLOAT32
-		tmpDomain := domain.([]float32)
-		cdomain = unsafe.Pointer(&tmpDomain[0])
-	case reflect.Float64:
-		datatype = TILEDB_FLOAT64
-		tmpDomain := domain.([]float64)
-		cdomain = unsafe.Pointer(&tmpDomain[0])
-	default:
-		return nil, fmt.Errorf("Unrecognized domain type passed: %s", domainInterfaceVal.Index(0).Kind().String())
-	}
-
-	// Convert extent to type then to void*
-	var cextent unsafe.Pointer
-	switch reflect.ValueOf(extent).Kind() {
-	case reflect.Int:
-		tmpExtent := (extent.(int))
-		cextent = unsafe.Pointer(&tmpExtent)
-	case reflect.Int8:
-		tmpExtent := (extent.(int8))
-		cextent = unsafe.Pointer(&tmpExtent)
-	case reflect.Int16:
-		tmpExtent := (extent.(int16))
-		cextent = unsafe.Pointer(&tmpExtent)
-	case reflect.Int32:
-		tmpExtent := (extent.(int32))
-		cextent = unsafe.Pointer(&tmpExtent)
-	case reflect.Int64:
-		tmpExtent := (extent.(int64))
-		cextent = unsafe.Pointer(&tmpExtent)
-	case reflect.Uint:
+		// Create extent void*
 		tmpExtent := (extent.(uint))
 		cextent = unsafe.Pointer(&tmpExtent)
 	case reflect.Uint8:
+		datatype = TILEDB_UINT8
+		// Create domain void*
+		tmpDomain := domain.([]uint8)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+		// Create extent void*
 		tmpExtent := (extent.(uint8))
 		cextent = unsafe.Pointer(&tmpExtent)
 	case reflect.Uint16:
+		datatype = TILEDB_UINT16
+		// Create domain void*
+		tmpDomain := domain.([]uint16)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+		// Create extent void*
 		tmpExtent := (extent.(uint16))
 		cextent = unsafe.Pointer(&tmpExtent)
 	case reflect.Uint32:
+		datatype = TILEDB_UINT32
+		// Create domain void*
+		tmpDomain := domain.([]uint32)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+		// Create extent void*
 		tmpExtent := (extent.(uint32))
 		cextent = unsafe.Pointer(&tmpExtent)
 	case reflect.Uint64:
+		datatype = TILEDB_UINT64
+		// Create domain void*
+		tmpDomain := domain.([]uint64)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+		// Create extent void*
 		tmpExtent := (extent.(uint64))
 		cextent = unsafe.Pointer(&tmpExtent)
 	case reflect.Float32:
+		datatype = TILEDB_FLOAT32
+		// Create domain void*
+		tmpDomain := domain.([]float32)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+		// Create extent void*
 		tmpExtent := (extent.(float32))
 		cextent = unsafe.Pointer(&tmpExtent)
 	case reflect.Float64:
+		datatype = TILEDB_FLOAT64
+		// Create domain void*
+		tmpDomain := domain.([]float64)
+		cdomain = unsafe.Pointer(&tmpDomain[0])
+		// Create extent void*
 		tmpExtent := (extent.(float64))
 		cextent = unsafe.Pointer(&tmpExtent)
 	default:
-		return nil, fmt.Errorf("Unrecognized extent type passed: %s", reflect.ValueOf(extent).Kind().String())
+		return nil, fmt.Errorf("Unrecognized domain type passed: %s", domainInterfaceVal.Index(0).Kind().String())
 	}
 
 	ret = C.tiledb_dimension_alloc(context.tiledbContext, cname, C.tiledb_datatype_t(datatype), cdomain, cextent, &dimension.tiledbDimension)

--- a/dimension.go
+++ b/dimension.go
@@ -148,7 +148,7 @@ func NewDimension(context *Context, name string, domain interface{}, extent inte
 
 	ret = C.tiledb_dimension_alloc(context.tiledbContext, cname, C.tiledb_datatype_t(datatype), cdomain, cextent, &dimension.tiledbDimension)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb dimension: %s", context.GetLastError())
 	}
 
@@ -172,7 +172,7 @@ func (d *Dimension) Name() (string, error) {
 	var cName *C.char
 	defer C.free(unsafe.Pointer(cName))
 	ret := C.tiledb_dimension_get_name(d.context.tiledbContext, d.tiledbDimension, &cName)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("Error getting tiledb dimension name: %s", d.context.GetLastError())
 	}
 
@@ -183,7 +183,7 @@ func (d *Dimension) Name() (string, error) {
 func (d *Dimension) Type() (Datatype, error) {
 	var cType C.tiledb_datatype_t
 	ret := C.tiledb_dimension_get_type(d.context.tiledbContext, d.tiledbDimension, &cType)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("Error getting tiledb dimension type: %s", d.context.GetLastError())
 	}
 
@@ -303,7 +303,7 @@ func (d *Dimension) Domain() (interface{}, error) {
 	default:
 		return nil, fmt.Errorf("Unrecognized domain type: %d", datatype)
 	}
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error getting tiledb dimension's domain: %s", d.context.GetLastError())
 	}
 
@@ -373,7 +373,7 @@ func (d *Dimension) Extent() (interface{}, error) {
 	default:
 		return nil, fmt.Errorf("Unrecognized extent type: %d", datatype)
 	}
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error getting tiledb dimension's extent: %s", d.context.GetLastError())
 	}
 

--- a/dimension_test.go
+++ b/dimension_test.go
@@ -1,8 +1,9 @@
 package tiledb
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func ExampleNewDimension() {
@@ -21,7 +22,7 @@ func ExampleNewDimension() {
 	}
 
 	// Create Dimension
-	_, err = NewDimension(context, "test", []int32{1, 10}, 5)
+	_, err = NewDimension(context, "test", []int32{1, 10}, int32(5))
 	if err != nil {
 		// Handle error
 		return
@@ -39,7 +40,13 @@ func TestDimension(t *testing.T) {
 	context, err := NewContext(config)
 	assert.Nil(t, err)
 
+	// Dimension will error due to extent and domain having different datatypes
 	dimension, err := NewDimension(context, "test", []int32{1, 10}, 5)
+	assert.NotNil(t, err)
+	assert.Nil(t, dimension)
+
+	// Create dimension
+	dimension, err = NewDimension(context, "test", []int32{1, 10}, int32(5))
 	assert.Nil(t, err)
 	assert.NotNil(t, dimension)
 

--- a/dimension_test.go
+++ b/dimension_test.go
@@ -1,0 +1,214 @@
+package tiledb
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func ExampleNewDimension() {
+	// Create Config, this is optional
+	config, err := NewConfig()
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Test context with config
+	context, err := NewContext(config)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Create Dimension
+	_, err = NewDimension(context, "test", []int32{1, 10}, 5)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+}
+
+// TestDimension tests creating a new dimension
+func TestDimension(t *testing.T) {
+	// Create configuration
+	config, err := NewConfig()
+	assert.Nil(t, err)
+
+	// Test context with config
+	context, err := NewContext(config)
+	assert.Nil(t, err)
+
+	dimension, err := NewDimension(context, "test", []int32{1, 10}, 5)
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+
+	name, err := dimension.Name()
+	assert.Nil(t, err)
+	assert.Equal(t, "test", name)
+
+	datatype, err := dimension.Type()
+	assert.Nil(t, err)
+	assert.Equal(t, TILEDB_INT32, datatype)
+
+	dimension.Free()
+}
+
+// TestDimensionDomainTypes tests creating dimension of all domain types
+func TestDimensionDomainTypes(t *testing.T) {
+	// Create configuration
+	config, err := NewConfig()
+	assert.Nil(t, err)
+
+	// Test context with config
+	context, err := NewContext(config)
+	assert.Nil(t, err)
+
+	dimension, err := NewDimension(context, "test", []int{1, 10}, int(5))
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+
+	dimension, err = NewDimension(context, "test", []int8{1, 10}, int8(5))
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+	domain, err := dimension.Domain()
+	assert.Nil(t, err)
+	// Test getting domain
+	assert.NotNil(t, domain)
+	// Test getting extent
+	assert.EqualValues(t, []int8{1, 10}, domain)
+	extent, err := dimension.Extent()
+	assert.Nil(t, err)
+	assert.NotNil(t, extent)
+	assert.EqualValues(t, int8(5), extent)
+
+	dimension, err = NewDimension(context, "test", []int16{1, 10}, int16(5))
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+	// Test getting domain
+	domain, err = dimension.Domain()
+	assert.Nil(t, err)
+	assert.NotNil(t, domain)
+	// Test getting extent
+	assert.EqualValues(t, []int16{1, 10}, domain)
+	extent, err = dimension.Extent()
+	assert.Nil(t, err)
+	assert.NotNil(t, extent)
+	assert.EqualValues(t, int16(5), extent)
+
+	dimension, err = NewDimension(context, "test", []int32{1, 10}, int32(5))
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+	// Test getting domain
+	domain, err = dimension.Domain()
+	assert.Nil(t, err)
+	assert.NotNil(t, domain)
+	// Test getting extent
+	assert.EqualValues(t, []int32{1, 10}, domain)
+	extent, err = dimension.Extent()
+	assert.Nil(t, err)
+	assert.NotNil(t, extent)
+	assert.EqualValues(t, int32(5), extent)
+
+	dimension, err = NewDimension(context, "test", []int64{1, 10}, int64(5))
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+	// Test getting domain
+	domain, err = dimension.Domain()
+	assert.Nil(t, err)
+	assert.NotNil(t, domain)
+	// Test getting extent
+	assert.EqualValues(t, []int64{1, 10}, domain)
+	extent, err = dimension.Extent()
+	assert.Nil(t, err)
+	assert.NotNil(t, extent)
+	assert.EqualValues(t, int64(5), extent)
+
+	dimension, err = NewDimension(context, "test", []uint{1, 10}, uint(5))
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+
+	dimension, err = NewDimension(context, "test", []uint8{1, 10}, uint8(5))
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+	// Test getting domain
+	domain, err = dimension.Domain()
+	assert.Nil(t, err)
+	assert.NotNil(t, domain)
+	assert.EqualValues(t, []uint8{1, 10}, domain)
+	// Test getting extent
+	extent, err = dimension.Extent()
+	assert.Nil(t, err)
+	assert.NotNil(t, extent)
+	assert.EqualValues(t, uint8(5), extent)
+
+	dimension, err = NewDimension(context, "test", []uint16{1, 10}, uint16(5))
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+	// Test getting domain
+	domain, err = dimension.Domain()
+	assert.Nil(t, err)
+	assert.NotNil(t, domain)
+	assert.EqualValues(t, []uint16{1, 10}, domain)
+	// Test getting extent
+	extent, err = dimension.Extent()
+	assert.Nil(t, err)
+	assert.NotNil(t, extent)
+	assert.EqualValues(t, uint16(5), extent)
+
+	dimension, err = NewDimension(context, "test", []uint32{1, 10}, uint32(5))
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+	// Test getting domain
+	domain, err = dimension.Domain()
+	assert.Nil(t, err)
+	assert.NotNil(t, domain)
+	assert.EqualValues(t, []uint32{1, 10}, domain)
+	// Test getting extent
+	extent, err = dimension.Extent()
+	assert.Nil(t, err)
+	assert.NotNil(t, extent)
+	assert.EqualValues(t, uint32(5), extent)
+
+	dimension, err = NewDimension(context, "test", []uint64{1, 10}, uint64(5))
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+	// Test getting domain
+	domain, err = dimension.Domain()
+	assert.Nil(t, err)
+	assert.NotNil(t, domain)
+	assert.EqualValues(t, []uint64{1, 10}, domain)
+	// Test getting extent
+	extent, err = dimension.Extent()
+	assert.Nil(t, err)
+	assert.NotNil(t, extent)
+	assert.EqualValues(t, uint64(5), extent)
+
+	dimension, err = NewDimension(context, "test", []float32{1, 10}, float32(5))
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+	// Test getting domain
+	domain, err = dimension.Domain()
+	assert.Nil(t, err)
+	assert.NotNil(t, domain)
+	assert.EqualValues(t, []float32{1, 10}, domain)
+	// Test getting extent
+	extent, err = dimension.Extent()
+	assert.Nil(t, err)
+	assert.NotNil(t, extent)
+	assert.EqualValues(t, float32(5), extent)
+
+	dimension, err = NewDimension(context, "test", []float64{1, 10}, float64(5))
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+	// Test getting domain
+	domain, err = dimension.Domain()
+	assert.Nil(t, err)
+	assert.NotNil(t, domain)
+	assert.EqualValues(t, []float64{1, 10}, domain)
+	// Test getting extent
+	extent, err = dimension.Extent()
+	assert.Nil(t, err)
+	assert.NotNil(t, extent)
+	assert.EqualValues(t, float64(5), extent)
+}

--- a/domain.go
+++ b/domain.go
@@ -1,0 +1,96 @@
+package tiledb
+
+/*
+#cgo LDFLAGS: -ltiledb
+#include <tiledb/tiledb.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+// Domain is tiledb domain
+type Domain struct {
+	tiledbDomain *C.tiledb_domain_t
+	context      *Context
+}
+
+// NewDomain alloc a new domainuration
+func NewDomain(ctx *Context) (*Domain, error) {
+	domain := Domain{context: ctx}
+	ret := C.tiledb_domain_alloc(domain.context.tiledbContext, &domain.tiledbDomain)
+	if ret == C.TILEDB_ERR {
+		return nil, fmt.Errorf("Error creating tiledb domain: %s", domain.context.GetLastError())
+	}
+
+	// Set finalizer for free C pointer on gc
+	runtime.SetFinalizer(&domain, func(domain *Domain) {
+		domain.Free()
+	})
+
+	return &domain, nil
+}
+
+// Free tiledb_domain_t that was allocated on heap in c
+func (d *Domain) Free() {
+	if d.tiledbDomain != nil {
+		C.tiledb_domain_free(&d.tiledbDomain)
+	}
+}
+
+// Type returns a domains type deduced from dimensions
+func (d *Domain) Type() (Datatype, error) {
+	var datatype C.tiledb_datatype_t
+	ret := C.tiledb_domain_get_type(d.context.tiledbContext, d.tiledbDomain, &datatype)
+	if ret == C.TILEDB_ERR {
+		return -1, fmt.Errorf("Error getting tiledb domain type: %s", d.context.GetLastError())
+	}
+	return Datatype(datatype), nil
+}
+
+// NDim returns a domains type deduced from dimensions
+func (d *Domain) NDim() (uint, error) {
+	var ndim C.uint
+	ret := C.tiledb_domain_get_ndim(d.context.tiledbContext, d.tiledbDomain, &ndim)
+	if ret == C.TILEDB_ERR {
+		return 0, fmt.Errorf("Error getting tiledb domain number of dimensions: %s", d.context.GetLastError())
+	}
+	return uint(ndim), nil
+}
+
+// DimensionFromIndex returns a dimension given index
+func (d *Domain) DimensionFromIndex(index uint) (*Dimension, error) {
+	var dim *C.tiledb_dimension_t
+	ret := C.tiledb_domain_get_dimension_from_index(d.context.tiledbContext, d.tiledbDomain, C.uint(index), &dim)
+	if ret == C.TILEDB_ERR {
+		return nil, fmt.Errorf("Error getting tiledb dimension by index for domain: %s", d.context.GetLastError())
+	}
+	return &Dimension{tiledbDimension: dim, context: d.context}, nil
+}
+
+// DimensionFromName returns a dimension given index
+func (d *Domain) DimensionFromName(name string) (*Dimension, error) {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	var dim *C.tiledb_dimension_t
+	ret := C.tiledb_domain_get_dimension_from_name(d.context.tiledbContext, d.tiledbDomain, cname, &dim)
+	if ret == C.TILEDB_ERR {
+		return nil, fmt.Errorf("Error getting tiledb dimension by name for domain: %s", d.context.GetLastError())
+	}
+	return &Dimension{tiledbDimension: dim, context: d.context}, nil
+}
+
+// AddDimension adds one or more dimensions to a domain
+func (d *Domain) AddDimension(dimensions ...Dimension) error {
+	for _, dimension := range dimensions {
+		ret := C.tiledb_domain_add_dimension(d.context.tiledbContext, d.tiledbDomain, dimension.tiledbDimension)
+		if ret == C.TILEDB_ERR {
+			return fmt.Errorf("Error adding dimension to domain: %s", d.context.GetLastError())
+		}
+	}
+	return nil
+}

--- a/domain.go
+++ b/domain.go
@@ -23,7 +23,7 @@ type Domain struct {
 func NewDomain(ctx *Context) (*Domain, error) {
 	domain := Domain{context: ctx}
 	ret := C.tiledb_domain_alloc(domain.context.tiledbContext, &domain.tiledbDomain)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb domain: %s", domain.context.GetLastError())
 	}
 
@@ -46,7 +46,7 @@ func (d *Domain) Free() {
 func (d *Domain) Type() (Datatype, error) {
 	var datatype C.tiledb_datatype_t
 	ret := C.tiledb_domain_get_type(d.context.tiledbContext, d.tiledbDomain, &datatype)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return -1, fmt.Errorf("Error getting tiledb domain type: %s", d.context.GetLastError())
 	}
 	return Datatype(datatype), nil
@@ -56,7 +56,7 @@ func (d *Domain) Type() (Datatype, error) {
 func (d *Domain) NDim() (uint, error) {
 	var ndim C.uint
 	ret := C.tiledb_domain_get_ndim(d.context.tiledbContext, d.tiledbDomain, &ndim)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("Error getting tiledb domain number of dimensions: %s", d.context.GetLastError())
 	}
 	return uint(ndim), nil
@@ -66,7 +66,7 @@ func (d *Domain) NDim() (uint, error) {
 func (d *Domain) DimensionFromIndex(index uint) (*Dimension, error) {
 	var dim *C.tiledb_dimension_t
 	ret := C.tiledb_domain_get_dimension_from_index(d.context.tiledbContext, d.tiledbDomain, C.uint(index), &dim)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error getting tiledb dimension by index for domain: %s", d.context.GetLastError())
 	}
 	return &Dimension{tiledbDimension: dim, context: d.context}, nil
@@ -78,7 +78,7 @@ func (d *Domain) DimensionFromName(name string) (*Dimension, error) {
 	defer C.free(unsafe.Pointer(cname))
 	var dim *C.tiledb_dimension_t
 	ret := C.tiledb_domain_get_dimension_from_name(d.context.tiledbContext, d.tiledbDomain, cname, &dim)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error getting tiledb dimension by name for domain: %s", d.context.GetLastError())
 	}
 	return &Dimension{tiledbDimension: dim, context: d.context}, nil
@@ -88,7 +88,7 @@ func (d *Domain) DimensionFromName(name string) (*Dimension, error) {
 func (d *Domain) AddDimension(dimensions ...Dimension) error {
 	for _, dimension := range dimensions {
 		ret := C.tiledb_domain_add_dimension(d.context.tiledbContext, d.tiledbDomain, dimension.tiledbDimension)
-		if ret == C.TILEDB_ERR {
+		if ret != C.TILEDB_OK {
 			return fmt.Errorf("Error adding dimension to domain: %s", d.context.GetLastError())
 		}
 	}

--- a/domain_test.go
+++ b/domain_test.go
@@ -1,0 +1,100 @@
+package tiledb
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func ExampleNewDomain() {
+	// Create Config, this is optional
+	config, err := NewConfig()
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Test context with config
+	context, err := NewContext(config)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Create Dimension
+	dimension, err := NewDimension(context, "test", []int32{1, 10}, 5)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Create Domain
+	domain, err := NewDomain(context)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Add dimension to domain
+	err = domain.AddDimension(*dimension)
+	if err != nil {
+		// Handle error
+		return
+	}
+}
+
+// TestDomain tests creating a new dimension
+func TestDomain(t *testing.T) {
+	// Create configuration
+	config, err := NewConfig()
+	assert.Nil(t, err)
+
+	// Test context with config
+	context, err := NewContext(config)
+	assert.Nil(t, err)
+
+	// Test create dimension
+	dimension, err := NewDimension(context, "test", []int32{1, 10}, 5)
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+
+	// Test creating domain
+	domain, err := NewDomain(context)
+	assert.Nil(t, err)
+	assert.NotNil(t, domain)
+
+	// Add dimension
+	err = domain.AddDimension(*dimension)
+	assert.Nil(t, err)
+
+	// Test getting type
+	datatype, err := domain.Type()
+	assert.Nil(t, err)
+	assert.Equal(t, TILEDB_INT32, datatype)
+
+	// Test getting number of dimension
+	ndim, err := domain.NDim()
+	assert.Nil(t, err)
+	assert.Equal(t, uint(1), ndim)
+
+	// Test getting dimension from index for domain
+	dimensionFromIndex, err := domain.DimensionFromIndex(0)
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+
+	// Validate dimension returned
+	dimensionName, err := dimensionFromIndex.Name()
+	assert.Nil(t, err)
+	assert.Equal(t, "test", dimensionName)
+
+	// Test getting dimension from name for domain
+	dimensionFromName, err := domain.DimensionFromName(dimensionName)
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+
+	// Validate dimension returned
+	dimensionName, err = dimensionFromName.Name()
+	assert.Nil(t, err)
+	assert.Equal(t, "test", dimensionName)
+
+	domain.Free()
+}

--- a/domain_test.go
+++ b/domain_test.go
@@ -1,8 +1,9 @@
 package tiledb
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func ExampleNewDomain() {
@@ -21,7 +22,7 @@ func ExampleNewDomain() {
 	}
 
 	// Create Dimension
-	dimension, err := NewDimension(context, "test", []int32{1, 10}, 5)
+	dimension, err := NewDimension(context, "test", []int32{1, 10}, int32(5))
 	if err != nil {
 		// Handle error
 		return
@@ -53,7 +54,7 @@ func TestDomain(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Test create dimension
-	dimension, err := NewDimension(context, "test", []int32{1, 10}, 5)
+	dimension, err := NewDimension(context, "test", []int32{1, 10}, int32(5))
 	assert.Nil(t, err)
 	assert.NotNil(t, dimension)
 

--- a/enums.go
+++ b/enums.go
@@ -8,6 +8,80 @@ package tiledb
 */
 import "C"
 
+// CompressorType enum in tiledb for compressors
+type CompressorType int8
+
+const (
+	// TILEDB_NO_COMPRESSION No compressor
+	TILEDB_NO_COMPRESSION CompressorType = C.TILEDB_NO_COMPRESSION
+	// TILEDB_GZIP Gzip compressor
+	TILEDB_GZIP CompressorType = C.TILEDB_GZIP
+	// TILEDB_ZSTD Zstandard compressor
+	TILEDB_ZSTD CompressorType = C.TILEDB_ZSTD
+	// TILEDB_LZ4 LZ4 compressor
+	TILEDB_LZ4 CompressorType = C.TILEDB_LZ4
+	// TILEDB_BLOSC_LZ Blosc compressor using LZ
+	TILEDB_BLOSC_LZ CompressorType = C.TILEDB_BLOSC_LZ
+	// TILEDB_BLOSC_LZ4 Blosc compressor using LZ4
+	TILEDB_BLOSC_LZ4 CompressorType = C.TILEDB_BLOSC_LZ4
+	// TILEDB_BLOSC_LZ4HC Blosc compressor using LZ4HC
+	TILEDB_BLOSC_LZ4HC CompressorType = C.TILEDB_BLOSC_LZ4HC
+	// TILEDB_BLOSC_SNAPPY Blosc compressor using Snappy
+	TILEDB_BLOSC_SNAPPY CompressorType = C.TILEDB_BLOSC_SNAPPY
+	// TILEDB_BLOSC_ZLIB Blosc compressor using zlib
+	TILEDB_BLOSC_ZLIB CompressorType = C.TILEDB_BLOSC_ZLIB
+	// TILEDB_BLOSC_ZSTD Blosc compressor using Zstandard
+	TILEDB_BLOSC_ZSTD CompressorType = C.TILEDB_BLOSC_ZSTD
+	// TILEDB_RLE Run-length encoding compressor
+	TILEDB_RLE CompressorType = C.TILEDB_RLE
+	// TILEDB_BZIP2 Bzip2 compressor
+	TILEDB_BZIP2 CompressorType = C.TILEDB_BZIP2
+	// TILEDB_DOUBLE_DELTA Double-delta compressor
+	TILEDB_DOUBLE_DELTA CompressorType = C.TILEDB_DOUBLE_DELTA
+)
+
+// Datatype
+type Datatype int8
+
+const (
+	// TILEDB_INT32 32-bit signed integer
+	TILEDB_INT32 Datatype = C.TILEDB_INT32
+	// TILEDB_INT64 64-bit signed integer
+	TILEDB_INT64 Datatype = C.TILEDB_INT64
+	// TILEDB_FLOAT32 32-bit floating point value
+	TILEDB_FLOAT32 Datatype = C.TILEDB_FLOAT32
+	// TILEDB_FLOAT64 64-bit floating point value
+	TILEDB_FLOAT64 Datatype = C.TILEDB_FLOAT64
+	// TILEDB_CHAR Character
+	TILEDB_CHAR Datatype = C.TILEDB_CHAR
+	// TILEDB_INT8 8-bit signed integer
+	TILEDB_INT8 Datatype = C.TILEDB_INT8
+	// TILEDB_UINT8 8-bit unsigned integer
+	TILEDB_UINT8 Datatype = C.TILEDB_UINT8
+	// TILEDB_INT16 16-bit signed integer
+	TILEDB_INT16 Datatype = C.TILEDB_INT16
+	// TILEDB_UINT16 16-bit unsigned integer
+	TILEDB_UINT16 Datatype = C.TILEDB_UINT16
+	// TILEDB_UINT32 32-bit unsigned integer
+	TILEDB_UINT32 Datatype = C.TILEDB_UINT32
+	// TILEDB_UINT64 64-bit unsigned integer
+	TILEDB_UINT64 Datatype = C.TILEDB_UINT64
+	// TILEDB_STRING_ASCII ASCII string
+	TILEDB_STRING_ASCII Datatype = C.TILEDB_STRING_ASCII
+	// TILEDB_STRING_UTF8 UTF-8 string
+	TILEDB_STRING_UTF8 Datatype = C.TILEDB_STRING_UTF8
+	// TILEDB_STRING_UTF16 UTF-16 string
+	TILEDB_STRING_UTF16 Datatype = C.TILEDB_STRING_UTF16
+	// TILEDB_STRING_UTF32 UTF-32 string
+	TILEDB_STRING_UTF32 Datatype = C.TILEDB_STRING_UTF32
+	// TILEDB_STRING_UCS2 UCS2 string
+	TILEDB_STRING_UCS2 Datatype = C.TILEDB_STRING_UCS2
+	// TILEDB_STRING_UCS4 UCS4 string
+	TILEDB_STRING_UCS4 Datatype = C.TILEDB_STRING_UCS4
+	// TILEDB_ANY This can be any datatype. Must store (type tag, value) pairs.
+	TILEDB_ANY Datatype = C.TILEDB_ANY
+)
+
 // FS
 type FS int8
 
@@ -31,3 +105,6 @@ const (
 	// TILEDB_VFS_APPENDopen file in write append mode
 	TILEDB_VFS_APPEND VFSMode = C.TILEDB_VFS_APPEND
 )
+
+// TIELDB_VAR_NUM indicates variable sized attributes for cell values
+var TILEDB_VAR_NUM = C.TILEDB_VAR_NUM

--- a/enums.go
+++ b/enums.go
@@ -103,6 +103,7 @@ const (
 	TILEDB_S3 FS = C.TILEDB_S3
 )
 
+// Layout cell/tile layout
 type Layout int8
 
 const (
@@ -114,6 +115,15 @@ const (
 	TILEDB_GLOBAL_ORDER Layout = C.TILEDB_GLOBAL_ORDER
 	// TILEDB_UNORDERED Unordered layout
 	TILEDB_UNORDERED Layout = C.TILEDB_UNORDERED
+)
+
+type QueryType int8
+
+const (
+	// TILEDB_READ Read query
+	TILEDB_READ QueryType = C.TILEDB_READ
+	// TILEDB_WRITE Write query
+	TILEDB_WRITE QueryType = C.TILEDB_WRITE
 )
 
 // VFSMode is virtual file system file open mode
@@ -131,4 +141,4 @@ const (
 )
 
 // TIELDB_VAR_NUM indicates variable sized attributes for cell values
-var TILEDB_VAR_NUM = C.TILEDB_VAR_NUM
+var TILEDB_VAR_NUM = uint(C.TILEDB_VAR_NUM)

--- a/enums.go
+++ b/enums.go
@@ -8,26 +8,26 @@ package tiledb
 */
 import "C"
 
-// TiledbFS
-type TiledbFS int8
+// FS
+type FS int8
 
 const (
 	// TILEDB_HDFS HDFS filesystem support
-	TILEDB_HDFS TiledbFS = C.TILEDB_HDFS
+	TILEDB_HDFS FS = C.TILEDB_HDFS
 
 	// TILEDB_S3 S3 filesystem support
-	TILEDB_S3 TiledbFS = C.TILEDB_S3
+	TILEDB_S3 FS = C.TILEDB_S3
 )
 
-type TiledbVFSMode int8
+type VFSMode int8
 
 const (
 	// TILEDB_VFS_READ open file in read mode
-	TILEDB_VFS_READ TiledbVFSMode = C.TILEDB_VFS_READ
+	TILEDB_VFS_READ VFSMode = C.TILEDB_VFS_READ
 
 	// TILEDB_VFS_WRITE open file in write mode
-	TILEDB_VFS_WRITE TiledbVFSMode = C.TILEDB_VFS_WRITE
+	TILEDB_VFS_WRITE VFSMode = C.TILEDB_VFS_WRITE
 
 	// TILEDB_VFS_APPENDopen file in write append mode
-	TILEDB_VFS_APPEND TiledbVFSMode = C.TILEDB_VFS_APPEND
+	TILEDB_VFS_APPEND VFSMode = C.TILEDB_VFS_APPEND
 )

--- a/enums.go
+++ b/enums.go
@@ -8,6 +8,16 @@ package tiledb
 */
 import "C"
 
+// ArrayType enum for tiledb arrays
+type ArrayType int8
+
+const (
+	// TILEDB_DENSE dense array
+	TILEDB_DENSE ArrayType = C.TILEDB_DENSE
+	// TILEDB_SPARSE dense array
+	TILEDB_SPARSE ArrayType = C.TILEDB_SPARSE
+)
+
 // CompressorType enum in tiledb for compressors
 type CompressorType int8
 
@@ -82,7 +92,7 @@ const (
 	TILEDB_ANY Datatype = C.TILEDB_ANY
 )
 
-// FS
+// FS represents support fs types
 type FS int8
 
 const (
@@ -93,6 +103,20 @@ const (
 	TILEDB_S3 FS = C.TILEDB_S3
 )
 
+type Layout int8
+
+const (
+	// TILEDB_ROW_MAJOR Row-major layout
+	TILEDB_ROW_MAJOR Layout = C.TILEDB_ROW_MAJOR
+	// TILEDB_COL_MAJOR Column-major layout
+	TILEDB_COL_MAJOR Layout = C.TILEDB_COL_MAJOR
+	// TILEDB_GLOBAL_ORDER Global-order layout
+	TILEDB_GLOBAL_ORDER Layout = C.TILEDB_GLOBAL_ORDER
+	// TILEDB_UNORDERED Unordered layout
+	TILEDB_UNORDERED Layout = C.TILEDB_UNORDERED
+)
+
+// VFSMode is virtual file system file open mode
 type VFSMode int8
 
 const (

--- a/group.go
+++ b/group.go
@@ -18,7 +18,7 @@ func GroupCreate(context *Context, group string) error {
 	defer C.free(unsafe.Pointer(cgroup))
 
 	ret := C.tiledb_group_create(context.tiledbContext, cgroup)
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error in creating group %s: %s", group, context.GetLastError())
 	}
 	return nil

--- a/group.go
+++ b/group.go
@@ -1,0 +1,25 @@
+package tiledb
+
+/*
+#cgo LDFLAGS: -ltiledb
+#include <tiledb/tiledb.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+// GroupCreate creates a new tiledb group
+func GroupCreate(context *Context, group string) error {
+	cgroup := C.CString(group)
+	defer C.free(unsafe.Pointer(cgroup))
+
+	ret := C.tiledb_group_create(context.tiledbContext, cgroup)
+	if ret == C.TILEDB_ERR {
+		return fmt.Errorf("Error in creating group %s: %s", group, context.GetLastError())
+	}
+	return nil
+}

--- a/group_test.go
+++ b/group_test.go
@@ -1,0 +1,46 @@
+package tiledb
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestGroupCreate(t *testing.T) {
+
+	// Test context without config
+	context, err := NewContext(nil)
+	assert.Nil(t, err)
+
+	// create temp group name
+	tmpGroup := os.TempDir() + string(os.PathSeparator) + "tiledb_test_group"
+	// Cleanup group when test ends
+	defer os.RemoveAll(tmpGroup)
+	if _, err = os.Stat(tmpGroup); err == nil {
+		os.RemoveAll(tmpGroup)
+	}
+
+	// Create initial group
+	err = GroupCreate(context, tmpGroup)
+	assert.Nil(t, err)
+
+	// Creating the same group twice should error
+	err = GroupCreate(context, tmpGroup)
+	assert.NotNil(t, err)
+}
+
+func ExampleGroupCreate() {
+	// Create context without config
+	context, err := NewContext(nil)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Create Group
+	err = GroupCreate(context, "my_group")
+	if err != nil {
+		// Handle error
+		return
+	}
+}

--- a/vfs.go
+++ b/vfs.go
@@ -275,7 +275,7 @@ func (v *VFS) MoveDir(context *Context, oldURI string, newURI string) error {
 }
 
 // Open a file
-func (v *VFS) Open(context *Context, uri string, mode TiledbVFSMode) (*VFSfh, error) {
+func (v *VFS) Open(context *Context, uri string, mode VFSMode) (*VFSfh, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	fh := &VFSfh{}

--- a/vfs.go
+++ b/vfs.go
@@ -33,7 +33,7 @@ func (v *VFSfh) IsClosed() (bool, error) {
 
 	ret := C.tiledb_vfs_fh_is_closed(v.context.tiledbContext, v.tiledbVFSfh, &isClosed)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("Error in checking if vfs file handler is closed")
 	}
 
@@ -86,7 +86,7 @@ func (v *VFS) CreateBucket(uri string) error {
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_vfs_create_bucket(v.context.tiledbContext, v.tiledbVFS, curi)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error in creating s3 bucket %s: %s", uri, v.context.GetLastError())
 	}
 
@@ -99,7 +99,7 @@ func (v *VFS) RemoveBucket(uri string) error {
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_vfs_remove_bucket(v.context.tiledbContext, v.tiledbVFS, curi)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error in removing s3 bucket %s: %s", uri, v.context.GetLastError())
 	}
 
@@ -112,7 +112,7 @@ func (v *VFS) EmptyBucket(uri string) error {
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_vfs_empty_bucket(v.context.tiledbContext, v.tiledbVFS, curi)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error in emptying s3 bucket %s: %s", uri, v.context.GetLastError())
 	}
 
@@ -126,7 +126,7 @@ func (v *VFS) IsEmptyBucket(uri string) (bool, error) {
 	var isEmpty C.int
 	ret := C.tiledb_vfs_is_empty_bucket(v.context.tiledbContext, v.tiledbVFS, curi, &isEmpty)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("Error in checking if s3 bucket %s is empty: %s", uri, v.context.GetLastError())
 	}
 
@@ -144,7 +144,7 @@ func (v *VFS) IsBucket(uri string) (bool, error) {
 	var isBucket C.int
 	ret := C.tiledb_vfs_is_bucket(v.context.tiledbContext, v.tiledbVFS, curi, &isBucket)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("Error in checking if %s is a s3 bucket: %s", uri, v.context.GetLastError())
 	}
 
@@ -161,7 +161,7 @@ func (v *VFS) CreateDir(uri string) error {
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_vfs_create_dir(v.context.tiledbContext, v.tiledbVFS, curi)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error in creating directory %s: %s", uri, v.context.GetLastError())
 	}
 
@@ -175,7 +175,7 @@ func (v *VFS) IsDir(uri string) (bool, error) {
 	var isDir C.int
 	ret := C.tiledb_vfs_is_dir(v.context.tiledbContext, v.tiledbVFS, curi, &isDir)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("Error in checking if %s is a directory: %s", uri, v.context.GetLastError())
 	}
 
@@ -192,7 +192,7 @@ func (v *VFS) RemoveDir(uri string) error {
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_vfs_remove_dir(v.context.tiledbContext, v.tiledbVFS, curi)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error in removing directory %s: %s", uri, v.context.GetLastError())
 	}
 
@@ -206,7 +206,7 @@ func (v *VFS) IsFile(uri string) (bool, error) {
 	var isFile C.int
 	ret := C.tiledb_vfs_is_file(v.context.tiledbContext, v.tiledbVFS, curi, &isFile)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("Error in checking if %s is a file: %s", uri, v.context.GetLastError())
 	}
 
@@ -223,7 +223,7 @@ func (v *VFS) RemoveFile(uri string) error {
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_vfs_remove_file(v.context.tiledbContext, v.tiledbVFS, curi)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error in removing file %s: %s", uri, v.context.GetLastError())
 	}
 
@@ -237,7 +237,7 @@ func (v *VFS) FileSize(uri string) (uint64, error) {
 	var cfsize C.uint64_t
 	ret := C.tiledb_vfs_file_size(v.context.tiledbContext, v.tiledbVFS, curi, &cfsize)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("Error in removing file %s: %s", uri, v.context.GetLastError())
 	}
 
@@ -253,7 +253,7 @@ func (v *VFS) MoveFile(oldURI string, newURI string) error {
 
 	ret := C.tiledb_vfs_move_file(v.context.tiledbContext, v.tiledbVFS, cOldURI, cNewURI)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error in moving file %s to %s: %s", oldURI, newURI, v.context.GetLastError())
 	}
 
@@ -269,7 +269,7 @@ func (v *VFS) MoveDir(oldURI string, newURI string) error {
 
 	ret := C.tiledb_vfs_move_dir(v.context.tiledbContext, v.tiledbVFS, cOldURI, cNewURI)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error in moving directory %s to %s: %s", oldURI, newURI, v.context.GetLastError())
 	}
 
@@ -290,7 +290,7 @@ func (v *VFS) Open(uri string, mode VFSMode) (*VFSfh, error) {
 
 	if ret == C.TILEDB_OOM {
 		return nil, fmt.Errorf("Out of Memory error in VFS.Open: %s", v.context.GetLastError())
-	} else if ret == C.TILEDB_ERR {
+	} else if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Unknown error in VFS.Open: %s", v.context.GetLastError())
 	}
 
@@ -302,7 +302,7 @@ func (v *VFS) Close(fh *VFSfh) error {
 
 	ret := C.tiledb_vfs_close(v.context.tiledbContext, fh.tiledbVFSfh)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Unknown error in VFS.Close: %s", v.context.GetLastError())
 	}
 
@@ -316,7 +316,7 @@ func (v *VFS) Read(fh *VFSfh, offset uint64, nbytes uint64) ([]byte, error) {
 	cbuffer := C.CBytes(bytes)
 	ret := C.tiledb_vfs_read(v.context.tiledbContext, fh.tiledbVFSfh, C.uint64_t(offset), cbuffer, C.uint64_t(nbytes))
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return []byte{}, fmt.Errorf("Unknown error in VFS.Read: %s", v.context.GetLastError())
 	}
 
@@ -330,7 +330,7 @@ func (v *VFS) Write(fh *VFSfh, bytes []byte) error {
 	cbuffer := C.CBytes(bytes)
 	ret := C.tiledb_vfs_write(v.context.tiledbContext, fh.tiledbVFSfh, cbuffer, C.uint64_t(len(bytes)))
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Unknown error in VFS.Write: %s", v.context.GetLastError())
 	}
 
@@ -341,7 +341,7 @@ func (v *VFS) Write(fh *VFSfh, bytes []byte) error {
 func (v *VFS) Sync(fh *VFSfh) error {
 	ret := C.tiledb_vfs_sync(v.context.tiledbContext, fh.tiledbVFSfh)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Unknown error in VFS.Sync: %s", v.context.GetLastError())
 	}
 
@@ -354,7 +354,7 @@ func (v *VFS) Touch(uri string) error {
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_vfs_touch(v.context.tiledbContext, v.tiledbVFS, curi)
 
-	if ret == C.TILEDB_ERR {
+	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error in touching %s: %s", uri, v.context.GetLastError())
 	}
 

--- a/vfs.go
+++ b/vfs.go
@@ -16,6 +16,7 @@ import (
 // VFSfh is a virtual file system file handler
 type VFSfh struct {
 	tiledbVFSfh *C.tiledb_vfs_fh_t
+	context     *Context
 }
 
 // Free a tiledb c vfs file handler
@@ -27,10 +28,10 @@ func (v *VFSfh) Free() {
 
 // IsClosed checks a vfs file handler to see if it is closed. Return true if
 // file handler is closed, false if its not closed and error is non-nil on error
-func (v *VFSfh) IsClosed(context *Context) (bool, error) {
+func (v *VFSfh) IsClosed() (bool, error) {
 	var isClosed C.int
 
-	ret := C.tiledb_vfs_fh_is_closed(context.tiledbContext, v.tiledbVFSfh, &isClosed)
+	ret := C.tiledb_vfs_fh_is_closed(v.context.tiledbContext, v.tiledbVFSfh, &isClosed)
 
 	if ret == C.TILEDB_ERR {
 		return false, fmt.Errorf("Error in checking if vfs file handler is closed")
@@ -46,13 +47,14 @@ func (v *VFSfh) IsClosed(context *Context) (bool, error) {
 // VFS is tiledb virtual file system structure
 type VFS struct {
 	tiledbVFS *C.tiledb_vfs_t
+	context   *Context
 }
 
 // NewVFS alloc a new context using tiledb_vfs_alloc. This also registers the
 // `runtime.SetFinalizer` for handling the free'ing of the c data structure on
 // garbage collection
 func NewVFS(context *Context, config *Config) (*VFS, error) {
-	var vfs VFS
+	vfs := VFS{context: context}
 	var err *C.tiledb_error_t
 	C.tiledb_vfs_alloc(context.tiledbContext, config.tiledbConfig, &vfs.tiledbVFS)
 	if err != nil {
@@ -79,53 +81,53 @@ func (v *VFS) Free() {
 }
 
 // CreateBucket creates a s3 bucket
-func (v *VFS) CreateBucket(context *Context, uri string) error {
+func (v *VFS) CreateBucket(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_create_bucket(context.tiledbContext, v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_create_bucket(v.context.tiledbContext, v.tiledbVFS, curi)
 
 	if ret == C.TILEDB_ERR {
-		return fmt.Errorf("Error in creating s3 bucket %s: %s", uri, context.GetLastError())
+		return fmt.Errorf("Error in creating s3 bucket %s: %s", uri, v.context.GetLastError())
 	}
 
 	return nil
 }
 
 // RemoveBucket removes a s3 bucket
-func (v *VFS) RemoveBucket(context *Context, uri string) error {
+func (v *VFS) RemoveBucket(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_remove_bucket(context.tiledbContext, v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_remove_bucket(v.context.tiledbContext, v.tiledbVFS, curi)
 
 	if ret == C.TILEDB_ERR {
-		return fmt.Errorf("Error in removing s3 bucket %s: %s", uri, context.GetLastError())
+		return fmt.Errorf("Error in removing s3 bucket %s: %s", uri, v.context.GetLastError())
 	}
 
 	return nil
 }
 
 // EmptyBucket empties a s3 bucket
-func (v *VFS) EmptyBucket(context *Context, uri string) error {
+func (v *VFS) EmptyBucket(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_empty_bucket(context.tiledbContext, v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_empty_bucket(v.context.tiledbContext, v.tiledbVFS, curi)
 
 	if ret == C.TILEDB_ERR {
-		return fmt.Errorf("Error in emptying s3 bucket %s: %s", uri, context.GetLastError())
+		return fmt.Errorf("Error in emptying s3 bucket %s: %s", uri, v.context.GetLastError())
 	}
 
 	return nil
 }
 
 // IsEmptyBucket checks if a s3 bucket is empty
-func (v *VFS) IsEmptyBucket(context *Context, uri string) (bool, error) {
+func (v *VFS) IsEmptyBucket(uri string) (bool, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var isEmpty C.int
-	ret := C.tiledb_vfs_is_empty_bucket(context.tiledbContext, v.tiledbVFS, curi, &isEmpty)
+	ret := C.tiledb_vfs_is_empty_bucket(v.context.tiledbContext, v.tiledbVFS, curi, &isEmpty)
 
 	if ret == C.TILEDB_ERR {
-		return false, fmt.Errorf("Error in checking if s3 bucket %s is empty: %s", uri, context.GetLastError())
+		return false, fmt.Errorf("Error in checking if s3 bucket %s is empty: %s", uri, v.context.GetLastError())
 	}
 
 	if isEmpty == 1 {
@@ -136,14 +138,14 @@ func (v *VFS) IsEmptyBucket(context *Context, uri string) (bool, error) {
 }
 
 // IsBucket checks if a uri is a s3 bucket
-func (v *VFS) IsBucket(context *Context, uri string) (bool, error) {
+func (v *VFS) IsBucket(uri string) (bool, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var isBucket C.int
-	ret := C.tiledb_vfs_is_bucket(context.tiledbContext, v.tiledbVFS, curi, &isBucket)
+	ret := C.tiledb_vfs_is_bucket(v.context.tiledbContext, v.tiledbVFS, curi, &isBucket)
 
 	if ret == C.TILEDB_ERR {
-		return false, fmt.Errorf("Error in checking if %s is a s3 bucket: %s", uri, context.GetLastError())
+		return false, fmt.Errorf("Error in checking if %s is a s3 bucket: %s", uri, v.context.GetLastError())
 	}
 
 	if isBucket == 1 {
@@ -154,27 +156,27 @@ func (v *VFS) IsBucket(context *Context, uri string) (bool, error) {
 }
 
 // CreateDir creates a directory
-func (v *VFS) CreateDir(context *Context, uri string) error {
+func (v *VFS) CreateDir(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_create_dir(context.tiledbContext, v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_create_dir(v.context.tiledbContext, v.tiledbVFS, curi)
 
 	if ret == C.TILEDB_ERR {
-		return fmt.Errorf("Error in creating directory %s: %s", uri, context.GetLastError())
+		return fmt.Errorf("Error in creating directory %s: %s", uri, v.context.GetLastError())
 	}
 
 	return nil
 }
 
 // IsDir checks if a uri is a exists directory
-func (v *VFS) IsDir(context *Context, uri string) (bool, error) {
+func (v *VFS) IsDir(uri string) (bool, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var isDir C.int
-	ret := C.tiledb_vfs_is_dir(context.tiledbContext, v.tiledbVFS, curi, &isDir)
+	ret := C.tiledb_vfs_is_dir(v.context.tiledbContext, v.tiledbVFS, curi, &isDir)
 
 	if ret == C.TILEDB_ERR {
-		return false, fmt.Errorf("Error in checking if %s is a directory: %s", uri, context.GetLastError())
+		return false, fmt.Errorf("Error in checking if %s is a directory: %s", uri, v.context.GetLastError())
 	}
 
 	if isDir == 1 {
@@ -185,27 +187,27 @@ func (v *VFS) IsDir(context *Context, uri string) (bool, error) {
 }
 
 // RemoveDir creates a directory
-func (v *VFS) RemoveDir(context *Context, uri string) error {
+func (v *VFS) RemoveDir(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_remove_dir(context.tiledbContext, v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_remove_dir(v.context.tiledbContext, v.tiledbVFS, curi)
 
 	if ret == C.TILEDB_ERR {
-		return fmt.Errorf("Error in removing directory %s: %s", uri, context.GetLastError())
+		return fmt.Errorf("Error in removing directory %s: %s", uri, v.context.GetLastError())
 	}
 
 	return nil
 }
 
 // IsFile checks if a uri is a exists file
-func (v *VFS) IsFile(context *Context, uri string) (bool, error) {
+func (v *VFS) IsFile(uri string) (bool, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var isFile C.int
-	ret := C.tiledb_vfs_is_file(context.tiledbContext, v.tiledbVFS, curi, &isFile)
+	ret := C.tiledb_vfs_is_file(v.context.tiledbContext, v.tiledbVFS, curi, &isFile)
 
 	if ret == C.TILEDB_ERR {
-		return false, fmt.Errorf("Error in checking if %s is a file: %s", uri, context.GetLastError())
+		return false, fmt.Errorf("Error in checking if %s is a file: %s", uri, v.context.GetLastError())
 	}
 
 	if isFile == 1 {
@@ -216,92 +218,92 @@ func (v *VFS) IsFile(context *Context, uri string) (bool, error) {
 }
 
 // RemoveFile creates a file
-func (v *VFS) RemoveFile(context *Context, uri string) error {
+func (v *VFS) RemoveFile(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_remove_file(context.tiledbContext, v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_remove_file(v.context.tiledbContext, v.tiledbVFS, curi)
 
 	if ret == C.TILEDB_ERR {
-		return fmt.Errorf("Error in removing file %s: %s", uri, context.GetLastError())
+		return fmt.Errorf("Error in removing file %s: %s", uri, v.context.GetLastError())
 	}
 
 	return nil
 }
 
 // FileSize creates a file
-func (v *VFS) FileSize(context *Context, uri string) (uint64, error) {
+func (v *VFS) FileSize(uri string) (uint64, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var cfsize C.uint64_t
-	ret := C.tiledb_vfs_file_size(context.tiledbContext, v.tiledbVFS, curi, &cfsize)
+	ret := C.tiledb_vfs_file_size(v.context.tiledbContext, v.tiledbVFS, curi, &cfsize)
 
 	if ret == C.TILEDB_ERR {
-		return 0, fmt.Errorf("Error in removing file %s: %s", uri, context.GetLastError())
+		return 0, fmt.Errorf("Error in removing file %s: %s", uri, v.context.GetLastError())
 	}
 
 	return uint64(cfsize), nil
 }
 
 // MoveFile moves a file
-func (v *VFS) MoveFile(context *Context, oldURI string, newURI string) error {
+func (v *VFS) MoveFile(oldURI string, newURI string) error {
 	cOldURI := C.CString(oldURI)
 	defer C.free(unsafe.Pointer(cOldURI))
 	cNewURI := C.CString(newURI)
 	defer C.free(unsafe.Pointer(cNewURI))
 
-	ret := C.tiledb_vfs_move_file(context.tiledbContext, v.tiledbVFS, cOldURI, cNewURI)
+	ret := C.tiledb_vfs_move_file(v.context.tiledbContext, v.tiledbVFS, cOldURI, cNewURI)
 
 	if ret == C.TILEDB_ERR {
-		return fmt.Errorf("Error in moving file %s to %s: %s", oldURI, newURI, context.GetLastError())
+		return fmt.Errorf("Error in moving file %s to %s: %s", oldURI, newURI, v.context.GetLastError())
 	}
 
 	return nil
 }
 
 // MoveDir moves a directory
-func (v *VFS) MoveDir(context *Context, oldURI string, newURI string) error {
+func (v *VFS) MoveDir(oldURI string, newURI string) error {
 	cOldURI := C.CString(oldURI)
 	defer C.free(unsafe.Pointer(cOldURI))
 	cNewURI := C.CString(newURI)
 	defer C.free(unsafe.Pointer(cNewURI))
 
-	ret := C.tiledb_vfs_move_dir(context.tiledbContext, v.tiledbVFS, cOldURI, cNewURI)
+	ret := C.tiledb_vfs_move_dir(v.context.tiledbContext, v.tiledbVFS, cOldURI, cNewURI)
 
 	if ret == C.TILEDB_ERR {
-		return fmt.Errorf("Error in moving directory %s to %s: %s", oldURI, newURI, context.GetLastError())
+		return fmt.Errorf("Error in moving directory %s to %s: %s", oldURI, newURI, v.context.GetLastError())
 	}
 
 	return nil
 }
 
 // Open a file
-func (v *VFS) Open(context *Context, uri string, mode VFSMode) (*VFSfh, error) {
+func (v *VFS) Open(uri string, mode VFSMode) (*VFSfh, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	fh := &VFSfh{}
+	fh := &VFSfh{context: v.context}
 	// Set finalizer for free C pointer on gc
 	runtime.SetFinalizer(fh, func(fh *VFSfh) {
 		fh.Free()
 	})
 
-	ret := C.tiledb_vfs_open(context.tiledbContext, v.tiledbVFS, curi, C.tiledb_vfs_mode_t(mode), &fh.tiledbVFSfh)
+	ret := C.tiledb_vfs_open(v.context.tiledbContext, v.tiledbVFS, curi, C.tiledb_vfs_mode_t(mode), &fh.tiledbVFSfh)
 
 	if ret == C.TILEDB_OOM {
-		return nil, fmt.Errorf("Out of Memory error in VFS.Open: %s", context.GetLastError())
+		return nil, fmt.Errorf("Out of Memory error in VFS.Open: %s", v.context.GetLastError())
 	} else if ret == C.TILEDB_ERR {
-		return nil, fmt.Errorf("Unknown error in VFS.Open: %s", context.GetLastError())
+		return nil, fmt.Errorf("Unknown error in VFS.Open: %s", v.context.GetLastError())
 	}
 
 	return fh, nil
 }
 
 // Close a file
-func (v *VFS) Close(context *Context, fh *VFSfh) error {
+func (v *VFS) Close(fh *VFSfh) error {
 
-	ret := C.tiledb_vfs_close(context.tiledbContext, fh.tiledbVFSfh)
+	ret := C.tiledb_vfs_close(v.context.tiledbContext, fh.tiledbVFSfh)
 
 	if ret == C.TILEDB_ERR {
-		return fmt.Errorf("Unknown error in VFS.Close: %s", context.GetLastError())
+		return fmt.Errorf("Unknown error in VFS.Close: %s", v.context.GetLastError())
 	}
 
 	fh.Free()
@@ -309,13 +311,13 @@ func (v *VFS) Close(context *Context, fh *VFSfh) error {
 }
 
 // Read part of a file
-func (v *VFS) Read(context *Context, fh *VFSfh, offset uint64, nbytes uint64) ([]byte, error) {
+func (v *VFS) Read(fh *VFSfh, offset uint64, nbytes uint64) ([]byte, error) {
 	bytes := make([]byte, nbytes)
 	cbuffer := C.CBytes(bytes)
-	ret := C.tiledb_vfs_read(context.tiledbContext, fh.tiledbVFSfh, C.uint64_t(offset), cbuffer, C.uint64_t(nbytes))
+	ret := C.tiledb_vfs_read(v.context.tiledbContext, fh.tiledbVFSfh, C.uint64_t(offset), cbuffer, C.uint64_t(nbytes))
 
 	if ret == C.TILEDB_ERR {
-		return []byte{}, fmt.Errorf("Unknown error in VFS.Read: %s", context.GetLastError())
+		return []byte{}, fmt.Errorf("Unknown error in VFS.Read: %s", v.context.GetLastError())
 	}
 
 	bytes = C.GoBytes(cbuffer, C.int(nbytes))
@@ -324,36 +326,36 @@ func (v *VFS) Read(context *Context, fh *VFSfh, offset uint64, nbytes uint64) ([
 }
 
 // Write bytes to a file
-func (v *VFS) Write(context *Context, fh *VFSfh, bytes []byte) error {
+func (v *VFS) Write(fh *VFSfh, bytes []byte) error {
 	cbuffer := C.CBytes(bytes)
-	ret := C.tiledb_vfs_write(context.tiledbContext, fh.tiledbVFSfh, cbuffer, C.uint64_t(len(bytes)))
+	ret := C.tiledb_vfs_write(v.context.tiledbContext, fh.tiledbVFSfh, cbuffer, C.uint64_t(len(bytes)))
 
 	if ret == C.TILEDB_ERR {
-		return fmt.Errorf("Unknown error in VFS.Write: %s", context.GetLastError())
+		return fmt.Errorf("Unknown error in VFS.Write: %s", v.context.GetLastError())
 	}
 
 	return nil
 }
 
 // Sync a file handler
-func (v *VFS) Sync(context *Context, fh *VFSfh) error {
-	ret := C.tiledb_vfs_sync(context.tiledbContext, fh.tiledbVFSfh)
+func (v *VFS) Sync(fh *VFSfh) error {
+	ret := C.tiledb_vfs_sync(v.context.tiledbContext, fh.tiledbVFSfh)
 
 	if ret == C.TILEDB_ERR {
-		return fmt.Errorf("Unknown error in VFS.Sync: %s", context.GetLastError())
+		return fmt.Errorf("Unknown error in VFS.Sync: %s", v.context.GetLastError())
 	}
 
 	return nil
 }
 
 // Touch creates an empty file
-func (v *VFS) Touch(context *Context, uri string) error {
+func (v *VFS) Touch(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_touch(context.tiledbContext, v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_touch(v.context.tiledbContext, v.tiledbVFS, curi)
 
 	if ret == C.TILEDB_ERR {
-		return fmt.Errorf("Error in touching %s: %s", uri, context.GetLastError())
+		return fmt.Errorf("Error in touching %s: %s", uri, v.context.GetLastError())
 	}
 
 	return nil

--- a/vfs_test.go
+++ b/vfs_test.go
@@ -24,43 +24,43 @@ func TestVFS(t *testing.T) {
 		os.Remove(tmpPath)
 	}
 
-	isFile, err := vfs.IsFile(context, tmpPath)
+	isFile, err := vfs.IsFile(tmpPath)
 	assert.Nil(t, err)
 	assert.False(t, isFile)
 
-	isDir, err := vfs.IsDir(context, tmpPath)
+	isDir, err := vfs.IsDir(tmpPath)
 	assert.Nil(t, err)
 	assert.False(t, isDir)
 
 	// Create directory
-	err = vfs.CreateDir(context, tmpPath)
+	err = vfs.CreateDir(tmpPath)
 	assert.Nil(t, err)
 
-	isDir, err = vfs.IsDir(context, tmpPath)
+	isDir, err = vfs.IsDir(tmpPath)
 	assert.Nil(t, err)
 	assert.True(t, isDir)
 
 	// Remove directory
-	err = vfs.RemoveDir(context, tmpPath)
+	err = vfs.RemoveDir(tmpPath)
 	assert.Nil(t, err)
 
 	// Create File
-	err = vfs.Touch(context, tmpPath)
+	err = vfs.Touch(tmpPath)
 	assert.Nil(t, err)
 
-	fh, err := vfs.Open(context, tmpPath, TILEDB_VFS_WRITE)
+	fh, err := vfs.Open(tmpPath, TILEDB_VFS_WRITE)
 	assert.Nil(t, err)
 
 	bytes := []byte{0, 1, 2}
-	err = vfs.Write(context, fh, bytes)
+	err = vfs.Write(fh, bytes)
 	assert.Nil(t, err)
 
-	bytes2, err := vfs.Read(context, fh, 0, uint64(len(bytes)))
+	bytes2, err := vfs.Read(fh, 0, uint64(len(bytes)))
 
 	assert.EqualValues(t, bytes, bytes2)
 
 	// Remove File
-	err = vfs.RemoveFile(context, tmpPath)
+	err = vfs.RemoveFile(tmpPath)
 	assert.Nil(t, err)
 }
 
@@ -88,7 +88,7 @@ func ExampleNewVFS() {
 
 	uri := "file:///tmp/tiledb_example_folder"
 	// Check if directory exists
-	if isDir, err := vfs.IsDir(context, uri); err != nil {
+	if isDir, err := vfs.IsDir(uri); err != nil {
 		fmt.Println(err)
 	} else {
 		// Directory exists


### PR DESCRIPTION
This add Array Support, Array Schema, Dimension, Domain, Attribute, Group and adjust VFS to store context on struct.

Test coverage is only about 58% as query support is not implemented so any code paths that require data/non-empty arrays can't be tested via unit testing yet.

For functions which take void pointers to handle arrays of varies datatypes I've handled that by taking interface{}'s as a parameter to the function and then switching on the domain/dimension datatype to be able to convert the golang array to a void * in C.

Closes #7.