### PR TITLE
uses go modules, enables tests for quickstarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+.idea

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/TileDB-Inc/TileDB-Go
+
+require github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/TileDB-Inc/TileDB-Go v0.4.0 h1:EYXlxehyaVCbZgifLsXa8xRAea/12iOApSi4RASqcRo=
+github.com/TileDB-Inc/TileDB-Go v0.4.0/go.mod h1:2UcagP8mjfTaNfNFjL8NZiYOVa9xXu8IEKA7UrW4kcA=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/quickstart_sparse_test.go
+++ b/quickstart_sparse_test.go
@@ -27,13 +27,13 @@ When run, this program will create a simple 2D sparse array, write some data
 to it, and read a slice of the data back, then clean up.
 For simplicity this program does not handle errors
 */
-package tiledb_test
+package tiledb
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"os"
-
-	tiledb "github.com/TileDB-Inc/TileDB-Go"
+	"testing"
 )
 
 // Name of array.
@@ -41,41 +41,41 @@ var sparseArrayName = "quickstart_sparse"
 
 func createSparseArray() {
 	// Create a TileDB context.
-	ctx, _ := tiledb.NewContext(nil)
+	ctx, _ := NewContext(nil)
 
 	// The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4].
-	domain, _ := tiledb.NewDomain(ctx)
-	rowDim, _ := tiledb.NewDimension(ctx, "rows", []int32{1, 4}, int32(4))
-	colDim, _ := tiledb.NewDimension(ctx, "cols", []int32{1, 4}, int32(4))
+	domain, _ := NewDomain(ctx)
+	rowDim, _ := NewDimension(ctx, "rows", []int32{1, 4}, int32(4))
+	colDim, _ := NewDimension(ctx, "cols", []int32{1, 4}, int32(4))
 	domain.AddDimensions(rowDim, colDim)
 
 	// The array will be dense.
-	schema, _ := tiledb.NewArraySchema(ctx, tiledb.TILEDB_SPARSE)
+	schema, _ := NewArraySchema(ctx, TILEDB_SPARSE)
 	schema.SetDomain(domain)
-	schema.SetCellOrder(tiledb.TILEDB_ROW_MAJOR)
-	schema.SetTileOrder(tiledb.TILEDB_ROW_MAJOR)
+	schema.SetCellOrder(TILEDB_ROW_MAJOR)
+	schema.SetTileOrder(TILEDB_ROW_MAJOR)
 
 	// Add a single attribute "a" so each (i,j) cell can store an integer.
-	a, _ := tiledb.NewAttribute(ctx, "a", tiledb.TILEDB_INT32)
+	a, _ := NewAttribute(ctx, "a", TILEDB_INT32)
 	schema.AddAttributes(a)
 
 	// Create the (empty) array on disk.
-	array, _ := tiledb.NewArray(ctx, sparseArrayName)
+	array, _ := NewArray(ctx, sparseArrayName)
 	array.Create(schema)
 }
 
 func writeSparseArray() {
-	ctx, _ := tiledb.NewContext(nil)
+	ctx, _ := NewContext(nil)
 
 	// Write some simple data to cells (1, 1), (2, 4) and (2, 3).
 	coords := []int32{1, 1, 2, 4, 2, 3}
 	data := []int32{1, 2, 3}
 
 	// Open the array for writing and create the query.
-	array, _ := tiledb.NewArray(ctx, sparseArrayName)
-	array.Open(tiledb.TILEDB_WRITE)
-	query, _ := tiledb.NewQuery(ctx, array)
-	query.SetLayout(tiledb.TILEDB_UNORDERED)
+	array, _ := NewArray(ctx, sparseArrayName)
+	array.Open(TILEDB_WRITE)
+	query, _ := NewQuery(ctx, array)
+	query.SetLayout(TILEDB_UNORDERED)
 	query.SetBuffer("a", data)
 	query.SetCoordinates(coords)
 
@@ -84,12 +84,12 @@ func writeSparseArray() {
 	array.Close()
 }
 
-func readSparseArray() {
-	ctx, _ := tiledb.NewContext(nil)
+func readSparseArray() ([]int32, []int32) {
+	ctx, _ := NewContext(nil)
 
 	// Prepare the array for reading
-	array, _ := tiledb.NewArray(ctx, sparseArrayName)
-	array.Open(tiledb.TILEDB_READ)
+	array, _ := NewArray(ctx, sparseArrayName)
+	array.Open(TILEDB_READ)
 
 	// Slice only rows 1, 2 and cols 2, 3, 4
 	subArray := []int32{1, 2, 2, 4}
@@ -99,12 +99,12 @@ func readSparseArray() {
 	// a buffer is needed since the array is sparse
 	maxElements, _ := array.MaxBufferElements(subArray)
 	data := make([]int32, maxElements["a"][1])
-	coords := make([]int32, maxElements[tiledb.TILEDB_COORDS][1])
+	coords := make([]int32, maxElements[TILEDB_COORDS][1])
 
 	// Prepare the query
-	query, _ := tiledb.NewQuery(ctx, array)
+	query, _ := NewQuery(ctx, array)
 	query.SetSubArray(subArray)
-	query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
+	query.SetLayout(TILEDB_ROW_MAJOR)
 	query.SetBuffer("a", data)
 	query.SetCoordinates(coords)
 
@@ -118,17 +118,23 @@ func readSparseArray() {
 		j := coords[2*r+1]
 		fmt.Printf("Cell (%d, %d) has data %d\n", i, j, data[r])
 	}
+
+	return data, coords
 }
 
 // ExampleSparseArray shows and example creation, writing and reading of a
 // sparse array
-func Example_sparseArray() {
+func TestSparseArray(t *testing.T) {
 	createSparseArray()
 	writeSparseArray()
-	readSparseArray()
 
-	// Output: Cell (2, 3) has data 3
-	// Cell (2, 4) has data 2
+	data, coords := readSparseArray()
+
+	expectedData := []int32{3, 2, 0}
+	assert.EqualValues(t, data, expectedData)
+
+	expectedCoords := []int32{2, 3, 2, 4, 0, 0}
+	assert.EqualValues(t, coords, expectedCoords)
 
 	// Cleanup example so unit tests are clean
 	if _, err := os.Stat(sparseArrayName); err == nil {


### PR DESCRIPTION
Adds go.mod file having name:
module github.com/TileDB-Inc/TileDB-Go 
Closes #32 

With go version 1.11.x and later it is no longer needed to put the code in GOPATH. After the first go test or go build command dependencies are downloaded automatically.

Quickstarts (sparse /dense) are included in the tiledb package in order to compile (avoids cyclic reference), also adds simple assertions