### PR TITLE
Make URI public in array struct

### DIFF
--- a/array.go
+++ b/array.go
@@ -661,3 +661,15 @@ func (a *Array) MaxBufferElements(subarray interface{}) (map[string][2]uint64, e
 
 	return ret, nil
 }
+
+// URI returns the array's uri
+func (a *Array) URI() (string, error) {
+	var curi *C.char
+	defer C.free(unsafe.Pointer(curi))
+	C.tiledb_array_get_uri(a.context.tiledbContext, a.tiledbArray, &curi)
+	uri := C.GoString(curi)
+	if uri == "" {
+		return uri, fmt.Errorf("Error getting URI for array: uri is empty")
+	}
+	return uri, nil
+}

--- a/array_test.go
+++ b/array_test.go
@@ -2,6 +2,7 @@ package tiledb
 
 import (
 	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -131,7 +132,7 @@ func TestArray(t *testing.T) {
 	assert.Nil(t, err)
 
 	// create temp group name
-	tmpArrayPath := os.TempDir() + string(os.PathSeparator) + "tiledb_test_array"
+	tmpArrayPath := path.Join(os.TempDir(), "tiledb_test_array")
 	// Cleanup group when test ends
 	defer os.RemoveAll(tmpArrayPath)
 	if _, err = os.Stat(tmpArrayPath); err == nil {
@@ -147,6 +148,11 @@ func TestArray(t *testing.T) {
 	// Create array on disk
 	err = array.Create(arraySchema)
 	assert.Nil(t, err)
+
+	// Get array URI
+	uri, err := array.URI()
+	assert.Nil(t, err)
+	assert.Equal(t, "file://"+tmpArrayPath, uri)
 
 	//err = array.Consolidate()
 	//assert.Nil(t, err)
@@ -221,7 +227,7 @@ func TestArrayEncryption(t *testing.T) {
 	assert.Nil(t, err)
 
 	// create temp group name
-	tmpArrayPath := os.TempDir() + string(os.PathSeparator) + "tiledb_test_array"
+	tmpArrayPath := path.Join(os.TempDir(), "tiledb_test_array")
 	// Cleanup group when test ends
 	defer os.RemoveAll(tmpArrayPath)
 	if _, err = os.Stat(tmpArrayPath); err == nil {


### PR DESCRIPTION
Make URI public in array struct. This is helpful to users because after an array is created or loaded there currently is no way to get the URI from the Array Struct itself.



Closes #27