### PR TITLE
SparseArray example does not work

### DIFF
--- a/array.go
+++ b/array.go
@@ -662,6 +662,22 @@ func (a *Array) MaxBufferElements(subarray interface{}) (map[string][2]uint64, e
 		}
 	}
 
+	// Handle coordinates
+	domain, err := schema.Domain()
+	if err != nil {
+		return nil, fmt.Errorf("Could not get domain for MaxBufferElements: %s", err)
+	}
+	domainType, err := domain.Type()
+	if err != nil {
+		return nil, fmt.Errorf("Could not get domainType for MaxBufferElements: %s", err)
+	}
+	domainTypeSize := uint64(C.tiledb_datatype_size(C.tiledb_datatype_t(domainType)))
+	bufferValSize, err := a.MaxBufferSize(TILEDB_COORDS, subarray)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting MaxBufferElements for array: %s", err)
+	}
+	ret[TILEDB_COORDS] = [2]uint64{0, bufferValSize / domainTypeSize}
+
 	return ret, nil
 }
 

--- a/quickstart_sparse_test.go
+++ b/quickstart_sparse_test.go
@@ -75,7 +75,7 @@ func writeSparseArray() {
 	array, _ := tiledb.NewArray(ctx, sparseArrayName)
 	array.Open(tiledb.TILEDB_WRITE)
 	query, _ := tiledb.NewQuery(ctx, array)
-	query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
+	query.SetLayout(tiledb.TILEDB_UNORDERED)
 	query.SetBuffer("a", data)
 	query.SetCoordinates(coords)
 


### PR DESCRIPTION
Problems are:
- the write query layout cannot be `ROW_MAJOR` for SparseArray
- `array.MaxBufferElements()` should return buffer bounds for coordinates too

This pull request fixes these issues by:
- modifying the write query layout to `TILEDB_UNORDERED` in the example code
- adding logic inside the `Array.MaxBufferElements` function  to handle coordinates