### PR TITLE
Add tiledb stats bindings

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,78 @@
+package tiledb
+
+/*
+#cgo LDFLAGS: -ltiledb
+#include <tiledb/tiledb.h>
+#include <stdio.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+)
+
+// StatsEnable enable internal statistics gathering
+func StatsEnable() error {
+	ret := C.tiledb_stats_enable()
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error enabling stats")
+	}
+	return nil
+}
+
+// StatsDisable disable internal statistics gathering.
+func StatsDisable() error {
+	ret := C.tiledb_stats_disable()
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error disabling stats")
+	}
+	return nil
+}
+
+// StatsReset reset all internal statistics counters to 0.
+func StatsReset() error {
+	ret := C.tiledb_stats_reset()
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error resetting stats")
+	}
+	return nil
+}
+
+// StatsDumpSTDOUT prints internal stats to stdout
+func StatsDumpSTDOUT() error {
+	ret := C.tiledb_stats_dump(C.stdout)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error dumping stats to stdout")
+	}
+	return nil
+}
+
+// StatsDump prints internal stats to file path given
+func StatsDump(path string) error {
+
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("Error path already %s exists", path)
+	}
+
+	// Convert to char *
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	// Set mode as char*
+	cMode := C.CString("w")
+	defer C.free(unsafe.Pointer(cMode))
+
+	// Open file to get FILE*
+	cFile := C.fopen(cPath, cMode)
+	defer C.fclose(cFile)
+
+	// Dump stats to file
+	ret := C.tiledb_stats_dump(cFile)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error dumping stats to file %s", path)
+	}
+	return nil
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,0 +1,62 @@
+package tiledb
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Example usage of tiledb statistics
+func ExampleStatsEnable() {
+
+	err := StatsEnable()
+	if err != nil {
+		// Handle error
+	}
+
+	// Perform tile operations
+	err = StatsDumpSTDOUT()
+	if err != nil {
+		// Handle error
+	}
+}
+
+// Test statistics
+func TestStats(t *testing.T) {
+	// Enable statistics
+	err := StatsEnable()
+	assert.Nil(t, err)
+
+	// Reset all internal counters to 0
+	err = StatsReset()
+	assert.Nil(t, err)
+
+	// Dump statistics to stdout
+	err = StatsDumpSTDOUT()
+	assert.Nil(t, err)
+
+	tmpPath := os.TempDir() + string(os.PathSeparator) + "tiledb_stats_test"
+	// Cleanup group when test ends
+	defer os.RemoveAll(tmpPath)
+	if _, err = os.Stat(tmpPath); err == nil {
+		os.RemoveAll(tmpPath)
+	}
+
+	// Dump statistics to file
+	err = StatsDump(tmpPath)
+	assert.Nil(t, err)
+
+	// Validate dumped file is non-empty
+	fileInfo, err := os.Stat(tmpPath)
+	assert.Nil(t, err)
+	assert.NotZero(t, fileInfo.Size())
+
+	// Dump statistics to existing file should error
+	err = StatsDump(tmpPath)
+	assert.NotNil(t, err)
+
+	// Disable statistics
+	err = StatsDisable()
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
Add tiledb stats bindings including dump support to a given filepath and to stdout.

Closes #12