### PR TITLE
Query operation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ go test github.com/TileDB-Inc/TileDB-Go
 
 ## Example Usage
 
-Below is a small example using vfs functionality. Additionale examples are
+Below is a small example using vfs functionality. Additional examples are
 provided in the GoDoc documentation.
 
 ```golang

--- a/array.go
+++ b/array.go
@@ -38,7 +38,7 @@ func NewArray(ctx *Context, uri string) (*Array, error) {
 	return &array, nil
 }
 
-// Free tiledb_domain_t that was allocated on heap in c
+// Free tiledb_array_t that was allocated on heap in c
 func (a *Array) Free() {
 	if a.tiledbArray != nil {
 		C.tiledb_array_free(&a.tiledbArray)

--- a/array_schema.go
+++ b/array_schema.go
@@ -35,7 +35,7 @@ func NewArraySchema(ctx *Context, arrayType ArrayType) (*ArraySchema, error) {
 	return &arraySchema, nil
 }
 
-// Free tiledb_domain_t that was allocated on heap in c
+// Free tiledb_array_schema_t that was allocated on heap in c
 func (a *ArraySchema) Free() {
 	if a.tiledbArraySchema != nil {
 		C.tiledb_array_schema_free(&a.tiledbArraySchema)

--- a/enums.go
+++ b/enums.go
@@ -8,6 +8,8 @@ package tiledb
 */
 import "C"
 
+import "reflect"
+
 // ArrayType enum for tiledb arrays
 type ArrayType int8
 
@@ -92,6 +94,48 @@ const (
 	TILEDB_ANY Datatype = C.TILEDB_ANY
 )
 
+// ReflectKind returns the reflect kind given a datatype
+func (d Datatype) ReflectKind() reflect.Kind {
+	switch d {
+	case TILEDB_INT8:
+		return reflect.Int8
+	case TILEDB_INT16:
+		return reflect.Int16
+	case TILEDB_INT32:
+		return reflect.Int32
+	case TILEDB_INT64:
+		return reflect.Int64
+	case TILEDB_UINT8:
+		return reflect.Uint8
+	case TILEDB_UINT16:
+		return reflect.Uint16
+	case TILEDB_UINT32:
+		return reflect.Uint32
+	case TILEDB_UINT64:
+		return reflect.Uint64
+	case TILEDB_FLOAT32:
+		return reflect.Float32
+	case TILEDB_FLOAT64:
+		return reflect.Float64
+	case TILEDB_STRING_ASCII:
+		return reflect.Uint8
+	case TILEDB_STRING_UTF8:
+		return reflect.Uint8
+	case TILEDB_STRING_UTF16:
+		return reflect.Uint16
+	case TILEDB_STRING_UTF32:
+		return reflect.Uint32
+	case TILEDB_STRING_UCS2:
+		return reflect.Uint16
+	case TILEDB_STRING_UCS4:
+		return reflect.Uint32
+	case TILEDB_ANY:
+		return reflect.Interface
+	default:
+		return reflect.Interface
+	}
+}
+
 // FS represents support fs types
 type FS int8
 
@@ -117,6 +161,23 @@ const (
 	TILEDB_UNORDERED Layout = C.TILEDB_UNORDERED
 )
 
+// QueryStatus status of a query
+type QueryStatus int8
+
+const (
+	// TILEDB_FAILED Query failed
+	TILEDB_FAILED QueryStatus = C.TILEDB_FAILED
+	// TILEDB_COMPLETED Query completed (all data has been read)
+	TILEDB_COMPLETED QueryStatus = C.TILEDB_COMPLETED
+	// TILEDB_INPROGRESS Query is in progress
+	TILEDB_INPROGRESS QueryStatus = C.TILEDB_INPROGRESS
+	//TILEDB_INCOMPLETE Query completed (but not all data has been read)
+	TILEDB_INCOMPLETE QueryStatus = C.TILEDB_INCOMPLETE
+	// TILEDB_UNINITIALIZED Query not initialized.
+	TILEDB_UNINITIALIZED QueryStatus = C.TILEDB_UNINITIALIZED
+)
+
+// QueryType read or write query
 type QueryType int8
 
 const (

--- a/query.go
+++ b/query.go
@@ -1,0 +1,544 @@
+package tiledb
+
+/*
+#cgo LDFLAGS: -ltiledb
+#include <tiledb/tiledb.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"sync"
+	"unsafe"
+)
+
+// Query is tiledb query
+type Query struct {
+	tiledbQuery *C.tiledb_query_t
+	array       *Array
+	context     *Context
+	uri         string
+	buffers     []interface{}
+	bufferMutex sync.Mutex
+}
+
+// NewQuery alloc a new query
+func NewQuery(ctx *Context, array *Array) (*Query, error) {
+	if array == nil {
+		return nil, fmt.Errorf("Error creating tiledb query: passed array is nil")
+	}
+
+	queryType, err := array.QueryType()
+	if err != nil {
+		return nil, fmt.Errorf("Error getting QueryType from passed array %s", err)
+	}
+
+	query := Query{context: ctx, array: array}
+	ret := C.tiledb_query_alloc(query.context.tiledbContext, array.tiledbArray, C.tiledb_query_type_t(queryType), &query.tiledbQuery)
+	if ret != C.TILEDB_OK {
+		return nil, fmt.Errorf("Error creating tiledb query: %s", query.context.GetLastError())
+	}
+
+	// Set finalizer for free C pointer on gc
+	runtime.SetFinalizer(&query, func(query *Query) {
+		query.Free()
+	})
+
+	return &query, nil
+}
+
+// Free tiledb_query_t that was allocated on heap in c
+func (q *Query) Free() {
+	if q.tiledbQuery != nil {
+		C.tiledb_query_free(&q.tiledbQuery)
+	}
+}
+
+// SetSubArray indicates that the query will write or read a subarray, and provides the appropriate information.
+func (q *Query) SetSubArray(subArray interface{}) error {
+
+	if reflect.TypeOf(subArray).Kind() != reflect.Slice {
+		return fmt.Errorf("Subarray passed must be a slice, type passed was: %s", reflect.TypeOf(subArray).Kind().String())
+	}
+
+	subArrayType := reflect.TypeOf(subArray).Elem().Kind()
+
+	schema, err := q.array.Schema()
+	if err != nil {
+		return fmt.Errorf("Could not get array schema from query array: %s", err)
+	}
+
+	domain, err := schema.Domain()
+	if err != nil {
+		return fmt.Errorf("Could not get domain from array schema: %s", err)
+	}
+
+	domainType, err := domain.Type()
+	if err != nil {
+		return fmt.Errorf("Could not get domain type: %s", err)
+	}
+
+	if subArrayType != domainType.ReflectKind() {
+		return fmt.Errorf("Domain and subarray do not have the same data types. Domain: %s, Extent: %s", domainType.ReflectKind().String(), subArrayType.String())
+	}
+
+	var csubArray unsafe.Pointer
+	switch subArrayType {
+	case reflect.Int:
+		// Create subArray void*
+		tmpSubArray := subArray.([]int)
+		csubArray = unsafe.Pointer(&tmpSubArray[0])
+	case reflect.Int8:
+		// Create subArray void*
+		tmpSubArray := subArray.([]int8)
+		csubArray = unsafe.Pointer(&tmpSubArray[0])
+	case reflect.Int16:
+		// Create subArray void*
+		tmpSubArray := subArray.([]int16)
+		csubArray = unsafe.Pointer(&tmpSubArray[0])
+	case reflect.Int32:
+		// Create subArray void*
+		tmpSubArray := subArray.([]int32)
+		csubArray = unsafe.Pointer(&tmpSubArray[0])
+	case reflect.Int64:
+		// Create subArray void*
+		tmpSubArray := subArray.([]int64)
+		csubArray = unsafe.Pointer(&tmpSubArray[0])
+	case reflect.Uint:
+		// Create subArray void*
+		tmpSubArray := subArray.([]uint)
+		csubArray = unsafe.Pointer(&tmpSubArray[0])
+	case reflect.Uint8:
+		// Create subArray void*
+		tmpSubArray := subArray.([]uint8)
+		csubArray = unsafe.Pointer(&tmpSubArray[0])
+	case reflect.Uint16:
+		// Create subArray void*
+		tmpSubArray := subArray.([]uint16)
+		csubArray = unsafe.Pointer(&tmpSubArray[0])
+	case reflect.Uint32:
+		// Create subArray void*
+		tmpSubArray := subArray.([]uint32)
+		csubArray = unsafe.Pointer(&tmpSubArray[0])
+	case reflect.Uint64:
+		// Create subArray void*
+		tmpSubArray := subArray.([]uint64)
+		csubArray = unsafe.Pointer(&tmpSubArray[0])
+	case reflect.Float32:
+		// Create subArray void*
+		tmpSubArray := subArray.([]float32)
+		csubArray = unsafe.Pointer(&tmpSubArray[0])
+	case reflect.Float64:
+		// Create subArray void*
+		tmpSubArray := subArray.([]float64)
+		csubArray = unsafe.Pointer(&tmpSubArray[0])
+	default:
+		return fmt.Errorf("Unrecognized subArray type passed: %s", subArrayType.String())
+	}
+
+	ret := C.tiledb_query_set_subarray(q.context.tiledbContext, q.tiledbQuery, csubArray)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error setting query subarray: %s", q.context.GetLastError())
+	}
+	return nil
+}
+
+// SetBuffer Sets the buffer for a fixed-sized attribute to a query
+// The buffer must be an array and not a slice
+func (q *Query) SetBuffer(attribute string, buffer interface{}) error {
+	bufferReflectType := reflect.TypeOf(buffer)
+	bufferReflectValue := reflect.ValueOf(buffer)
+	if bufferReflectValue.Kind() != reflect.Slice {
+		return fmt.Errorf("Buffer passed must be a slice that is pre-allocated, type passed was: %s", bufferReflectValue.Kind().String())
+	}
+
+	// Next get the attribute to validate the buffer type is the same as the attribute
+	schema, err := q.array.Schema()
+	if err != nil {
+		return fmt.Errorf("Could not get array schema for SetBuffer: %s", err)
+	}
+
+	schemaAttribute, err := schema.AttributeFromName(attribute)
+	if err != nil {
+		return fmt.Errorf("Could not get attribute for SetBuffer: %s", attribute)
+	}
+
+	attributeType, err := schemaAttribute.Type()
+	if err != nil {
+		return fmt.Errorf("Could not get attributeType for SetBuffer: %s", attribute)
+	}
+
+	bufferType := bufferReflectType.Elem().Kind()
+	if attributeType.ReflectKind() != bufferType {
+		return fmt.Errorf("Buffer and Attribute do not have the same data types. Buffer: %s, Attribute: %s", bufferType.String(), attributeType.ReflectKind().String())
+	}
+
+	var cbuffer unsafe.Pointer
+	// Get length of slice, this will be multiplied by size of datatype below
+	cbufferSize := C.uint64_t(uint64(bufferReflectValue.Len()))
+
+	if cbufferSize == C.uint64_t(0) {
+		return fmt.Errorf("Buffer has no length, buffers are required to be initialized before reading or writting")
+	}
+
+	// Acquire a lock to make appending to buffer slice thread safe
+	q.bufferMutex.Lock()
+	defer q.bufferMutex.Unlock()
+
+	switch bufferType {
+	case reflect.Int:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(int(0)))
+		// Create buffer void*
+		tmpBuffer := buffer.([]int)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Int8:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(int8(0)))
+		// Create buffer void*
+		tmpBuffer := buffer.([]int8)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Int16:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(int16(0)))
+		// Create buffer void*
+		tmpBuffer := buffer.([]int16)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Int32:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(int32(0)))
+		// Create buffer void*
+		tmpBuffer := buffer.([]int32)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Int64:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(int64(0)))
+		// Create buffer void*
+		tmpBuffer := buffer.([]int64)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Uint:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(uint(0)))
+		// Create buffer void*
+		tmpBuffer := buffer.([]uint)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Uint8:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(uint8(0)))
+		// Create buffer void*
+		tmpBuffer := buffer.([]uint8)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Uint16:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(uint16(0)))
+		// Create buffer void*
+		tmpBuffer := buffer.([]uint16)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Uint32:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(uint32(0)))
+		// Create buffer void*
+		tmpBuffer := buffer.([]uint32)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Uint64:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(uint64(0)))
+		// Create buffer void*
+		tmpBuffer := buffer.([]uint64)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Float32:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(float32(0)))
+		// Create buffer void*
+		tmpBuffer := buffer.([]float32)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Float64:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(float64(0)))
+		// Create buffer void*
+		tmpBuffer := buffer.([]float64)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	default:
+		return fmt.Errorf("Unrecognized buffer type passed: %s", bufferType.String())
+	}
+
+	cAttribute := C.CString(attribute)
+	defer C.free(unsafe.Pointer(cAttribute))
+	ret := C.tiledb_query_set_buffer(q.context.tiledbContext, q.tiledbQuery, cAttribute, cbuffer, &cbufferSize)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error setting query buffer: %s", q.context.GetLastError())
+	}
+	return nil
+}
+
+// SetBufferVar Sets the buffer for a fixed-sized attribute to a query
+// The buffer must be an array and not a slice
+func (q *Query) SetBufferVar(attribute string, offset []uint64, buffer interface{}) error {
+	bufferReflectType := reflect.TypeOf(buffer)
+	bufferReflectValue := reflect.ValueOf(buffer)
+	if bufferReflectValue.Kind() != reflect.Slice {
+		return fmt.Errorf("Buffer passed must be a slice that is pre-allocated, type passed was: %s", bufferReflectValue.Kind().String())
+	}
+
+	// Next get the attribute to validate the buffer type is the same as the attribute
+	schema, err := q.array.Schema()
+	if err != nil {
+		return fmt.Errorf("Could not get array schema for SetBuffer: %s", err)
+	}
+
+	schemaAttribute, err := schema.AttributeFromName(attribute)
+	if err != nil {
+		return fmt.Errorf("Could not get attribute for SetBuffer: %s", attribute)
+	}
+
+	attributeType, err := schemaAttribute.Type()
+	if err != nil {
+		return fmt.Errorf("Could not get attributeType for SetBuffer: %s", attribute)
+	}
+
+	bufferType := bufferReflectType.Elem().Kind()
+	if attributeType.ReflectKind() != bufferType {
+		return fmt.Errorf("Buffer and Attribute do not have the same data types. Buffer: %s, Attribute: %s", bufferType.String(), attributeType.ReflectKind().String())
+	}
+
+	cbufferSize := C.uint64_t(uint64(bufferReflectValue.Len()))
+
+	if cbufferSize == C.uint64_t(0) {
+		return fmt.Errorf("Buffer has no length, buffers are required to be initialized before reading or writting")
+	}
+
+	coffsetSize := C.uint64_t(uint64(len(offset)) * uint64(unsafe.Sizeof(uint64(0))))
+
+	if coffsetSize == C.uint64_t(0) {
+		return fmt.Errorf("Offset slice has no length, offset slices are required to be initialized before reading or writting")
+	}
+
+	// Acquire a lock to make appending to buffer slice thread safe
+	q.bufferMutex.Lock()
+	defer q.bufferMutex.Unlock()
+
+	// Store offset so array does not get gc'ed
+	q.buffers = append(q.buffers, offset)
+
+	// Set offset and buffer
+	var cbuffer unsafe.Pointer
+	coffset := unsafe.Pointer(&(offset)[0])
+	switch bufferType {
+	case reflect.Int:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(int(0)))
+
+		// Create buffer void*
+		tmpBuffer := buffer.([]int)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Int8:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(int8(0)))
+
+		// Create buffer void*
+		tmpBuffer := buffer.([]int8)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Int16:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(int16(0)))
+
+		// Create buffer void*
+		tmpBuffer := buffer.([]int16)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Int32:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(int32(0)))
+
+		// Create buffer void*
+		tmpBuffer := buffer.([]int32)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Int64:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(int64(0)))
+
+		// Create buffer void*
+		tmpBuffer := buffer.([]int64)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Uint:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(uint(0)))
+
+		// Create buffer void*
+		tmpBuffer := buffer.([]uint)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Uint8:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(uint8(0)))
+
+		// Create buffer void*
+		tmpBuffer := buffer.([]uint8)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Uint16:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(uint16(0)))
+
+		// Create buffer void*
+		tmpBuffer := buffer.([]uint16)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Uint32:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(uint32(0)))
+
+		// Create buffer void*
+		tmpBuffer := buffer.([]uint32)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Uint64:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(uint64(0)))
+
+		// Create buffer void*
+		tmpBuffer := buffer.([]uint64)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Float32:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(float32(0)))
+
+		// Create buffer void*
+		tmpBuffer := buffer.([]float32)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	case reflect.Float64:
+		// Set buffersize
+		cbufferSize = cbufferSize * C.uint64_t(unsafe.Sizeof(float64(0)))
+
+		// Create buffer void*
+		tmpBuffer := buffer.([]float64)
+		// Store slice so underlying array is not gc'ed
+		q.buffers = append(q.buffers, tmpBuffer)
+		cbuffer = unsafe.Pointer(&(tmpBuffer)[0])
+	default:
+		return fmt.Errorf("Unrecognized buffer type passed: %s", bufferType.String())
+	}
+
+	cAttribute := C.CString(attribute)
+	defer C.free(unsafe.Pointer(cAttribute))
+	ret := C.tiledb_query_set_buffer_var(q.context.tiledbContext, q.tiledbQuery, cAttribute, (*C.uint64_t)(coffset), &coffsetSize, cbuffer, &cbufferSize)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error setting query var buffer: %s", q.context.GetLastError())
+	}
+	return nil
+}
+
+// SetLayout sets the layout of the cells to be written or read
+func (q *Query) SetLayout(layout Layout) error {
+	ret := C.tiledb_query_set_layout(q.context.tiledbContext, q.tiledbQuery, C.tiledb_layout_t(layout))
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error setting query layout: %s", q.context.GetLastError())
+	}
+	return nil
+}
+
+// Finalize flushes a query
+func (q *Query) Finalize() error {
+	ret := C.tiledb_query_finalize(q.context.tiledbContext, q.tiledbQuery)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error finalizing query: %s", q.context.GetLastError())
+	}
+	q.bufferMutex.Lock()
+	defer q.bufferMutex.Unlock()
+	q.buffers = nil
+	return nil
+}
+
+// Submit a TileDB query
+// This will block until query is completed
+func (q *Query) Submit() error {
+	ret := C.tiledb_query_submit(q.context.tiledbContext, q.tiledbQuery)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error submitting query: %s", q.context.GetLastError())
+	}
+	return nil
+}
+
+// SubmitAsync a TileDB query
+// Async does not currently support the callback function parameter
+func (q *Query) SubmitAsync() error {
+	ret := C.tiledb_query_submit_async(q.context.tiledbContext, q.tiledbQuery, nil, nil)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error submitting query: %s", q.context.GetLastError())
+	}
+	return nil
+}
+
+// Status returns the status of a query
+func (q *Query) Status() (QueryStatus, error) {
+	var status C.tiledb_query_status_t
+	ret := C.tiledb_query_get_status(q.context.tiledbContext, q.tiledbQuery, &status)
+	if ret != C.TILEDB_OK {
+		return -1, fmt.Errorf("Error getting query status: %s", q.context.GetLastError())
+	}
+	return QueryStatus(status), nil
+}
+
+// Type returns the query type
+func (q *Query) Type() (QueryType, error) {
+	var queryType C.tiledb_query_type_t
+	ret := C.tiledb_query_get_type(q.context.tiledbContext, q.tiledbQuery, &queryType)
+	if ret != C.TILEDB_OK {
+		return -1, fmt.Errorf("Error getting query type: %s", q.context.GetLastError())
+	}
+	return QueryType(queryType), nil
+}
+
+// HasResults Checks if the query has returned any results.
+func (q *Query) HasResults() (bool, error) {
+	var hasResults C.int
+	ret := C.tiledb_query_has_results(q.context.tiledbContext, q.tiledbQuery, &hasResults)
+	if ret != C.TILEDB_OK {
+		return false, fmt.Errorf("Error checking if query has results: %s", q.context.GetLastError())
+	}
+	return int(hasResults) == 1, nil
+}

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,670 @@
+package tiledb
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ExampleNewQuery shows a complete write and read example
+func ExampleNewQuery() {
+	// Create configuration
+	config, err := NewConfig()
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Test context with config
+	context, err := NewContext(config)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Test create dimension
+	dimension, err := NewDimension(context, "dim1", []int8{0, 9}, int8(10))
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Test creating domain
+	domain, err := NewDomain(context)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Add dimension
+	err = domain.AddDimension(*dimension)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Create array schema
+	arraySchema, err := NewArraySchema(context, TILEDB_DENSE)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Crete attribute to add to schema
+	attribute, err := NewAttribute(context, "a1", TILEDB_INT32)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Crete attribute to add to schema
+	attribute2, err := NewAttribute(context, "a2", TILEDB_STRING_ASCII)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Crete attribute to add to schema
+	attribute3, err := NewAttribute(context, "a3", TILEDB_FLOAT32)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Crete attribute to add to schema
+	attribute4, err := NewAttribute(context, "a4", TILEDB_STRING_UTF8)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Set a3 to be variable length
+	err = attribute3.SetCellValNum(TILEDB_VAR_NUM)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Set a4 to be variable length
+	err = attribute4.SetCellValNum(TILEDB_VAR_NUM)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Add Attribute
+	err = arraySchema.AddAttributes(*attribute, *attribute2, *attribute3, *attribute4)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Set Domain
+	err = arraySchema.SetDomain(domain)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Validate Schema
+	err = arraySchema.Check()
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// create temp array name and path
+	// normal usage would be "my_array" uri
+	// Temp path is used here so unit test can clean up after itself
+	tmpArrayPath := os.TempDir() + string(os.PathSeparator) + "tiledb_test_array"
+	// Cleanup group when test ends
+	defer os.RemoveAll(tmpArrayPath)
+	if _, err = os.Stat(tmpArrayPath); err == nil {
+		os.RemoveAll(tmpArrayPath)
+	}
+	// Create new array struct
+	array, err := NewArray(context, tmpArrayPath)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Create array on disk
+	err = array.Create(arraySchema)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Open array for writting
+	err = array.Open(TILEDB_WRITE)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Create write query
+	query, err := NewQuery(context, array)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Limit writting to subarray
+	err = query.SetSubArray([]int8{0, 1})
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Set write layout
+	err = query.SetLayout(TILEDB_ROW_MAJOR)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Create write buffers
+	bufferA1 := []int32{1, 2}
+	err = query.SetBuffer("a1", bufferA1)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	bufferA2 := []byte("ab")
+	err = query.SetBuffer("a2", bufferA2)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	bufferA3 := []float32{1.0, 2.0, 3.0, 4.0, 5.0}
+	offsetBufferA3 := []uint64{0, 3}
+	err = query.SetBufferVar("a3", offsetBufferA3, bufferA3)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	bufferA4 := []byte("hello" + "world")
+	offsetBufferA4 := []uint64{0, 5}
+	err = query.SetBufferVar("a4", offsetBufferA4, bufferA4)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	err = query.Submit()
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Validate status, since query was used this is should be complete
+	status, err := query.Status()
+	if err != nil {
+		// Handle error
+		return
+	}
+	if status != TILEDB_COMPLETED {
+		// handle non-complete query
+		// If applicable read partial data in buffer
+		// and re-submit for remaining results
+	}
+
+	// Finalize Write
+	err = query.Finalize()
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Close and prepare to read
+	err = array.Close()
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Reopen array for reading
+	err = array.Open(TILEDB_READ)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Create query for reading
+	query, err = NewQuery(context, array)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Set read subarray to only data that was written
+	err = query.SetSubArray([]int8{0, 1})
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Set empty buffers for reading
+	readBufferA1 := make([]int32, 2)
+	err = query.SetBuffer("a1", readBufferA1)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	readBufferA2 := make([]byte, 2)
+	err = query.SetBuffer("a2", readBufferA2)
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	readBufferA3 := make([]float32, 5)
+	readOffsetBufferA3 := make([]uint64, 2)
+	err = query.SetBufferVar("a3", readOffsetBufferA3, readBufferA3)
+	if err != nil {
+		// Handle error
+		return
+	}
+	readBufferA4 := make([]byte, 10)
+	readOffsetBufferA4 := make([]uint64, 2)
+	err = query.SetBufferVar("a4", readOffsetBufferA4, readBufferA4)
+	if err != nil {
+		// Handle error
+		return
+	}
+	// Set read layout
+	err = query.SetLayout(TILEDB_ROW_MAJOR)
+	if err != nil {
+		// Handle error
+		return
+	}
+	// Submit read query async
+	// Async submits do not block
+	err = query.SubmitAsync()
+	if err != nil {
+		// Handle error
+		return
+	}
+	// Wait for status to return complete or to error
+	// Loop while status is inprogress
+	for status, err = query.Status(); status == TILEDB_INPROGRESS && err == nil; status, err = query.Status() {
+		// Do something while query is running
+	}
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	// Results should be returned
+	hasResults, err := query.HasResults()
+	if err != nil {
+		// Handle error
+		return
+	}
+	if hasResults {
+		// Do something with read buffer
+	}
+
+}
+
+// TestQueryReadEmpty validates an empty array can be read from without error
+func TestQueryReadEmpty(t *testing.T) {
+	// Create configuration
+	config, err := NewConfig()
+	assert.Nil(t, err)
+
+	// Test context with config
+	context, err := NewContext(config)
+	assert.Nil(t, err)
+
+	// Test create dimension
+	dimension, err := NewDimension(context, "dim1", []int8{1, 10}, int8(5))
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+
+	// Test creating domain
+	domain, err := NewDomain(context)
+	assert.Nil(t, err)
+	assert.NotNil(t, domain)
+
+	// Add dimension
+	err = domain.AddDimension(*dimension)
+	assert.Nil(t, err)
+
+	// Create array schema
+	arraySchema, err := NewArraySchema(context, TILEDB_DENSE)
+	assert.Nil(t, err)
+	assert.NotNil(t, arraySchema)
+
+	// Crete attribute to add to schema
+	attribute, err := NewAttribute(context, "a1", TILEDB_INT32)
+	assert.Nil(t, err)
+	assert.NotNil(t, attribute)
+
+	// Crete attribute to add to schema
+	attribute2, err := NewAttribute(context, "a2", TILEDB_STRING_ASCII)
+	assert.Nil(t, err)
+	assert.NotNil(t, attribute2)
+
+	// Crete attribute to add to schema
+	attribute3, err := NewAttribute(context, "a3", TILEDB_FLOAT32)
+	assert.Nil(t, err)
+	assert.NotNil(t, attribute3)
+
+	// Crete attribute to add to schema
+	attribute4, err := NewAttribute(context, "a4", TILEDB_STRING_UTF8)
+	assert.Nil(t, err)
+	assert.NotNil(t, attribute4)
+
+	// Set a3 to be variable length
+	err = attribute3.SetCellValNum(TILEDB_VAR_NUM)
+	assert.Nil(t, err)
+
+	// Set a4 to be variable length
+	err = attribute4.SetCellValNum(TILEDB_VAR_NUM)
+	assert.Nil(t, err)
+
+	// Add Attribute
+	err = arraySchema.AddAttributes(*attribute, *attribute2, *attribute3, *attribute4)
+	assert.Nil(t, err)
+
+	// Set Domain
+	err = arraySchema.SetDomain(domain)
+	assert.Nil(t, err)
+
+	// create temp group name
+	tmpArrayPath := os.TempDir() + string(os.PathSeparator) + "tiledb_test_array"
+	// Cleanup group when test ends
+	defer os.RemoveAll(tmpArrayPath)
+	if _, err = os.Stat(tmpArrayPath); err == nil {
+		os.RemoveAll(tmpArrayPath)
+	}
+	// Create new array struct
+	array, err := NewArray(context, tmpArrayPath)
+	assert.Nil(t, err)
+	assert.NotNil(t, array)
+
+	// Create array on disk
+	err = array.Create(arraySchema)
+	assert.Nil(t, err)
+
+	// Open array for reading
+	err = array.Open(TILEDB_READ)
+	assert.Nil(t, err)
+
+	// Create Query
+	query, err := NewQuery(context, array)
+	assert.Nil(t, err)
+	assert.NotNil(t, query)
+
+	// Limit reading to subArray
+	err = query.SetSubArray([]int8{2, 4})
+	assert.Nil(t, err)
+
+	// Set buffer to incorrect type, should err
+	bufferA1Bad := make([]int8, 2)
+	err = query.SetBuffer("a1", bufferA1Bad)
+	assert.NotNil(t, err)
+
+	// Create read buffers
+	bufferA1 := make([]int32, 2)
+	err = query.SetBuffer("a1", bufferA1)
+	assert.Nil(t, err)
+
+	bufferA2 := make([]byte, 2)
+	err = query.SetBuffer("a2", bufferA2)
+	assert.Nil(t, err)
+
+	bufferA3 := make([]float32, 5)
+	offsetBufferA3 := make([]uint64, 3)
+	err = query.SetBufferVar("a3", offsetBufferA3, bufferA3)
+	assert.Nil(t, err)
+
+	bufferA4 := make([]byte, 4)
+	offsetBufferA4 := make([]uint64, 4)
+	err = query.SetBufferVar("a4", offsetBufferA4, bufferA4)
+	assert.Nil(t, err)
+
+	// Set read layout
+	assert.Nil(t, query.SetLayout(TILEDB_ROW_MAJOR))
+
+	// Submit query
+	assert.Nil(t, query.Submit())
+
+	// Validate status, since query was used this is should be complete
+	status, err := query.Status()
+	assert.Nil(t, err)
+	assert.Equal(t, TILEDB_COMPLETED, status)
+
+	// Validate query type
+	queryType, err := query.Type()
+	assert.Nil(t, err)
+	assert.Equal(t, TILEDB_READ, queryType)
+
+	// No results because query it empty
+	hasResults, err := query.HasResults()
+	assert.Nil(t, err)
+	assert.Equal(t, false, hasResults)
+
+}
+
+// TestQueryWrite validates a array can be written to and read from
+func TestQueryWrite(t *testing.T) {
+	// Create configuration
+	config, err := NewConfig()
+	assert.Nil(t, err)
+
+	// Test context with config
+	context, err := NewContext(config)
+	assert.Nil(t, err)
+
+	// Test create dimension
+	dimension, err := NewDimension(context, "dim1", []int8{0, 9}, int8(10))
+	assert.Nil(t, err)
+	assert.NotNil(t, dimension)
+
+	// Test creating domain
+	domain, err := NewDomain(context)
+	assert.Nil(t, err)
+	assert.NotNil(t, domain)
+
+	// Add dimension
+	err = domain.AddDimension(*dimension)
+	assert.Nil(t, err)
+
+	// Create array schema
+	arraySchema, err := NewArraySchema(context, TILEDB_DENSE)
+	assert.Nil(t, err)
+	assert.NotNil(t, arraySchema)
+
+	// Crete attribute to add to schema
+	attribute, err := NewAttribute(context, "a1", TILEDB_INT32)
+	assert.Nil(t, err)
+	assert.NotNil(t, attribute)
+
+	// Crete attribute to add to schema
+	attribute2, err := NewAttribute(context, "a2", TILEDB_STRING_ASCII)
+	assert.Nil(t, err)
+	assert.NotNil(t, attribute2)
+
+	// Crete attribute to add to schema
+	attribute3, err := NewAttribute(context, "a3", TILEDB_FLOAT32)
+	assert.Nil(t, err)
+	assert.NotNil(t, attribute3)
+
+	// Crete attribute to add to schema
+	attribute4, err := NewAttribute(context, "a4", TILEDB_STRING_UTF8)
+	assert.Nil(t, err)
+	assert.NotNil(t, attribute4)
+
+	// Set a3 to be variable length
+	err = attribute3.SetCellValNum(TILEDB_VAR_NUM)
+	assert.Nil(t, err)
+
+	// Set a4 to be variable length
+	err = attribute4.SetCellValNum(TILEDB_VAR_NUM)
+	assert.Nil(t, err)
+
+	// Add Attribute
+	err = arraySchema.AddAttributes(*attribute, *attribute2, *attribute3, *attribute4)
+	assert.Nil(t, err)
+
+	// Set Domain
+	err = arraySchema.SetDomain(domain)
+	assert.Nil(t, err)
+
+	// Validate Schema
+	err = arraySchema.Check()
+	assert.Nil(t, err)
+
+	// create temp group name
+	tmpArrayPath := os.TempDir() + string(os.PathSeparator) + "tiledb_test_array"
+	// Cleanup group when test ends
+	defer os.RemoveAll(tmpArrayPath)
+	if _, err = os.Stat(tmpArrayPath); err == nil {
+		os.RemoveAll(tmpArrayPath)
+	}
+	// Create new array struct
+	array, err := NewArray(context, tmpArrayPath)
+	assert.Nil(t, err)
+	assert.NotNil(t, array)
+
+	// Create array on disk
+	err = array.Create(arraySchema)
+	assert.Nil(t, err)
+
+	// Open array for writting
+	err = array.Open(TILEDB_WRITE)
+	assert.Nil(t, err)
+
+	// Create write query
+	query, err := NewQuery(context, array)
+	assert.Nil(t, err)
+	assert.NotNil(t, query)
+
+	// Limit writting to subarray
+	err = query.SetSubArray([]int8{0, 1})
+	assert.Nil(t, err)
+
+	// Set write layout
+	assert.Nil(t, query.SetLayout(TILEDB_ROW_MAJOR))
+
+	// Create write buffers
+	bufferA1 := []int32{1, 2}
+	err = query.SetBuffer("a1", bufferA1)
+	assert.Nil(t, err)
+
+	bufferA2 := []byte("ab")
+	err = query.SetBuffer("a2", bufferA2)
+	assert.Nil(t, err)
+
+	bufferA3 := []float32{1.0, 2.0, 3.0, 4.0, 5.0}
+	offsetBufferA3 := []uint64{0, 3}
+	err = query.SetBufferVar("a3", offsetBufferA3, bufferA3)
+	assert.Nil(t, err)
+
+	bufferA4 := []byte("hello" + "world")
+	offsetBufferA4 := []uint64{0, 5}
+	// Second byte array so we can compare reads
+	bufferA4Comparison := make([]byte, len(bufferA4))
+	elementsCopied := copy(bufferA4Comparison, bufferA4)
+	assert.Equal(t, len(bufferA4), elementsCopied)
+
+	err = query.SetBufferVar("a4", offsetBufferA4, bufferA4)
+	// Immediately set bufferA4 to nil to validate underlying array is not GC'ed
+	bufferA4 = nil
+	assert.Nil(t, err)
+
+	// Submit write query
+	err = query.Submit()
+	assert.Nil(t, err)
+
+	// Validate status, since query was used this is should be complete
+	status, err := query.Status()
+	assert.Nil(t, err)
+	assert.Equal(t, TILEDB_COMPLETED, status)
+
+	// Validate query type
+	queryType, err := query.Type()
+	assert.Nil(t, err)
+	assert.Equal(t, TILEDB_WRITE, queryType)
+
+	// Finalize Write
+	err = query.Finalize()
+	assert.Nil(t, err)
+	// Close and prepare to read
+	err = array.Close()
+	assert.Nil(t, err)
+
+	// Reopen array for reading
+	err = array.Open(TILEDB_READ)
+	assert.Nil(t, err)
+
+	query, err = NewQuery(context, array)
+	assert.Nil(t, err)
+	assert.NotNil(t, query)
+
+	// Set read subarray to only data that was written
+	err = query.SetSubArray([]int8{0, 1})
+	assert.Nil(t, err)
+
+	// Set empty buffers for reading
+	readBufferA1 := make([]int32, 2)
+	err = query.SetBuffer("a1", readBufferA1)
+	assert.Nil(t, err)
+
+	readBufferA2 := make([]byte, 2)
+	err = query.SetBuffer("a2", readBufferA2)
+	assert.Nil(t, err)
+
+	readBufferA3 := make([]float32, 5)
+	readOffsetBufferA3 := make([]uint64, 2)
+	err = query.SetBufferVar("a3", readOffsetBufferA3, readBufferA3)
+	assert.Nil(t, err)
+
+	readBufferA4 := make([]byte, 10)
+	readOffsetBufferA4 := make([]uint64, 2)
+	err = query.SetBufferVar("a4", readOffsetBufferA4, readBufferA4)
+	assert.Nil(t, err)
+
+	// Set read layout
+	err = query.SetLayout(TILEDB_ROW_MAJOR)
+	assert.Nil(t, err)
+
+	// Submit read query async
+	err = query.SubmitAsync()
+	assert.Nil(t, err)
+
+	// Wait for status to return complete or to error
+	// Loop while status is inprogress
+	for status, err = query.Status(); status == TILEDB_INPROGRESS && err == nil; status, err = query.Status() {
+		assert.Nil(t, err)
+		assert.Equal(t, TILEDB_INPROGRESS, status)
+	}
+	assert.Nil(t, err)
+	assert.Equal(t, TILEDB_COMPLETED, status)
+
+	// Validate query type
+	queryType, err = query.Type()
+	assert.Nil(t, err)
+	assert.Equal(t, TILEDB_READ, queryType)
+
+	// Results should be returned
+	hasResults, err := query.HasResults()
+	assert.Nil(t, err)
+	assert.Equal(t, true, hasResults)
+
+	// Validate read buffers equal original write buffers
+	assert.EqualValues(t, bufferA1, readBufferA1)
+	assert.EqualValues(t, bufferA2, readBufferA2)
+	assert.EqualValues(t, bufferA3, readBufferA3)
+	assert.EqualValues(t, bufferA4Comparison, readBufferA4)
+
+	query.Free()
+}


### PR DESCRIPTION
This add support for querying. A full example is given for the docs for NewQuery showing how to create and use an array with fixed and variable attributes.

Current limitations:
- SubmitAsync does not support a call back function. Support could be added for passing a void* in but this will require the end user to write a cgo function themselves. A good example is in the [cgo wiki article](https://github.com/golang/go/wiki/cgo#function-pointer-callbacks). I believe we'd need to document this and provide examples for users, so for now I've left off support.
  - An alternative to use the callback from the c api is we could start a goroutine that polls the status and calls a user pass function when status is complete. This is simplier to an end user, but it would be nice to keep the functionality in the c api instead of reproducing it.
- Encoding/Decoding utf-16/utf-32/ucs-2/ucs-4 is left to a user, the SetBuffers will expect only uint16/32 array. At somepoint it'd be nice to handle the encoding/decoding for the user
- Same goes for strings (utf-8/ascii), a []byte (uint8) array is expected, it'd be nice to convert to/from go string for a user if they pass that as the buffer.

Closes #9 