### PR TITLE
implements 18 out of 25 examples

### DIFF
--- a/examples/config_test.go
+++ b/examples/config_test.go
@@ -1,0 +1,410 @@
+/**
+ * @file   config_test.go
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This is a part of the TileDB tutorial:
+ *   https://docs.tiledb.io/en/latest/tutorials/config.html
+ *
+ * This program shows how to set/get the TileDB configuration parameters.
+ */
+
+package examples
+
+import (
+	"fmt"
+	"github.com/TileDB-Inc/TileDB-Go"
+	"os"
+)
+
+var configFileName = "tiledb_config.txt"
+
+func setGetConfigCtxVfs() {
+	// Create config objects
+	config, err := tiledb.NewConfig()
+
+	// Set/Get config to/from ctx
+	ctx, err := tiledb.NewContext(config)
+	checkError(err)
+	configCtx, err := ctx.Config()
+	checkError(err)
+	err = configCtx.Set("param1", "value1")
+	checkError(err)
+
+	vfs, err := tiledb.NewVFS(ctx, config)
+	checkError(err)
+	configVfs, err := vfs.Config()
+	checkError(err)
+	err = configVfs.Set("param2", "value2")
+	checkError(err)
+
+	param1, err := configCtx.Get("param1")
+	checkError(err)
+	fmt.Println(param1)
+	param2, err := configVfs.Get("param2")
+	checkError(err)
+	fmt.Println(param2)
+}
+
+func setGetConfig() {
+	// Create config object
+	config, err := tiledb.NewConfig()
+	checkError(err)
+
+	// Set a value
+	err = config.Set("vfs.s3.connect_timeout_ms", "5000")
+	checkError(err)
+
+	// Get the value and print it
+	vfsConnectTimeoutMs, err := config.Get("vfs.s3.connect_timeout_ms")
+	fmt.Printf("VFS connect timeout in ms is: %s\n", vfsConnectTimeoutMs)
+
+	// Get another value and print it
+	tileCacheSize, err := config.Get("sm.tile_cache_size")
+	fmt.Printf("Tile cache size: %s\n", tileCacheSize)
+}
+
+func printDefault() {
+	// Create config object
+	config, err := tiledb.NewConfig()
+	checkError(err)
+
+	// Get default settings and print them
+	fmt.Println("Default settings:")
+	smArraySchemaCacheSize, err := config.Get("sm.array_schema_cache_size")
+	checkError(err)
+	fmt.Printf("\"sm.array_schema_cache_size\" : \"%s\"\n",
+		smArraySchemaCacheSize)
+
+	smCheckCoordDups, err := config.Get("sm.check_coord_dups")
+	checkError(err)
+	fmt.Printf("\"sm.check_coord_dups\" : \"%s\"\n",
+		smCheckCoordDups)
+
+	smCheckCoordOob, err := config.Get("sm.check_coord_oob")
+	checkError(err)
+	fmt.Printf("\"sm.check_coord_oob\" : \"%s\"\n",
+		smCheckCoordOob)
+
+	smCheckGlobalOrder, err := config.Get("sm.check_global_order")
+	checkError(err)
+	fmt.Printf("\"sm.check_global_order\" : \"%s\"\n",
+		smCheckGlobalOrder)
+
+	smConsolidationAmplification, err := config.Get("sm.consolidation." +
+		"amplification")
+	checkError(err)
+	fmt.Printf("\"sm.consolidation.amplification\" : \"%s\"\n",
+		smConsolidationAmplification)
+
+	smConsolidationBufferSize, err := config.Get("sm.consolidation." +
+		"buffer_size")
+	checkError(err)
+	fmt.Printf("\"sm.consolidation.buffer_size\" : \"%s\"\n",
+		smConsolidationBufferSize)
+
+	smConsolidationStepMaxFrags, err := config.Get("sm.consolidation." +
+		"step_max_frags")
+	checkError(err)
+	fmt.Printf("\"sm.consolidation.step_max_frags\" : \"%s\"\n",
+		smConsolidationStepMaxFrags)
+
+	smConsolidationStepMinFrags, err := config.Get("sm.consolidation." +
+		"step_min_frags")
+	checkError(err)
+	fmt.Printf("\"sm.consolidation.step_min_frags\" : \"%s\"\n",
+		smConsolidationStepMinFrags)
+
+	smConsolidationStepSizeRatio, err := config.Get("sm.consolidation." +
+		"step_size_ratio")
+	checkError(err)
+	fmt.Printf("\"sm.consolidation.step_size_ratio\" : \"%s\"\n",
+		smConsolidationStepSizeRatio)
+
+	smConsolidationSteps, err := config.Get("sm.consolidation.steps")
+	checkError(err)
+	fmt.Printf("\"sm.consolidation.steps\" : \"%s\"\n",
+		smConsolidationSteps)
+
+	smDedupCoords, err := config.Get("sm.dedup_coords")
+	checkError(err)
+	fmt.Printf("\"sm.dedup_coords\" : \"%s\"\n",
+		smDedupCoords)
+
+	smEnableSignalHandlers, err := config.Get("sm.enable_signal_handlers")
+	checkError(err)
+	fmt.Printf("\"sm.enable_signal_handlers\" : \"%s\"\n",
+		smEnableSignalHandlers)
+
+	smFragmentMetadataCacheSize, err := config.Get("sm." +
+		"fragment_metadata_cache_size")
+	checkError(err)
+	fmt.Printf("\"sm.fragment_metadata_cache_size\" : \"%s\"\n",
+		smFragmentMetadataCacheSize)
+
+	smNumAsyncThreads, err := config.Get("sm.num_async_threads")
+	checkError(err)
+	fmt.Printf("\"sm.num_async_threads\" : \"%s\"\n",
+		smNumAsyncThreads)
+
+	smNumReaderThreads, err := config.Get("sm.num_reader_threads")
+	checkError(err)
+	fmt.Printf("\"sm.num_reader_threads\" : \"%s\"\n",
+		smNumReaderThreads)
+
+	smNumTbbThreads, err := config.Get("sm.num_tbb_threads")
+	checkError(err)
+	fmt.Printf("\"sm.num_tbb_threads\" : \"%s\"\n",
+		smNumTbbThreads)
+
+	smNumWriterThreads, err := config.Get("sm.num_writer_threads")
+	checkError(err)
+	fmt.Printf("\"sm.num_writer_threads\" : \"%s\"\n",
+		smNumWriterThreads)
+
+	smTileCacheSize, err := config.Get("sm.tile_cache_size")
+	checkError(err)
+	fmt.Printf("\"sm.tile_cache_size\" : \"%s\"\n",
+		smTileCacheSize)
+
+	vfsFileMaxParallelOps, err := config.Get("vfs.file.max_parallel_ops")
+	checkError(err)
+	fmt.Printf("\"vfs.file.max_parallel_ops\" : \"%s\"\n",
+		vfsFileMaxParallelOps)
+
+	vfsHdfsKerbTicketCachePath, err := config.Get("vfs.hdfs." +
+		"kerb_ticket_cache_path")
+	checkError(err)
+	fmt.Printf("\"vfs.hdfs.kerb_ticket_cache_path\" : \"%s\"\n",
+		vfsHdfsKerbTicketCachePath)
+
+	vfsHdfsNameNodeUri, err := config.Get("vfs.hdfs.name_node_uri")
+	checkError(err)
+	fmt.Printf("\"vfs.hdfs.name_node_uri\" : \"%s\"\n",
+		vfsHdfsNameNodeUri)
+
+	vfsHdfsUsername, err := config.Get("vfs.hdfs.username")
+	checkError(err)
+	fmt.Printf("\"vfs.hdfs.username\" : \"%s\"\n",
+		vfsHdfsUsername)
+
+	vfsMaxBatchReadAmplification, err := config.Get("vfs." +
+		"max_batch_read_amplification")
+	checkError(err)
+	fmt.Printf("\"vfs.max_batch_read_amplification\" : \"%s\"\n",
+		vfsMaxBatchReadAmplification)
+
+	vfsMaxBatchReadSize, err := config.Get("vfs.max_batch_read_size")
+	checkError(err)
+	fmt.Printf("\"vfs.max_batch_read_size\" : \"%s\"\n",
+		vfsMaxBatchReadSize)
+
+	vfsMinParallelSize, err := config.Get("vfs.min_parallel_size")
+	checkError(err)
+	fmt.Printf("\"vfs.min_parallel_size\" : \"%s\"\n",
+		vfsMinParallelSize)
+
+	vfsNumThreads, err := config.Get("vfs.num_threads")
+	checkError(err)
+	fmt.Printf("\"vfs.num_threads\" : \"%s\"\n",
+		vfsNumThreads)
+
+	vfsS3AwsAccessKeyId, err := config.Get("vfs.s3.aws_access_key_id")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.aws_access_key_id\" : \"%s\"\n",
+		vfsS3AwsAccessKeyId)
+
+	vfsS3AwsSecretAccessKey, err := config.Get("vfs.s3." +
+		"aws_secret_access_key")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.aws_secret_access_key\" : \"%s\"\n",
+		vfsS3AwsSecretAccessKey)
+
+	vfsS3ConnectMaxTries, err := config.Get("vfs.s3.connect_max_tries")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.connect_max_tries\" : \"%s\"\n",
+		vfsS3ConnectMaxTries)
+
+	vfsS3ConnectScaleFactor, err := config.Get("vfs.s3.connect_scale_factor")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.connect_scale_factor\" : \"%s\"\n",
+		vfsS3ConnectScaleFactor)
+
+	vfsS3ConnectTimeoutMs, err := config.Get("vfs.s3.connect_timeout_ms")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.connect_timeout_ms\" : \"%s\"\n",
+		vfsS3ConnectTimeoutMs)
+
+	vfsS3EndpointOverride, err := config.Get("vfs.s3.endpoint_override")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.endpoint_override\" : \"%s\"\n",
+		vfsS3EndpointOverride)
+
+	vfsS3MaxParallelOps, err := config.Get("vfs.s3.max_parallel_ops")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.max_parallel_ops\" : \"%s\"\n",
+		vfsS3MaxParallelOps)
+
+	vfsS3MultipartPartSize, err := config.Get("vfs.s3.multipart_part_size")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.multipart_part_size\" : \"%s\"\n",
+		vfsS3MultipartPartSize)
+
+	vfsS3ProxyHost, err := config.Get("vfs.s3.proxy_host")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.proxy_host\" : \"%s\"\n",
+		vfsS3ProxyHost)
+
+	vfsS3ProxyPassword, err := config.Get("vfs.s3.proxy_password")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.proxy_password\" : \"%s\"\n",
+		vfsS3ProxyPassword)
+
+	vfsS3ProxyPort, err := config.Get("vfs.s3.proxy_port")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.proxy_port\" : \"%s\"\n",
+		vfsS3ProxyPort)
+
+	vfsS3ProxyScheme, err := config.Get("vfs.s3.proxy_scheme")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.proxy_scheme\" : \"%s\"\n",
+		vfsS3ProxyScheme)
+
+	vfsS3ProxyUsername, err := config.Get("vfs.s3.proxy_username")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.proxy_username\" : \"%s\"\n",
+		vfsS3ProxyUsername)
+
+	vfsS3Region, err := config.Get("vfs.s3.region")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.region\" : \"%s\"\n",
+		vfsS3Region)
+
+	vfsS3RequestTimeoutMs, err := config.Get("vfs.s3.request_timeout_ms")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.request_timeout_ms\" : \"%s\"\n",
+		vfsS3RequestTimeoutMs)
+
+	vfsS3Scheme, err := config.Get("vfs.s3.scheme")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.scheme\" : \"%s\"\n",
+		vfsS3Scheme)
+
+	vfsS3UseVirtualAddressing, err := config.Get("vfs.s3." +
+		"use_virtual_addressing")
+	checkError(err)
+	fmt.Printf("\"vfs.s3.use_virtual_addressing\" : \"%s\"\n",
+		vfsS3UseVirtualAddressing)
+}
+
+func saveLoadConfig() {
+	fmt.Println("Save and load config")
+
+	// Create config object
+	config, err := tiledb.NewConfig()
+	checkError(err)
+
+	// Set a value
+	err = config.Set("sm.tile_cache_size", "8")
+	checkError(err)
+
+	// Save to disk
+	err = config.SaveToFile(configFileName)
+	checkError(err)
+
+	// Load config from file
+	newConfig, err := tiledb.LoadConfig(configFileName)
+	checkError(err)
+
+	// Print the retrieved value
+	smTileCacheSize, err := newConfig.Get("sm.tile_cache_size")
+	checkError(err)
+	fmt.Printf("\"sm.tile_cache_size\" : \"%s\"\n",
+		smTileCacheSize)
+
+	// Clean up
+	err = os.RemoveAll(configFileName)
+	checkError(err)
+}
+
+func ExampleConfig() {
+	setGetConfigCtxVfs()
+	setGetConfig()
+	printDefault()
+	saveLoadConfig()
+
+	// Output: value1
+	// value2
+	// VFS connect timeout in ms is: 5000
+	// Tile cache size: 10000000
+	// Default settings:
+	// "sm.array_schema_cache_size" : "10000000"
+	// "sm.check_coord_dups" : "true"
+	// "sm.check_coord_oob" : "true"
+	// "sm.check_global_order" : "true"
+	// "sm.consolidation.amplification" : "1"
+	// "sm.consolidation.buffer_size" : "50000000"
+	// "sm.consolidation.step_max_frags" : "4294967295"
+	// "sm.consolidation.step_min_frags" : "4294967295"
+	// "sm.consolidation.step_size_ratio" : "0"
+	// "sm.consolidation.steps" : "4294967295"
+	// "sm.dedup_coords" : "false"
+	// "sm.enable_signal_handlers" : "true"
+	// "sm.fragment_metadata_cache_size" : "10000000"
+	// "sm.num_async_threads" : "1"
+	// "sm.num_reader_threads" : "1"
+	// "sm.num_tbb_threads" : "-1"
+	// "sm.num_writer_threads" : "1"
+	// "sm.tile_cache_size" : "10000000"
+	// "vfs.file.max_parallel_ops" : "2"
+	// "vfs.hdfs.kerb_ticket_cache_path" : ""
+	// "vfs.hdfs.name_node_uri" : ""
+	// "vfs.hdfs.username" : ""
+	// "vfs.max_batch_read_amplification" : "1"
+	// "vfs.max_batch_read_size" : "104857600"
+	// "vfs.min_parallel_size" : "10485760"
+	// "vfs.num_threads" : "2"
+	// "vfs.s3.aws_access_key_id" : ""
+	// "vfs.s3.aws_secret_access_key" : ""
+	// "vfs.s3.connect_max_tries" : "5"
+	// "vfs.s3.connect_scale_factor" : "25"
+	// "vfs.s3.connect_timeout_ms" : "3000"
+	// "vfs.s3.endpoint_override" : ""
+	// "vfs.s3.max_parallel_ops" : "2"
+	// "vfs.s3.multipart_part_size" : "5242880"
+	// "vfs.s3.proxy_host" : ""
+	// "vfs.s3.proxy_password" : ""
+	// "vfs.s3.proxy_port" : "0"
+	// "vfs.s3.proxy_scheme" : "https"
+	// "vfs.s3.proxy_username" : ""
+	// "vfs.s3.region" : "us-east-1"
+	// "vfs.s3.request_timeout_ms" : "3000"
+	// "vfs.s3.scheme" : "https"
+	// "vfs.s3.use_virtual_addressing" : "true"
+	// Save and load config
+	// "sm.tile_cache_size" : "8"
+}

--- a/examples/error_check.go
+++ b/examples/error_check.go
@@ -1,0 +1,7 @@
+package examples
+
+func checkError(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/examples/errors_test.go
+++ b/examples/errors_test.go
@@ -1,0 +1,74 @@
+package examples
+
+import (
+	"fmt"
+	"github.com/TileDB-Inc/TileDB-Go"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Name of the group
+var groupName = "my_group"
+
+// Type of file system (e.g. file://, s3://)
+var fileSystem = "file://"
+
+func ExampleErrors() {
+	// Get filename of current file
+
+	// uncomment to use local filesystem
+	_, filename, _, _ := runtime.Caller(0)
+	pathName := filepath.Dir(filename)
+
+	// uncomment to use s3 bucket
+	//pathName := "test-bucket"
+
+	// Construct the path
+	groupPathName :=
+		fmt.Sprintf("%s%s/%s", fileSystem, pathName, groupName)
+
+	// Create config
+	config, err := tiledb.NewConfig()
+	checkError(err)
+
+	// Create a TileDB context.
+	ctx, err := tiledb.NewContext(config)
+	checkError(err)
+
+	// Create vfs
+	vfs, err := tiledb.NewVFS(ctx, config)
+	checkError(err)
+
+	// Find out if dir exists having group name
+	isDir, err := vfs.IsDir(groupName)
+	checkError(err)
+
+	// If it exists delete it to start clean
+	if isDir {
+		// For local filesystem it suffices to replace groupPathName with
+		// groupName since vfs can infer local directory
+		err = vfs.RemoveDir(groupPathName)
+		checkError(err)
+	}
+
+	err = tiledb.GroupCreate(ctx, groupPathName)
+	checkError(err)
+	//There cannot be two groups having the same name
+	err = tiledb.GroupCreate(ctx, groupPathName)
+
+	if err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			fmt.Println("[TileDB::StorageManager] Error: Cannot create group")
+			fmt.Println("Group already exists")
+		}
+	}
+
+	// Clean up
+	err = os.RemoveAll(groupName)
+	checkError(err)
+
+	// Output: [TileDB::StorageManager] Error: Cannot create group
+	// Group already exists
+}

--- a/examples/fragments_consolidation_test.go
+++ b/examples/fragments_consolidation_test.go
@@ -1,5 +1,5 @@
 /**
- * @file   quickstart_sparse_test.go
+ * @file   fragments_consolidation_test.go
  *
  * @section LICENSE
  *
@@ -27,13 +27,12 @@
  *
  * @section DESCRIPTION
  *
- * This is a part of the TileDB quickstart tutorial:
- * 	 https://docs.tiledb.io/en/latest/quickstart.html
+ * This is a part of the TileDB tutorial:
+ *   https://docs.tiledb.io/en/latest/tutorials/fragments-consolidation.html
  *
  * When run, this program will create a simple 2D dense array, write some data
- * to it, and read a slice of the data back in the layout of the user's choice
- * (passed as an argument to the program: "row", "col", or "global").
- *
+ * with three queries (creating three fragments), optionally consolidate
+ * and read the entire array data back.
  */
 
 package examples
@@ -45,15 +44,14 @@ import (
 )
 
 // Name of array.
-var sparseArrayName = "quickstart_sparse"
+var fragmentsConsolidationArrayName = "fragments_consolidation_array"
 
-func createSparseArray() {
+func createFragmentsConsolidationArray() {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
-	// The array will be 4x4 with dimensions "rows" and "cols",
-	// with domain [1,4].
+	// The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4].
 	domain, err := tiledb.NewDomain(ctx)
 	checkError(err)
 	rowDim, err := tiledb.NewDimension(ctx, "rows", []int32{1, 4}, int32(4))
@@ -63,8 +61,8 @@ func createSparseArray() {
 	err = domain.AddDimensions(rowDim, colDim)
 	checkError(err)
 
-	// The array will be sparse.
-	schema, err := tiledb.NewArraySchema(ctx, tiledb.TILEDB_SPARSE)
+	// The array will be dense.
+	schema, err := tiledb.NewArraySchema(ctx, tiledb.TILEDB_DENSE)
 	checkError(err)
 	err = schema.SetDomain(domain)
 	checkError(err)
@@ -74,28 +72,86 @@ func createSparseArray() {
 	checkError(err)
 
 	// Add a single attribute "a" so each (i,j) cell can store an integer.
-	a, err := tiledb.NewAttribute(ctx, "a", tiledb.TILEDB_UINT32)
+	a, err := tiledb.NewAttribute(ctx, "a", tiledb.TILEDB_INT32)
 	checkError(err)
 	err = schema.AddAttributes(a)
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	array, err := tiledb.NewArray(ctx, fragmentsConsolidationArrayName)
 	checkError(err)
 	err = array.Create(schema)
 	checkError(err)
 }
 
-func writeSparseArray() {
+func writeFragmentsConsolidationArray1() {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
-	// Write some simple data to cells (1, 1), (2, 4) and (2, 3).
-	coords := []int32{1, 1, 2, 4, 2, 3}
-	data := []uint32{1, 2, 3}
+	// Prepare some data for the array
+	data := []int32{1, 2, 3, 4, 5, 6, 7, 8}
+	subarray := []int32{1, 2, 1, 4}
 
-	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	// Create the query
+	array, err := tiledb.NewArray(ctx, fragmentsConsolidationArrayName)
+	checkError(err)
+	err = array.Open(tiledb.TILEDB_WRITE)
+	checkError(err)
+	query, err := tiledb.NewQuery(ctx, array)
+	checkError(err)
+	err = query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+	_, err = query.SetBuffer("a", data)
+	checkError(err)
+	err = query.SetSubArray(subarray)
+	checkError(err)
+
+	// Perform the write and close the array.
+	err = query.Submit()
+	checkError(err)
+	err = array.Close()
+	checkError(err)
+}
+
+func writeFragmentsConsolidationArray2() {
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
+
+	// Prepare some data for the array
+	data := []int32{101, 102, 103, 104}
+	subarray := []int32{2, 3, 2, 3}
+
+	// Create the query
+	array, err := tiledb.NewArray(ctx, fragmentsConsolidationArrayName)
+	checkError(err)
+	err = array.Open(tiledb.TILEDB_WRITE)
+	checkError(err)
+	query, err := tiledb.NewQuery(ctx, array)
+	checkError(err)
+	err = query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+	_, err = query.SetBuffer("a", data)
+	checkError(err)
+	err = query.SetSubArray(subarray)
+	checkError(err)
+
+	// Perform the write and close the array.
+	err = query.Submit()
+	checkError(err)
+	err = array.Close()
+	checkError(err)
+}
+
+func writeFragmentsConsolidationArray3() {
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
+
+	// Prepare some data for the array
+	data := []int32{201, 202}
+	coords := []int32{1, 1, 3, 4}
+
+	// Create the query
+	array, err := tiledb.NewArray(ctx, fragmentsConsolidationArrayName)
 	checkError(err)
 	err = array.Open(tiledb.TILEDB_WRITE)
 	checkError(err)
@@ -115,32 +171,32 @@ func writeSparseArray() {
 	checkError(err)
 }
 
-func readSparseArray() {
+func readFragmentsConsolidationArray() {
+	// Create TileDB context
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	array, err := tiledb.NewArray(ctx, fragmentsConsolidationArrayName)
 	checkError(err)
 	err = array.Open(tiledb.TILEDB_READ)
 	checkError(err)
 
-	// Slice only rows 1, 2 and cols 2, 3, 4
-	subArray := []int32{1, 2, 2, 4}
-
-	// Prepare the vector that will hold the results
-	// We take the upper bound on the result size as we do not know how large
-	// a buffer is needed since the array is sparse
-	maxElements, err := array.MaxBufferElements(subArray)
-	checkError(err)
-	data := make([]uint32, maxElements["a"][1])
-	coords := make([]int32, maxElements[tiledb.TILEDB_COORDS][1])
+	// Read the entire array
+	subArray := []int32{1, 4, 1, 4}
 
 	// Prepare the query
 	query, err := tiledb.NewQuery(ctx, array)
 	checkError(err)
 	err = query.SetSubArray(subArray)
 	checkError(err)
+
+	// Prepare the vector that will hold the result
+	maxElMap, err := array.MaxBufferElements(subArray)
+	checkError(err)
+	data := make([]int32, maxElMap["a"][1])
+	coords := make([]int32, maxElMap[tiledb.TILEDB_COORDS][1])
+
 	err = query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
 	checkError(err)
 	_, err = query.SetBuffer("a", data)
@@ -167,19 +223,33 @@ func readSparseArray() {
 	checkError(err)
 }
 
-// ExampleSparseArray shows and example creation, writing and reading of a
-// sparse array
-func ExampleSparseArray() {
-	createSparseArray()
-	writeSparseArray()
-	readSparseArray()
+func ExampleFragmentsConsolidationArray() {
+	createFragmentsConsolidationArray()
+	writeFragmentsConsolidationArray1()
+	writeFragmentsConsolidationArray2()
+	writeFragmentsConsolidationArray3()
+	readFragmentsConsolidationArray()
 
 	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(sparseArrayName); err == nil {
-		err = os.RemoveAll(sparseArrayName)
+	if _, err := os.Stat(fragmentsConsolidationArrayName); err == nil {
+		err = os.RemoveAll(fragmentsConsolidationArrayName)
 		checkError(err)
 	}
 
-	// Output: Cell (2, 3) has data 3
-	// Cell (2, 4) has data 2
+	// Output: Cell (1, 1) has data 201
+	// Cell (1, 2) has data 2
+	// Cell (1, 3) has data 3
+	// Cell (1, 4) has data 4
+	// Cell (2, 1) has data 5
+	// Cell (2, 2) has data 101
+	// Cell (2, 3) has data 102
+	// Cell (2, 4) has data 8
+	// Cell (3, 1) has data -2147483648
+	// Cell (3, 2) has data 103
+	// Cell (3, 3) has data 104
+	// Cell (3, 4) has data 202
+	// Cell (4, 1) has data -2147483648
+	// Cell (4, 2) has data -2147483648
+	// Cell (4, 3) has data -2147483648
+	// Cell (4, 4) has data -2147483648
 }

--- a/examples/multi_attribute_test.go
+++ b/examples/multi_attribute_test.go
@@ -1,0 +1,247 @@
+/**
+ * @file   multi_attribute_test.go
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This is a part of the TileDB "Multi-attribute Arrays" tutorial:
+ *   https://docs.tiledb.io/en/latest/tutorials/multi-attribute-arrays.html
+ *
+ * When run, this program will create a simple 2D dense array with two
+ * attributes, write some data to it, and read a slice of the data back on
+ * (i) both attributes, and (ii) subselecting on only one of the attributes.
+ *
+ */
+
+package examples
+
+import (
+	"fmt"
+	tiledb "github.com/TileDB-Inc/TileDB-Go"
+	"os"
+)
+
+// Name of array.
+var multiAttributeArrayName = "multi_attribute_array"
+
+func createMultiAttributeArray() {
+	// Create a TileDB context.
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
+
+	// The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4].
+	domain, err := tiledb.NewDomain(ctx)
+	checkError(err)
+	rowDim, err := tiledb.NewDimension(ctx, "rows", []int32{1, 4}, int32(4))
+	checkError(err)
+	colDim, err := tiledb.NewDimension(ctx, "cols", []int32{1, 4}, int32(4))
+	checkError(err)
+	err = domain.AddDimensions(rowDim, colDim)
+	checkError(err)
+
+	// The array will be dense.
+	schema, err := tiledb.NewArraySchema(ctx, tiledb.TILEDB_DENSE)
+	err = schema.SetDomain(domain)
+	checkError(err)
+	err = schema.SetCellOrder(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+	err = schema.SetTileOrder(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+
+	// Create two attributes "a1" and "a2", so each (i,j) cell can store
+	// a character on "a1" and a vector of two floats on "a2".
+	a1, err := tiledb.NewAttribute(ctx, "a1", tiledb.TILEDB_STRING_ASCII)
+	checkError(err)
+	a2, err := tiledb.NewAttribute(ctx, "a2", tiledb.TILEDB_FLOAT32)
+	checkError(err)
+	err = schema.AddAttributes(a1)
+	checkError(err)
+	err = a2.SetCellValNum(2)
+	checkError(err)
+	err = schema.AddAttributes(a2)
+	checkError(err)
+
+	// Create the (empty) array on disk.
+	array, err := tiledb.NewArray(ctx, multiAttributeArrayName)
+	checkError(err)
+	err = array.Create(schema)
+	checkError(err)
+}
+
+func writeMultiAttributeArray() {
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
+
+	// Prepare some data for the array
+	a1 := []byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
+		'm', 'n', 'o', 'p'}
+	a2 := []float32{1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2,
+		5.1, 5.2, 6.1, 6.2, 7.1, 7.2, 8.1, 8.2,
+		9.1, 9.2, 10.1, 10.2, 11.1, 11.2, 12.1, 12.2,
+		13.1, 13.2, 14.1, 14.2, 15.1, 15.2, 16.1, 16.2}
+
+	// Create the query
+	array, err := tiledb.NewArray(ctx, multiAttributeArrayName)
+	checkError(err)
+	err = array.Open(tiledb.TILEDB_WRITE)
+	checkError(err)
+	query, err := tiledb.NewQuery(ctx, array)
+	checkError(err)
+	err = query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+	_, err = query.SetBuffer("a1", a1)
+	checkError(err)
+	_, err = query.SetBuffer("a2", a2)
+	checkError(err)
+
+	// Perform the write and close the array.
+	err = query.Submit()
+	checkError(err)
+	err = array.Close()
+	checkError(err)
+}
+
+func readMultiAttributeArray() {
+	// Create TileDB context
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
+
+	// Prepare the array for reading
+	array, err := tiledb.NewArray(ctx, multiAttributeArrayName)
+	checkError(err)
+	err = array.Open(tiledb.TILEDB_READ)
+	checkError(err)
+
+	// Slice only rows 1, 2 and cols 2, 3, 4
+	subArray := []int32{1, 2, 2, 4}
+
+	// Prepare the query
+	query, err := tiledb.NewQuery(ctx, array)
+	checkError(err)
+	err = query.SetSubArray(subArray)
+	checkError(err)
+
+	// Prepare the vector that will hold the result
+	// (of size 6 elements for "a1" and 12 elements for "a2" since
+	// it stores two floats per cell)
+	maxElMap, err := array.MaxBufferElements(subArray)
+	checkError(err)
+	a1Data := make([]byte, maxElMap["a1"][1])
+	a2Data := make([]float32, maxElMap["a2"][1])
+
+	err = query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+	_, err = query.SetBuffer("a1", a1Data)
+	checkError(err)
+	_, err = query.SetBuffer("a2", a2Data)
+	checkError(err)
+
+	// Submit the query and close the array.
+	err = query.Submit()
+	checkError(err)
+	err = array.Close()
+	checkError(err)
+
+	fmt.Println("Reading both attributes a1 and a2:")
+	for i := 0; i < int(maxElMap["a1"][1]); i++ {
+		fmt.Printf("a1: %s, a2: (%.1f,%.1f)\n", string(a1Data[i]),
+			a2Data[2*i], a2Data[2*i+1])
+	}
+	fmt.Printf("\n")
+}
+
+func readMultiAttributeArraySubSelect() {
+	// Create TileDB context
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
+
+	// Prepare the array for reading
+	array, err := tiledb.NewArray(ctx, multiAttributeArrayName)
+	checkError(err)
+	err = array.Open(tiledb.TILEDB_READ)
+	checkError(err)
+
+	// Slice only rows 1, 2 and cols 2, 3, 4
+	subArray := []int32{1, 2, 2, 4}
+
+	// Prepare the query
+	query, err := tiledb.NewQuery(ctx, array)
+	checkError(err)
+	err = query.SetSubArray(subArray)
+	checkError(err)
+
+	// Prepare the vector that will hold the result
+	// (of size 6 elements for "a1")
+	maxElMap, err := array.MaxBufferElements(subArray)
+	checkError(err)
+	a1Data := make([]byte, maxElMap["a1"][1])
+
+	err = query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+	_, err = query.SetBuffer("a1", a1Data)
+	checkError(err)
+
+	// Submit the query and close the array.
+	err = query.Submit()
+	checkError(err)
+	err = array.Close()
+	checkError(err)
+
+	fmt.Println("Subselecting on attribute a1:")
+	for i := 0; i < int(maxElMap["a1"][1]); i++ {
+		fmt.Printf("a1: %s\n", string(a1Data[i]))
+	}
+	fmt.Printf("\n")
+}
+
+func ExampleMultiAttributeArray() {
+	createMultiAttributeArray()
+	writeMultiAttributeArray()
+	readMultiAttributeArray()
+	readMultiAttributeArraySubSelect()
+
+	// Cleanup example so unit tests are clean
+	if _, err := os.Stat(multiAttributeArrayName); err == nil {
+		err = os.RemoveAll(multiAttributeArrayName)
+		checkError(err)
+	}
+
+	// Output: Reading both attributes a1 and a2:
+	// a1: b, a2: (2.1,2.2)
+	// a1: c, a2: (3.1,3.2)
+	// a1: d, a2: (4.1,4.2)
+	// a1: f, a2: (6.1,6.2)
+	// a1: g, a2: (7.1,7.2)
+	// a1: h, a2: (8.1,8.2)
+	//
+	// Subselecting on attribute a1:
+	// a1: b
+	// a1: c
+	// a1: d
+	// a1: f
+	// a1: g
+	// a1: h
+}

--- a/examples/quickstart_dense_test.go
+++ b/examples/quickstart_dense_test.go
@@ -1,32 +1,41 @@
-/*
-Copyright (c) 2018 TileDB, Inc.
+/**
+ * @file   quickstart_dense_test.go
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This is a part of the TileDB quickstart tutorial:
+ *   https://docs.tiledb.io/en/latest/quickstart.html
+ *
+ * When run, this program will create a simple 2D dense array, write some data
+ * to it, and read a slice of the data back in the layout of the user's choice
+ * (passed as an argument to the program: "row", "col", or "global").
+ *
+ */
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-
-This is a part of the TileDB quickstart tutorial:
-https://docs.tiledb.io/en/latest/quickstart.html
-
-When run, this program will create a simple 2D dense array, write some data
-to it, and read a slice of the data back, then clean up.
-For simplicity this program does not handle errors
-*/
 package examples
 
 import (
@@ -41,54 +50,77 @@ var denseArrayName = "quickstart_dense"
 
 func createDenseArray() {
 	// Create a TileDB context.
-	ctx, _ := tiledb.NewContext(nil)
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
 
 	// The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4].
-	domain, _ := tiledb.NewDomain(ctx)
-	rowDim, _ := tiledb.NewDimension(ctx, "rows", []int32{1, 4}, int32(4))
-	colDim, _ := tiledb.NewDimension(ctx, "cols", []int32{1, 4}, int32(4))
-	domain.AddDimensions(rowDim, colDim)
+	domain, err := tiledb.NewDomain(ctx)
+	checkError(err)
+	rowDim, err := tiledb.NewDimension(ctx, "rows", []int32{1, 4}, int32(4))
+	checkError(err)
+	colDim, err := tiledb.NewDimension(ctx, "cols", []int32{1, 4}, int32(4))
+	checkError(err)
+	err = domain.AddDimensions(rowDim, colDim)
+	checkError(err)
 
 	// The array will be dense.
-	schema, _ := tiledb.NewArraySchema(ctx, tiledb.TILEDB_DENSE)
-	schema.SetDomain(domain)
-	schema.SetCellOrder(tiledb.TILEDB_ROW_MAJOR)
-	schema.SetTileOrder(tiledb.TILEDB_ROW_MAJOR)
+	schema, err := tiledb.NewArraySchema(ctx, tiledb.TILEDB_DENSE)
+	err = schema.SetDomain(domain)
+	checkError(err)
+	err = schema.SetCellOrder(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+	err = schema.SetTileOrder(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
 
 	// Add a single attribute "a" so each (i,j) cell can store an integer.
-	a, _ := tiledb.NewAttribute(ctx, "a", tiledb.TILEDB_INT32)
-	schema.AddAttributes(a)
+	a, err := tiledb.NewAttribute(ctx, "a", tiledb.TILEDB_INT32)
+	checkError(err)
+	err = schema.AddAttributes(a)
+	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, _ := tiledb.NewArray(ctx, denseArrayName)
-	array.Create(schema)
+	array, err := tiledb.NewArray(ctx, denseArrayName)
+	checkError(err)
+	err = array.Create(schema)
+	checkError(err)
 }
 
 func writeDenseArray() {
-	ctx, _ := tiledb.NewContext(nil)
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
 
 	// Prepare some data for the array
 	data := []int32{
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 
 	// Open the array for writing and create the query.
-	array, _ := tiledb.NewArray(ctx, denseArrayName)
-	array.Open(tiledb.TILEDB_WRITE)
-	query, _ := tiledb.NewQuery(ctx, array)
-	query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
-	query.SetBuffer("a", data)
+	array, err := tiledb.NewArray(ctx, denseArrayName)
+	checkError(err)
+	err = array.Open(tiledb.TILEDB_WRITE)
+	checkError(err)
+	query, err := tiledb.NewQuery(ctx, array)
+	checkError(err)
+	err = query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+	_, err = query.SetBuffer("a", data)
+	checkError(err)
 
 	// Perform the write and close the array.
-	query.Submit()
-	array.Close()
+	err = query.Submit()
+	checkError(err)
+	err = array.Close()
+	checkError(err)
 }
 
 func readDenseArray() {
-	ctx, _ := tiledb.NewContext(nil)
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
 
 	// Prepare the array for reading
-	array, _ := tiledb.NewArray(ctx, denseArrayName)
-	array.Open(tiledb.TILEDB_READ)
+	array, err := tiledb.NewArray(ctx, denseArrayName)
+	checkError(err)
+	err = array.Open(tiledb.TILEDB_READ)
+	checkError(err)
 
 	// Slice only rows 1, 2 and cols 2, 3, 4
 	subArray := []int32{1, 2, 2, 4}
@@ -97,14 +129,20 @@ func readDenseArray() {
 	data := make([]int32, 6)
 
 	// Prepare the query
-	query, _ := tiledb.NewQuery(ctx, array)
-	query.SetSubArray(subArray)
-	query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
-	query.SetBuffer("a", data)
+	query, err := tiledb.NewQuery(ctx, array)
+	checkError(err)
+	err = query.SetSubArray(subArray)
+	checkError(err)
+	err = query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+	_, err = query.SetBuffer("a", data)
+	checkError(err)
 
 	// Submit the query and close the array.
-	query.Submit()
-	array.Close()
+	err = query.Submit()
+	checkError(err)
+	err = array.Close()
+	checkError(err)
 
 	// Print out the results.
 	fmt.Println(data)
@@ -119,7 +157,8 @@ func ExampleDenseArray() {
 
 	// Cleanup example so unit tests are clean
 	if _, err := os.Stat(denseArrayName); err == nil {
-		os.RemoveAll(denseArrayName)
+		err = os.RemoveAll(denseArrayName)
+		checkError(err)
 	}
 
 	// Output: [2 3 4 6 7 8]

--- a/examples/reading_dense_layouts_test.go
+++ b/examples/reading_dense_layouts_test.go
@@ -1,5 +1,5 @@
 /**
- * @file   quickstart_sparse_test.go
+ * @file   reading_dense_layouts_test.go
  *
  * @section LICENSE
  *
@@ -27,8 +27,8 @@
  *
  * @section DESCRIPTION
  *
- * This is a part of the TileDB quickstart tutorial:
- * 	 https://docs.tiledb.io/en/latest/quickstart.html
+ * This is a part of the TileDB tutorial:
+ *   https://docs.tiledb.io/en/latest/tutorials/reading.html
  *
  * When run, this program will create a simple 2D dense array, write some data
  * to it, and read a slice of the data back in the layout of the user's choice
@@ -40,32 +40,30 @@ package examples
 
 import (
 	"fmt"
-	tiledb "github.com/TileDB-Inc/TileDB-Go"
+	"github.com/TileDB-Inc/TileDB-Go"
 	"os"
 )
 
 // Name of array.
-var sparseArrayName = "quickstart_sparse"
+var readingDenseLayoutsArrayName = "reading_dense_layouts_array"
 
-func createSparseArray() {
+func createReadingDenseLayoutsArray() {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
-	// The array will be 4x4 with dimensions "rows" and "cols",
-	// with domain [1,4].
+	// The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4].
 	domain, err := tiledb.NewDomain(ctx)
 	checkError(err)
-	rowDim, err := tiledb.NewDimension(ctx, "rows", []int32{1, 4}, int32(4))
+	rowDim, err := tiledb.NewDimension(ctx, "rows", []int32{1, 4}, int32(2))
 	checkError(err)
-	colDim, err := tiledb.NewDimension(ctx, "cols", []int32{1, 4}, int32(4))
+	colDim, err := tiledb.NewDimension(ctx, "cols", []int32{1, 4}, int32(2))
 	checkError(err)
 	err = domain.AddDimensions(rowDim, colDim)
 	checkError(err)
 
-	// The array will be sparse.
-	schema, err := tiledb.NewArraySchema(ctx, tiledb.TILEDB_SPARSE)
-	checkError(err)
+	// The array will be dense.
+	schema, err := tiledb.NewArraySchema(ctx, tiledb.TILEDB_DENSE)
 	err = schema.SetDomain(domain)
 	checkError(err)
 	err = schema.SetCellOrder(tiledb.TILEDB_ROW_MAJOR)
@@ -74,67 +72,72 @@ func createSparseArray() {
 	checkError(err)
 
 	// Add a single attribute "a" so each (i,j) cell can store an integer.
-	a, err := tiledb.NewAttribute(ctx, "a", tiledb.TILEDB_UINT32)
+	a, err := tiledb.NewAttribute(ctx, "a", tiledb.TILEDB_INT32)
 	checkError(err)
 	err = schema.AddAttributes(a)
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	array, err := tiledb.NewArray(ctx, readingDenseLayoutsArrayName)
 	checkError(err)
 	err = array.Create(schema)
 	checkError(err)
 }
 
-func writeSparseArray() {
+func writeReadingDenseLayoutsArray() {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
-	// Write some simple data to cells (1, 1), (2, 4) and (2, 3).
-	coords := []int32{1, 1, 2, 4, 2, 3}
-	data := []uint32{1, 2, 3}
+	// Prepare some data for the array
+	data := []int32{
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 
 	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	array, err := tiledb.NewArray(ctx, readingDenseLayoutsArrayName)
 	checkError(err)
 	err = array.Open(tiledb.TILEDB_WRITE)
 	checkError(err)
 	query, err := tiledb.NewQuery(ctx, array)
 	checkError(err)
-	err = query.SetLayout(tiledb.TILEDB_UNORDERED)
+	err = query.SetLayout(tiledb.TILEDB_GLOBAL_ORDER)
 	checkError(err)
 	_, err = query.SetBuffer("a", data)
-	checkError(err)
-	_, err = query.SetCoordinates(coords)
 	checkError(err)
 
 	// Perform the write and close the array.
 	err = query.Submit()
 	checkError(err)
+	err = query.Finalize()
+	checkError(err)
 	err = array.Close()
 	checkError(err)
 }
 
-func readSparseArray() {
+func readReadingDenseLayoutsArray() {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	array, err := tiledb.NewArray(ctx, readingDenseLayoutsArrayName)
 	checkError(err)
 	err = array.Open(tiledb.TILEDB_READ)
 	checkError(err)
 
+	// Non-empty domain: [1,4], [1,4]
+	x, isEmpty, err := array.NonEmptyDomain()
+	if !isEmpty {
+		rows := x[0].Bounds.([]int32)
+		cols := x[1].Bounds.([]int32)
+		fmt.Printf("Non-empty domain: [%d,%d], [%d,%d]\n",
+			rows[0], rows[1], cols[0], cols[1])
+	}
+
 	// Slice only rows 1, 2 and cols 2, 3, 4
 	subArray := []int32{1, 2, 2, 4}
 
-	// Prepare the vector that will hold the results
-	// We take the upper bound on the result size as we do not know how large
-	// a buffer is needed since the array is sparse
-	maxElements, err := array.MaxBufferElements(subArray)
-	checkError(err)
-	data := make([]uint32, maxElements["a"][1])
-	coords := make([]int32, maxElements[tiledb.TILEDB_COORDS][1])
+	// Prepare the vector that will hold the result (of size 6 elements)
+	data := make([]int32, 6)
+	coords := make([]int32, 12)
 
 	// Prepare the query
 	query, err := tiledb.NewQuery(ctx, array)
@@ -167,19 +170,22 @@ func readSparseArray() {
 	checkError(err)
 }
 
-// ExampleSparseArray shows and example creation, writing and reading of a
-// sparse array
-func ExampleSparseArray() {
-	createSparseArray()
-	writeSparseArray()
-	readSparseArray()
+func ExampleReadingDenseLayouts() {
+	createReadingDenseLayoutsArray()
+	writeReadingDenseLayoutsArray()
+	readReadingDenseLayoutsArray()
 
 	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(sparseArrayName); err == nil {
-		err = os.RemoveAll(sparseArrayName)
+	if _, err := os.Stat(readingDenseLayoutsArrayName); err == nil {
+		err = os.RemoveAll(readingDenseLayoutsArrayName)
 		checkError(err)
 	}
 
-	// Output: Cell (2, 3) has data 3
-	// Cell (2, 4) has data 2
+	// Output: Non-empty domain: [1,4], [1,4]
+	// Cell (1, 2) has data 2
+	// Cell (1, 3) has data 5
+	// Cell (1, 4) has data 6
+	// Cell (2, 2) has data 4
+	// Cell (2, 3) has data 7
+	// Cell (2, 4) has data 8
 }

--- a/examples/reading_incomplete_test.go
+++ b/examples/reading_incomplete_test.go
@@ -1,0 +1,279 @@
+/**
+ * @file   reading_incomplete_test.go
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This is a part of the TileDB "Multi-attribute Arrays" tutorial:
+ *   https://docs.tiledb.io/en/latest/tutorials/reading.html
+ *
+ * This example demonstrates the concept of incomplete read queries
+ * for a sparse array with two attributes.
+ */
+
+package examples
+
+import (
+	"fmt"
+	"github.com/TileDB-Inc/TileDB-Go"
+	"os"
+	"unsafe"
+)
+
+// Name of array.
+var readingIncompleteArrayName = "reading_incomplete_array"
+
+func createReadingIncompleteArray() {
+	// Create a TileDB context.
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
+
+	// The array will be 4x4 with dimensions "rows" and "cols",
+	// with domain [1,4].
+	domain, err := tiledb.NewDomain(ctx)
+	checkError(err)
+	rowDim, err := tiledb.NewDimension(ctx, "rows", []int32{1, 4}, int32(2))
+	checkError(err)
+	colDim, err := tiledb.NewDimension(ctx, "cols", []int32{1, 4}, int32(2))
+	checkError(err)
+	err = domain.AddDimensions(rowDim, colDim)
+	checkError(err)
+
+	// The array will be sparse.
+	schema, err := tiledb.NewArraySchema(ctx, tiledb.TILEDB_SPARSE)
+	checkError(err)
+	err = schema.SetDomain(domain)
+	checkError(err)
+	err = schema.SetCellOrder(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+	err = schema.SetTileOrder(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+
+	// Add an attribute "a1" so each (i,j) cell can store an integer.
+	a1, err := tiledb.NewAttribute(ctx, "a1", tiledb.TILEDB_INT32)
+	checkError(err)
+	err = schema.AddAttributes(a1)
+	checkError(err)
+
+	// Add an attribute "a2" so each (i,j) cell can store a string.
+	a2, err := tiledb.NewAttribute(ctx, "a2", tiledb.TILEDB_STRING_UTF8)
+	checkError(err)
+	err = a2.SetCellValNum(tiledb.TILEDB_VAR_NUM)
+	checkError(err)
+	err = schema.AddAttributes(a2)
+	checkError(err)
+
+	// Create the (empty) array on disk.
+	array, err := tiledb.NewArray(ctx, readingIncompleteArrayName)
+	checkError(err)
+	err = array.Create(schema)
+	checkError(err)
+}
+
+func writeReadingIncompleteArray() {
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
+
+	// Prepare some data for the array
+	coords := []int32{1, 1, 2, 1, 2, 2}
+	a1Data := []int32{1, 2, 3}
+	a2Data := []byte("abbccc")
+	a2Off := []uint64{0, 1, 3}
+
+	// Open the array for writing and create the query.
+	array, err := tiledb.NewArray(ctx, readingIncompleteArrayName)
+	checkError(err)
+	err = array.Open(tiledb.TILEDB_WRITE)
+	checkError(err)
+	query, err := tiledb.NewQuery(ctx, array)
+	checkError(err)
+	err = query.SetLayout(tiledb.TILEDB_GLOBAL_ORDER)
+	checkError(err)
+	_, err = query.SetBuffer("a1", a1Data)
+	checkError(err)
+	_, _, err = query.SetBufferVar("a2", a2Off, a2Data)
+	checkError(err)
+	_, err = query.SetCoordinates(coords)
+	checkError(err)
+
+	// Perform the write, finalize and close the array.
+	err = query.Submit()
+	checkError(err)
+	err = query.Finalize()
+	checkError(err)
+	err = array.Close()
+	checkError(err)
+}
+
+func reallocateBuffers(
+	coords *[]int32,
+	a1Data *[]int32,
+	a2Off *[]uint64,
+	a2Data *[]byte) {
+	fmt.Println("Reallocating...")
+
+	//// Note: this is a naive reallocation - you should handle
+	//// reallocation properly depending on your application
+	*coords = make([]int32, 2*len(*coords))
+	*a1Data = make([]int32, 2*len(*a1Data))
+	*a2Off = make([]uint64, 2*len(*a2Off))
+	*a2Data = make([]byte, 2*len(*a2Data))
+}
+
+func printResultsReadingIncomplete(
+	coords []int32,
+	a1Data []int32,
+	a2Off []uint64,
+	a2Data []byte,
+	resultElMap map[string][2]uint64) {
+	fmt.Println("Printing results...")
+
+	// Get the string sizes
+	resultElA2Off := resultElMap["a2"][0]
+
+	var a2StrSizes []uint64
+
+	for i := 0; i < int(resultElA2Off)-1; i++ {
+		a2StrSizes = append(a2StrSizes, a2Off[i+1]-a2Off[i])
+	}
+
+	resultA2DataSize := resultElMap["a2"][1] *
+		uint64(unsafe.Sizeof(byte(0)))
+	a2StrSizes = append(a2StrSizes,
+		resultA2DataSize-a2Off[resultElA2Off-1])
+
+	// Get the strings
+	a2Str := make([][]byte, resultElA2Off)
+	for i := 0; i < int(resultElA2Off); i++ {
+		a2Str[i] = make([]byte, 0)
+		for j := 0; j < int(a2StrSizes[i]); j++ {
+			a2Str[i] = append(a2Str[i], a2Data[a2Off[i]])
+		}
+	}
+
+	// Print the results
+	resultNum := resultElA2Off // For clarity
+	for r := 0; r < int(resultNum); r++ {
+		i := coords[2*r]
+		j := coords[2*r+1]
+		a1 := a1Data[r]
+		fmt.Printf("Cell (%d, %d), a1: %d, a2: %s\n",
+			i, j, a1, string(a2Str[r]))
+	}
+}
+
+func readReadingIncompleteArray() {
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
+
+	// Prepare the array for reading
+	array, err := tiledb.NewArray(ctx, readingIncompleteArrayName)
+	checkError(err)
+	err = array.Open(tiledb.TILEDB_READ)
+	checkError(err)
+
+	// Read the entire array
+	subArray := []int32{1, 4, 1, 4}
+
+	// Prepare buffers such that the results **cannot** fit
+	coords := make([]int32, 2)
+	a1Data := make([]int32, 1)
+	a2Off := make([]uint64, 1)
+	a2Data := make([]byte, 1)
+
+	// Prepare the query
+	query, err := tiledb.NewQuery(ctx, array)
+	checkError(err)
+	err = query.SetSubArray(subArray)
+	checkError(err)
+	err = query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+	_, err = query.SetBuffer("a1", a1Data)
+	checkError(err)
+	_, _, err = query.SetBufferVar("a2", a2Off, a2Data)
+	checkError(err)
+	_, err = query.SetCoordinates(coords)
+	checkError(err)
+
+	var queryStatus tiledb.QueryStatus
+
+	for {
+		// Submit the query
+		err = query.Submit()
+		checkError(err)
+
+		queryStatus, err = query.Status()
+		checkError(err)
+
+		// Print out the results.
+		elements, err := query.ResultBufferElements()
+		checkError(err)
+		resultNum := elements["a1"][1]
+
+		if queryStatus == tiledb.TILEDB_INCOMPLETE && resultNum == 0 {
+			reallocateBuffers(&coords, &a1Data, &a2Off, &a2Data)
+			_, err = query.SetBuffer("a1", a1Data)
+			checkError(err)
+			_, _, err = query.SetBufferVar("a2", a2Off, a2Data)
+			checkError(err)
+			_, err = query.SetCoordinates(coords)
+			checkError(err)
+		} else {
+			elements, err := query.ResultBufferElements()
+			checkError(err)
+			printResultsReadingIncomplete(
+				coords, a1Data, a2Off, a2Data, elements)
+		}
+
+		if queryStatus != tiledb.TILEDB_INCOMPLETE {
+			break
+		}
+	}
+
+	err = array.Close()
+	checkError(err)
+}
+
+func ExampleReadingIncompleteArray() {
+	createReadingIncompleteArray()
+	writeReadingIncompleteArray()
+	readReadingIncompleteArray()
+
+	// Cleanup example so unit tests are clean
+	if _, err := os.Stat(readingIncompleteArrayName); err == nil {
+		err = os.RemoveAll(readingIncompleteArrayName)
+		checkError(err)
+	}
+
+	// Output: Printing results...
+	// Cell (1, 1), a1: 1, a2: a
+	// Reallocating...
+	// Printing results...
+	// Cell (2, 1), a1: 2, a2: bb
+	// Reallocating...
+	// Printing results...
+	// Cell (2, 2), a1: 3, a2: ccc
+}

--- a/examples/variable_length_test.go
+++ b/examples/variable_length_test.go
@@ -1,0 +1,256 @@
+/**
+ * @file   variable_length_test.go
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This is a part of the TileDB "Multi-attribute Arrays" tutorial:
+ *   https://docs.tiledb.io/en/latest/tutorials/variable-length-attributes.html
+ *
+ * When run, this program will create a simple 2D dense array with two
+ * variable-length attributes, write some data to it, and read a slice of the
+ * data back on both attributes.
+ *
+ */
+
+package examples
+
+import (
+	"fmt"
+	"github.com/TileDB-Inc/TileDB-Go"
+	"os"
+	"unsafe"
+)
+
+// Name of array.
+var variableLengthArrayName = "variable_length_array"
+
+func createVariableLengthArray() {
+	// Create a TileDB context.
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
+
+	// The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4].
+	domain, err := tiledb.NewDomain(ctx)
+	checkError(err)
+	rowDim, err := tiledb.NewDimension(ctx, "rows", []int32{1, 4}, int32(4))
+	checkError(err)
+	colDim, err := tiledb.NewDimension(ctx, "cols", []int32{1, 4}, int32(4))
+	checkError(err)
+	err = domain.AddDimensions(rowDim, colDim)
+	checkError(err)
+
+	// The array will be dense.
+	schema, err := tiledb.NewArraySchema(ctx, tiledb.TILEDB_DENSE)
+	err = schema.SetDomain(domain)
+	checkError(err)
+	err = schema.SetCellOrder(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+	err = schema.SetTileOrder(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+
+	// Add two variable-length attributes "a1" and "a2", the first storing
+	// strings and the second storing a variable number of integers.
+	a1, err := tiledb.NewAttribute(ctx, "a1", tiledb.TILEDB_STRING_ASCII)
+	checkError(err)
+	a2, err := tiledb.NewAttribute(ctx, "a2", tiledb.TILEDB_INT32)
+	checkError(err)
+	err = a1.SetCellValNum(tiledb.TILEDB_VAR_NUM)
+	checkError(err)
+	err = schema.AddAttributes(a1)
+	checkError(err)
+	err = a2.SetCellValNum(tiledb.TILEDB_VAR_NUM)
+	checkError(err)
+	err = schema.AddAttributes(a2)
+	checkError(err)
+
+	// Create the (empty) array on disk.
+	array, err := tiledb.NewArray(ctx, variableLengthArrayName)
+	checkError(err)
+	err = array.Create(schema)
+	checkError(err)
+}
+
+func writeVariableLengthArray() {
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
+
+	// Prepare some data for the array
+	a1Data := []byte("a" + "bb" + "ccc" + "dd" + "eee" + "f" + "g" + "hhh" +
+		"i" + "jjj" + "kk" + "l" + "m" + "n" + "oo" + "p")
+	a1Off := []uint64{
+		0, 1, 3, 6, 8, 11, 12, 13, 16, 17, 20, 22, 23, 24, 25, 27}
+	a2Data := []int32{
+		1, 1, 2, 2, 3, 4, 5, 6, 6, 7, 7, 8, 8,
+		8, 9, 9, 10, 11, 12, 12, 13, 14, 14, 14, 15, 16}
+	a2ElOff := []uint64{
+		0, 2, 4, 5, 6, 7, 9, 11, 14, 16, 17, 18, 20, 21, 24, 25}
+
+	a2Off := make([]uint64, 16)
+	for i := range a2ElOff {
+		a2Off[i] = a2ElOff[i] * uint64(unsafe.Sizeof(int32(0)))
+	}
+
+	// Open the array for writing and create the query.
+	array, err := tiledb.NewArray(ctx, variableLengthArrayName)
+	checkError(err)
+	err = array.Open(tiledb.TILEDB_WRITE)
+	checkError(err)
+	query, err := tiledb.NewQuery(ctx, array)
+	checkError(err)
+	err = query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+	_, _, err = query.SetBufferVar("a1", a1Off, a1Data)
+	checkError(err)
+	_, _, err = query.SetBufferVar("a2", a2Off, a2Data)
+	checkError(err)
+
+	// Perform the write and close the array.
+	err = query.Submit()
+	checkError(err)
+	err = array.Close()
+	checkError(err)
+}
+
+func printResultsVariableLength(
+	a1Off []uint64,
+	a1Data []byte,
+	a2Off []uint64,
+	a2Data []int32,
+	resultElMap map[string][2]uint64) {
+
+	// Get the string sizes
+	resultElA1Off := resultElMap["a1"][0]
+
+	var a1StrSizes []uint64
+	for i := 0; i < int(resultElA1Off)-1; i++ {
+		a1StrSizes = append(a1StrSizes, a1Off[i+1]-a1Off[i])
+	}
+
+	resultA1DataSize := resultElMap["a1"][1] *
+		uint64(unsafe.Sizeof(byte(0)))
+	a1StrSizes = append(a1StrSizes,
+		resultA1DataSize-a1Off[resultElA1Off-1])
+
+	// Get the strings
+	a1Str := make([][]byte, resultElA1Off)
+	for i := 0; i < int(resultElA1Off); i++ {
+		a1Str[i] = make([]byte, 0)
+		for j := 0; j < int(a1StrSizes[i]); j++ {
+			a1Str[i] = append(a1Str[i], a1Data[a1Off[i]])
+		}
+	}
+
+	// Get the element offsets
+	var a2ElOff []uint64
+	resultElA2Off := resultElMap["a2"][0]
+	for i := 0; i < int(resultElA2Off); i++ {
+		a2ElOff = append(a2ElOff, a2Off[i]/uint64(unsafe.Sizeof(int32(0))))
+	}
+
+	// Get the number of elements per cell value
+	var a2CellEl []uint64
+	for i := 0; i < int(resultElA2Off)-1; i++ {
+		a2CellEl = append(a2CellEl, a2ElOff[i+1]-a2ElOff[i])
+	}
+	resultElA2Data := resultElMap["a2"][1]
+	a2CellEl = append(a2CellEl, resultElA2Data-a2ElOff[len(a2ElOff)-1])
+
+	// Print the results
+	for i := 0; i < int(resultElA1Off); i++ {
+		fmt.Printf("a1: %s, a2: ", string(a1Str[i]))
+		for j := 0; j < int(a2CellEl[i]); j++ {
+			fmt.Printf("%d", a2Data[a2ElOff[i]+uint64(j)])
+		}
+		fmt.Printf("\n")
+	}
+}
+
+func readVariableLengthArray() {
+	// Create TileDB context
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
+
+	// Prepare the array for reading
+	array, err := tiledb.NewArray(ctx, variableLengthArrayName)
+	checkError(err)
+	err = array.Open(tiledb.TILEDB_READ)
+	checkError(err)
+
+	// Slice only rows 1, 2 and cols 2, 3, 4
+	subArray := []int32{1, 2, 2, 4}
+
+	// Prepare the query
+	query, err := tiledb.NewQuery(ctx, array)
+	checkError(err)
+	err = query.SetSubArray(subArray)
+	checkError(err)
+
+	maxElMap, err := array.MaxBufferElements(subArray)
+	checkError(err)
+
+	a1Off := make([]uint64, maxElMap["a1"][0])
+	a1Data := make([]byte, maxElMap["a1"][1])
+	a2Off := make([]uint64, maxElMap["a2"][0])
+	a2Data := make([]int32, maxElMap["a2"][1])
+
+	err = query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+	_, _, err = query.SetBufferVar("a1", a1Off, a1Data)
+	checkError(err)
+	_, _, err = query.SetBufferVar("a2", a2Off, a2Data)
+	checkError(err)
+
+	// Submit the query and close the array.
+	err = query.Submit()
+	checkError(err)
+
+	elements, err := query.ResultBufferElements()
+	checkError(err)
+	printResultsVariableLength(a1Off, a1Data, a2Off, a2Data, elements)
+
+	err = array.Close()
+	checkError(err)
+}
+
+func ExampleVariableLengthArray() {
+	createVariableLengthArray()
+	writeVariableLengthArray()
+	readVariableLengthArray()
+
+	// Cleanup example so unit tests are clean
+	if _, err := os.Stat(variableLengthArrayName); err == nil {
+		err = os.RemoveAll(variableLengthArrayName)
+		checkError(err)
+	}
+
+	// Output: a1: bb, a2: 22
+	// a1: ccc, a2: 3
+	// a1: dd, a2: 4
+	// a1: f, a2: 66
+	// a1: g, a2: 77
+	// a1: hhh, a2: 888
+}

--- a/examples/vfs_test.go
+++ b/examples/vfs_test.go
@@ -1,0 +1,182 @@
+package examples
+
+import (
+	"encoding/binary"
+	"fmt"
+	"github.com/TileDB-Inc/TileDB-Go"
+	"math"
+	"os"
+	"unsafe"
+)
+
+var vfsFileName = "tiledb_vfs.bin"
+
+func dirsFiles() {
+	// Create a TileDB context.
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
+
+	// Create config object
+	config, err := tiledb.NewConfig()
+	checkError(err)
+
+	// Create TileDB VFS.
+	vfs, err := tiledb.NewVFS(ctx, config)
+	checkError(err)
+
+	isDir, err := vfs.IsDir("dir_A")
+	checkError(err)
+
+	if !isDir {
+		err = vfs.CreateDir("dir_A")
+		checkError(err)
+		fmt.Println("Created 'dir_A'")
+	} else {
+		fmt.Println("'dir_A' already exists")
+	}
+
+	// Creating an (empty) file
+	isFile, err := vfs.IsFile("dir_A/file_A")
+	checkError(err)
+
+	if !isFile {
+		err = vfs.Touch("dir_A/file_A")
+		checkError(err)
+		fmt.Println("Created empty file 'dir_A/file_A'")
+	} else {
+		fmt.Println("'dir_A/file_A' already exists")
+	}
+
+	// Getting the file size
+	fileSize, err := vfs.FileSize("dir_A/file_A")
+	checkError(err)
+	fmt.Printf("Size of file 'dir_A/file_A': %d\n", fileSize)
+
+	// Moving files (moving directories is similar)
+	fmt.Println("Moving file 'dir_A/file_A' to 'dir_A/file_B'")
+	err = vfs.MoveFile("dir_A/file_A", "dir_A/file_B")
+	checkError(err)
+
+	// Deleting files and directories
+	fmt.Println("Deleting 'dir_A/file_B' and 'dir_A'")
+	err = vfs.RemoveFile("dir_A/file_B")
+	checkError(err)
+	err = vfs.RemoveDir("dir_A")
+	checkError(err)
+}
+
+func float32FromBytes(bytes []byte) float32 {
+	bits := binary.LittleEndian.Uint32(bytes)
+	float := math.Float32frombits(bits)
+	return float
+}
+
+func float32ToBytes(float float32) []byte {
+	bits := math.Float32bits(float)
+	bytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(bytes, bits)
+	return bytes
+}
+
+func write() {
+	// Create TileDB context
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
+
+	// Create config object
+	config, err := tiledb.NewConfig()
+	checkError(err)
+
+	// Create TileDB VFS.
+	vfs, err := tiledb.NewVFS(ctx, config)
+	checkError(err)
+
+	// Write binary data
+	fh1, err := vfs.Open(vfsFileName, tiledb.TILEDB_VFS_WRITE)
+	if err != nil {
+		fmt.Printf("Error opening file '%s'\n", vfsFileName)
+	}
+
+	var f1 float32 = 153.0
+	s1 := "abcd"
+	err = vfs.Write(fh1, float32ToBytes(f1))
+	checkError(err)
+	err = vfs.Write(fh1, []byte(s1))
+	checkError(err)
+
+	// Write binary data again - this will overwrite the previous file
+	fh2, err := vfs.Open("tiledb_vfs.bin", tiledb.TILEDB_VFS_WRITE)
+	if err != nil {
+		fmt.Printf("Error opening file '%s' for write.\n", vfsFileName)
+	}
+
+	var f2 float32 = 153.1
+	s2 := "abcdef"
+	err = vfs.Write(fh2, float32ToBytes(f2))
+	checkError(err)
+	err = vfs.Write(fh2, []byte(s2))
+	checkError(err)
+
+	// Append binary data to existing file (this will NOT work on S3)
+	fh3, err := vfs.Open("tiledb_vfs.bin", tiledb.TILEDB_VFS_APPEND)
+	if err != nil {
+		fmt.Printf("Error opening file '%s' for append.\n", vfsFileName)
+	}
+
+	s3 := "ghijkl"
+	err = vfs.Write(fh3, []byte(s3))
+	checkError(err)
+}
+
+func read() {
+	// Create TileDB context
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
+
+	// Create config object
+	config, err := tiledb.NewConfig()
+	checkError(err)
+
+	// Create TileDB VFS.
+	vfs, err := tiledb.NewVFS(ctx, config)
+	checkError(err)
+
+	// Read binary data
+	fh, err := vfs.Open("tiledb_vfs.bin", tiledb.TILEDB_VFS_READ)
+	if err != nil {
+		fmt.Printf("Error opening file '%s'\n", vfsFileName)
+	}
+
+	sizefFile, err := vfs.FileSize(vfsFileName)
+	checkError(err)
+
+	var f float32 = 0.0
+	sizeOfFloat32 := uint64(unsafe.Sizeof(f))
+	f1, err := vfs.Read(fh, 0, sizeOfFloat32)
+	checkError(err)
+	s1, err := vfs.Read(fh, sizeOfFloat32, sizefFile-sizeOfFloat32)
+	checkError(err)
+
+	fmt.Println("Binary read:")
+	fmt.Println(float32FromBytes(f1))
+	fmt.Println(string(s1))
+
+	// Clean up
+	err = os.RemoveAll(vfsFileName)
+	checkError(err)
+}
+
+func ExampleVfs() {
+	dirsFiles()
+	write()
+	read()
+
+	// Output: Created 'dir_A'
+	// Created empty file 'dir_A/file_A'
+	// Size of file 'dir_A/file_A': 0
+	// Moving file 'dir_A/file_A' to 'dir_A/file_B'
+	// Deleting 'dir_A/file_B' and 'dir_A'
+	// Binary read:
+	// 153.1
+	// abcdefghijkl
+}

--- a/examples/writing_dense_global_test.go
+++ b/examples/writing_dense_global_test.go
@@ -1,5 +1,5 @@
 /**
- * @file   quickstart_sparse_test.go
+ * @file   writing_dense_global_test.go
  *
  * @section LICENSE
  *
@@ -27,45 +27,42 @@
  *
  * @section DESCRIPTION
  *
- * This is a part of the TileDB quickstart tutorial:
- * 	 https://docs.tiledb.io/en/latest/quickstart.html
+ * This is a part of the TileDB tutorial:
+ *   https://docs.tiledb.io/en/latest/tutorials/writing-dense.html
  *
  * When run, this program will create a simple 2D dense array, write some data
- * to it, and read a slice of the data back in the layout of the user's choice
- * (passed as an argument to the program: "row", "col", or "global").
- *
+ * to it in global layout, and read the entire array data back.
  */
 
 package examples
 
 import (
 	"fmt"
-	tiledb "github.com/TileDB-Inc/TileDB-Go"
+	"github.com/TileDB-Inc/TileDB-Go"
 	"os"
 )
 
 // Name of array.
-var sparseArrayName = "quickstart_sparse"
+var denseGlobalArrayName = "writing_dense_global_array"
 
-func createSparseArray() {
+func createDenseGlobalArray() {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
-	// The array will be 4x4 with dimensions "rows" and "cols",
-	// with domain [1,4].
+	// The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
+	// and space tiles 2x2
 	domain, err := tiledb.NewDomain(ctx)
 	checkError(err)
-	rowDim, err := tiledb.NewDimension(ctx, "rows", []int32{1, 4}, int32(4))
+	rowDim, err := tiledb.NewDimension(ctx, "rows", []int32{1, 4}, int32(2))
 	checkError(err)
-	colDim, err := tiledb.NewDimension(ctx, "cols", []int32{1, 4}, int32(4))
+	colDim, err := tiledb.NewDimension(ctx, "cols", []int32{1, 4}, int32(2))
 	checkError(err)
 	err = domain.AddDimensions(rowDim, colDim)
 	checkError(err)
 
-	// The array will be sparse.
-	schema, err := tiledb.NewArraySchema(ctx, tiledb.TILEDB_SPARSE)
-	checkError(err)
+	// The array will be dense.
+	schema, err := tiledb.NewArraySchema(ctx, tiledb.TILEDB_DENSE)
 	err = schema.SetDomain(domain)
 	checkError(err)
 	err = schema.SetCellOrder(tiledb.TILEDB_ROW_MAJOR)
@@ -74,67 +71,74 @@ func createSparseArray() {
 	checkError(err)
 
 	// Add a single attribute "a" so each (i,j) cell can store an integer.
-	a, err := tiledb.NewAttribute(ctx, "a", tiledb.TILEDB_UINT32)
+	a, err := tiledb.NewAttribute(ctx, "a", tiledb.TILEDB_INT32)
 	checkError(err)
 	err = schema.AddAttributes(a)
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	array, err := tiledb.NewArray(ctx, denseGlobalArrayName)
 	checkError(err)
 	err = array.Create(schema)
 	checkError(err)
 }
 
-func writeSparseArray() {
+func writeDenseGlobalArray() {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
-	// Write some simple data to cells (1, 1), (2, 4) and (2, 3).
-	coords := []int32{1, 1, 2, 4, 2, 3}
-	data := []uint32{1, 2, 3}
+	subarray := []int32{1, 4, 1, 2}
 
-	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	// Open the array for writing.
+	array, err := tiledb.NewArray(ctx, denseGlobalArrayName)
 	checkError(err)
 	err = array.Open(tiledb.TILEDB_WRITE)
 	checkError(err)
 	query, err := tiledb.NewQuery(ctx, array)
 	checkError(err)
-	err = query.SetLayout(tiledb.TILEDB_UNORDERED)
+
+	// First submission
+	data := []int32{1, 2, 3, 4}
+	err = query.SetLayout(tiledb.TILEDB_GLOBAL_ORDER)
 	checkError(err)
 	_, err = query.SetBuffer("a", data)
 	checkError(err)
-	_, err = query.SetCoordinates(coords)
+	err = query.SetSubArray(subarray)
 	checkError(err)
 
-	// Perform the write and close the array.
+	// Perform the write
 	err = query.Submit()
+	checkError(err)
+
+	// Second submission, after updating the buffer contents
+	for i := 0; i < 4; i++ {
+		data[i] = int32(5 + i)
+	}
+	err = query.Submit()
+	checkError(err)
+
+	// IMPORTANT!
+	err = query.Finalize()
 	checkError(err)
 	err = array.Close()
 	checkError(err)
 }
 
-func readSparseArray() {
+func readDenseGlobalArray() {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	array, err := tiledb.NewArray(ctx, denseGlobalArrayName)
 	checkError(err)
 	err = array.Open(tiledb.TILEDB_READ)
 	checkError(err)
 
-	// Slice only rows 1, 2 and cols 2, 3, 4
-	subArray := []int32{1, 2, 2, 4}
+	// Read the entire array
+	subArray := []int32{1, 4, 1, 4}
 
-	// Prepare the vector that will hold the results
-	// We take the upper bound on the result size as we do not know how large
-	// a buffer is needed since the array is sparse
-	maxElements, err := array.MaxBufferElements(subArray)
-	checkError(err)
-	data := make([]uint32, maxElements["a"][1])
-	coords := make([]int32, maxElements[tiledb.TILEDB_COORDS][1])
+	// Prepare the vector that will hold the result (of size 16 elements)
+	data := make([]int32, 16)
 
 	// Prepare the query
 	query, err := tiledb.NewQuery(ctx, array)
@@ -145,41 +149,27 @@ func readSparseArray() {
 	checkError(err)
 	_, err = query.SetBuffer("a", data)
 	checkError(err)
-	_, err = query.SetCoordinates(coords)
-	checkError(err)
 
 	// Submit the query and close the array.
 	err = query.Submit()
 	checkError(err)
-
-	// Print out the results.
-	elements, err := query.ResultBufferElements()
-	checkError(err)
-	resultNum := elements["a"][1]
-	for r := 0; r < int(resultNum); r++ {
-		i := coords[2*r]
-		j := coords[2*r+1]
-		a := data[r]
-		fmt.Printf("Cell (%d, %d) has data %d\n", i, j, a)
-	}
-
 	err = array.Close()
 	checkError(err)
+
+	// Print out the results.
+	fmt.Println(data)
 }
 
-// ExampleSparseArray shows and example creation, writing and reading of a
-// sparse array
-func ExampleSparseArray() {
-	createSparseArray()
-	writeSparseArray()
-	readSparseArray()
+func ExampleWritingDenseGlobal() {
+	createDenseGlobalArray()
+	writeDenseGlobalArray()
+	readDenseGlobalArray()
 
 	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(sparseArrayName); err == nil {
-		err = os.RemoveAll(sparseArrayName)
+	if _, err := os.Stat(denseGlobalArrayName); err == nil {
+		err = os.RemoveAll(denseGlobalArrayName)
 		checkError(err)
 	}
 
-	// Output: Cell (2, 3) has data 3
-	// Cell (2, 4) has data 2
+	// Output: [1 2 -2147483648 -2147483648 3 4 -2147483648 -2147483648 5 6 -2147483648 -2147483648 7 8 -2147483648 -2147483648]
 }

--- a/examples/writing_dense_multiple_test.go
+++ b/examples/writing_dense_multiple_test.go
@@ -1,5 +1,5 @@
 /**
- * @file   quickstart_sparse_test.go
+ * @file   writing_dense_mutliple_test.go
  *
  * @section LICENSE
  *
@@ -27,45 +27,42 @@
  *
  * @section DESCRIPTION
  *
- * This is a part of the TileDB quickstart tutorial:
- * 	 https://docs.tiledb.io/en/latest/quickstart.html
+ * This is a part of the TileDB tutorial:
+ *   https://docs.tiledb.io/en/latest/tutorials/writing-dense.html
  *
  * When run, this program will create a simple 2D dense array, write some data
- * to it, and read a slice of the data back in the layout of the user's choice
- * (passed as an argument to the program: "row", "col", or "global").
- *
+ * to it with two write queries, and read the entire array data back.
  */
 
 package examples
 
 import (
 	"fmt"
-	tiledb "github.com/TileDB-Inc/TileDB-Go"
+	"github.com/TileDB-Inc/TileDB-Go"
 	"os"
 )
 
 // Name of array.
-var sparseArrayName = "quickstart_sparse"
+var denseMultipleArrayName = "writing_dense_multiple_array"
 
-func createSparseArray() {
+func createDenseMultipleArray() {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
-	// The array will be 4x4 with dimensions "rows" and "cols",
-	// with domain [1,4].
+	// The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
+	// and space tiles 2x2
 	domain, err := tiledb.NewDomain(ctx)
 	checkError(err)
-	rowDim, err := tiledb.NewDimension(ctx, "rows", []int32{1, 4}, int32(4))
+	rowDim, err := tiledb.NewDimension(ctx, "rows", []int32{1, 4}, int32(2))
 	checkError(err)
-	colDim, err := tiledb.NewDimension(ctx, "cols", []int32{1, 4}, int32(4))
+	colDim, err := tiledb.NewDimension(ctx, "cols", []int32{1, 4}, int32(2))
 	checkError(err)
 	err = domain.AddDimensions(rowDim, colDim)
 	checkError(err)
 
-	// The array will be sparse.
-	schema, err := tiledb.NewArraySchema(ctx, tiledb.TILEDB_SPARSE)
-	checkError(err)
+	// The array will be dense.
+	schema, err := tiledb.NewArraySchema(ctx, tiledb.TILEDB_DENSE)
 	err = schema.SetDomain(domain)
 	checkError(err)
 	err = schema.SetCellOrder(tiledb.TILEDB_ROW_MAJOR)
@@ -74,38 +71,39 @@ func createSparseArray() {
 	checkError(err)
 
 	// Add a single attribute "a" so each (i,j) cell can store an integer.
-	a, err := tiledb.NewAttribute(ctx, "a", tiledb.TILEDB_UINT32)
+	a, err := tiledb.NewAttribute(ctx, "a", tiledb.TILEDB_INT32)
 	checkError(err)
 	err = schema.AddAttributes(a)
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	array, err := tiledb.NewArray(ctx, denseMultipleArrayName)
 	checkError(err)
 	err = array.Create(schema)
 	checkError(err)
 }
 
-func writeSparseArray() {
+func writeDenseMultipleArray1() {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
-	// Write some simple data to cells (1, 1), (2, 4) and (2, 3).
-	coords := []int32{1, 1, 2, 4, 2, 3}
-	data := []uint32{1, 2, 3}
+	subarray := []int32{1, 2, 1, 2}
 
-	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	// Open the array for writing.
+	array, err := tiledb.NewArray(ctx, denseMultipleArrayName)
 	checkError(err)
 	err = array.Open(tiledb.TILEDB_WRITE)
 	checkError(err)
 	query, err := tiledb.NewQuery(ctx, array)
 	checkError(err)
-	err = query.SetLayout(tiledb.TILEDB_UNORDERED)
+
+	// First submission
+	data := []int32{1, 2, 3, 4}
+	err = query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
 	checkError(err)
 	_, err = query.SetBuffer("a", data)
 	checkError(err)
-	_, err = query.SetCoordinates(coords)
+	err = query.SetSubArray(subarray)
 	checkError(err)
 
 	// Perform the write and close the array.
@@ -115,26 +113,51 @@ func writeSparseArray() {
 	checkError(err)
 }
 
-func readSparseArray() {
+func writeDenseMultipleArray2() {
+	ctx, err := tiledb.NewContext(nil)
+	checkError(err)
+
+	subarray := []int32{2, 3, 1, 4}
+
+	// Open the array for writing.
+	array, err := tiledb.NewArray(ctx, denseMultipleArrayName)
+	checkError(err)
+	err = array.Open(tiledb.TILEDB_WRITE)
+	checkError(err)
+	query, err := tiledb.NewQuery(ctx, array)
+	checkError(err)
+
+	// First submission
+	data := []int32{5, 6, 7, 8, 9, 10, 11, 12}
+	err = query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
+	checkError(err)
+	_, err = query.SetBuffer("a", data)
+	checkError(err)
+	err = query.SetSubArray(subarray)
+	checkError(err)
+
+	// Perform the write and close the array.
+	err = query.Submit()
+	checkError(err)
+	err = array.Close()
+	checkError(err)
+}
+
+func readDenseMultipleArray() {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	array, err := tiledb.NewArray(ctx, denseMultipleArrayName)
 	checkError(err)
 	err = array.Open(tiledb.TILEDB_READ)
 	checkError(err)
 
-	// Slice only rows 1, 2 and cols 2, 3, 4
-	subArray := []int32{1, 2, 2, 4}
+	// Read the entire array
+	subArray := []int32{1, 4, 1, 4}
 
-	// Prepare the vector that will hold the results
-	// We take the upper bound on the result size as we do not know how large
-	// a buffer is needed since the array is sparse
-	maxElements, err := array.MaxBufferElements(subArray)
-	checkError(err)
-	data := make([]uint32, maxElements["a"][1])
-	coords := make([]int32, maxElements[tiledb.TILEDB_COORDS][1])
+	// Prepare the vector that will hold the result (of size 16 elements)
+	data := make([]int32, 16)
 
 	// Prepare the query
 	query, err := tiledb.NewQuery(ctx, array)
@@ -145,41 +168,28 @@ func readSparseArray() {
 	checkError(err)
 	_, err = query.SetBuffer("a", data)
 	checkError(err)
-	_, err = query.SetCoordinates(coords)
-	checkError(err)
 
 	// Submit the query and close the array.
 	err = query.Submit()
 	checkError(err)
-
-	// Print out the results.
-	elements, err := query.ResultBufferElements()
-	checkError(err)
-	resultNum := elements["a"][1]
-	for r := 0; r < int(resultNum); r++ {
-		i := coords[2*r]
-		j := coords[2*r+1]
-		a := data[r]
-		fmt.Printf("Cell (%d, %d) has data %d\n", i, j, a)
-	}
-
 	err = array.Close()
 	checkError(err)
+
+	// Print out the results.
+	fmt.Println(data)
 }
 
-// ExampleSparseArray shows and example creation, writing and reading of a
-// sparse array
-func ExampleSparseArray() {
-	createSparseArray()
-	writeSparseArray()
-	readSparseArray()
+func ExampleWritingDenseMultiple() {
+	createDenseMultipleArray()
+	writeDenseMultipleArray1()
+	writeDenseMultipleArray2()
+	readDenseMultipleArray()
 
 	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(sparseArrayName); err == nil {
-		err = os.RemoveAll(sparseArrayName)
+	if _, err := os.Stat(denseMultipleArrayName); err == nil {
+		err = os.RemoveAll(denseMultipleArrayName)
 		checkError(err)
 	}
 
-	// Output: Cell (2, 3) has data 3
-	// Cell (2, 4) has data 2
+	// Output: [1 2 -2147483648 -2147483648 5 6 7 8 9 10 11 12 -2147483648 -2147483648 -2147483648 -2147483648]
 }

--- a/examples/writing_dense_padding_test.go
+++ b/examples/writing_dense_padding_test.go
@@ -1,5 +1,5 @@
 /**
- * @file   quickstart_sparse_test.go
+ * @file   writing_dense_padding_test.go
  *
  * @section LICENSE
  *
@@ -27,45 +27,42 @@
  *
  * @section DESCRIPTION
  *
- * This is a part of the TileDB quickstart tutorial:
- * 	 https://docs.tiledb.io/en/latest/quickstart.html
+ * This is a part of the TileDB tutorial:
+ *   https://docs.tiledb.io/en/latest/tutorials/writing-dense.html
  *
  * When run, this program will create a simple 2D dense array, write some data
- * to it, and read a slice of the data back in the layout of the user's choice
- * (passed as an argument to the program: "row", "col", or "global").
- *
+ * to it in a way that some space is empty, and read the entire array data back.
  */
 
 package examples
 
 import (
 	"fmt"
-	tiledb "github.com/TileDB-Inc/TileDB-Go"
+	"github.com/TileDB-Inc/TileDB-Go"
 	"os"
 )
 
 // Name of array.
-var sparseArrayName = "quickstart_sparse"
+var densePaddingArrayName = "writing_dense_padding_array"
 
-func createSparseArray() {
+func createDensePaddingArray() {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
-	// The array will be 4x4 with dimensions "rows" and "cols",
-	// with domain [1,4].
+	// The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
+	// and space tiles 2x2
 	domain, err := tiledb.NewDomain(ctx)
 	checkError(err)
-	rowDim, err := tiledb.NewDimension(ctx, "rows", []int32{1, 4}, int32(4))
+	rowDim, err := tiledb.NewDimension(ctx, "rows", []int32{1, 4}, int32(2))
 	checkError(err)
-	colDim, err := tiledb.NewDimension(ctx, "cols", []int32{1, 4}, int32(4))
+	colDim, err := tiledb.NewDimension(ctx, "cols", []int32{1, 4}, int32(2))
 	checkError(err)
 	err = domain.AddDimensions(rowDim, colDim)
 	checkError(err)
 
-	// The array will be sparse.
-	schema, err := tiledb.NewArraySchema(ctx, tiledb.TILEDB_SPARSE)
-	checkError(err)
+	// The array will be dense.
+	schema, err := tiledb.NewArraySchema(ctx, tiledb.TILEDB_DENSE)
 	err = schema.SetDomain(domain)
 	checkError(err)
 	err = schema.SetCellOrder(tiledb.TILEDB_ROW_MAJOR)
@@ -74,38 +71,39 @@ func createSparseArray() {
 	checkError(err)
 
 	// Add a single attribute "a" so each (i,j) cell can store an integer.
-	a, err := tiledb.NewAttribute(ctx, "a", tiledb.TILEDB_UINT32)
+	a, err := tiledb.NewAttribute(ctx, "a", tiledb.TILEDB_INT32)
 	checkError(err)
 	err = schema.AddAttributes(a)
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	array, err := tiledb.NewArray(ctx, densePaddingArrayName)
 	checkError(err)
 	err = array.Create(schema)
 	checkError(err)
 }
 
-func writeSparseArray() {
+func writeDensePaddingArray() {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
-	// Write some simple data to cells (1, 1), (2, 4) and (2, 3).
-	coords := []int32{1, 1, 2, 4, 2, 3}
-	data := []uint32{1, 2, 3}
+	subarray := []int32{2, 3, 1, 2}
 
-	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	// Open the array for writing.
+	array, err := tiledb.NewArray(ctx, densePaddingArrayName)
 	checkError(err)
 	err = array.Open(tiledb.TILEDB_WRITE)
 	checkError(err)
 	query, err := tiledb.NewQuery(ctx, array)
 	checkError(err)
-	err = query.SetLayout(tiledb.TILEDB_UNORDERED)
+
+	// First submission
+	data := []int32{1, 2, 3, 4}
+	err = query.SetLayout(tiledb.TILEDB_ROW_MAJOR)
 	checkError(err)
 	_, err = query.SetBuffer("a", data)
 	checkError(err)
-	_, err = query.SetCoordinates(coords)
+	err = query.SetSubArray(subarray)
 	checkError(err)
 
 	// Perform the write and close the array.
@@ -115,26 +113,21 @@ func writeSparseArray() {
 	checkError(err)
 }
 
-func readSparseArray() {
+func readDensePaddingArray() {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	array, err := tiledb.NewArray(ctx, densePaddingArrayName)
 	checkError(err)
 	err = array.Open(tiledb.TILEDB_READ)
 	checkError(err)
 
-	// Slice only rows 1, 2 and cols 2, 3, 4
-	subArray := []int32{1, 2, 2, 4}
+	// Read the entire array
+	subArray := []int32{1, 4, 1, 4}
 
-	// Prepare the vector that will hold the results
-	// We take the upper bound on the result size as we do not know how large
-	// a buffer is needed since the array is sparse
-	maxElements, err := array.MaxBufferElements(subArray)
-	checkError(err)
-	data := make([]uint32, maxElements["a"][1])
-	coords := make([]int32, maxElements[tiledb.TILEDB_COORDS][1])
+	// Prepare the vector that will hold the result (of size 16 elements)
+	data := make([]int32, 16)
 
 	// Prepare the query
 	query, err := tiledb.NewQuery(ctx, array)
@@ -145,41 +138,27 @@ func readSparseArray() {
 	checkError(err)
 	_, err = query.SetBuffer("a", data)
 	checkError(err)
-	_, err = query.SetCoordinates(coords)
-	checkError(err)
 
 	// Submit the query and close the array.
 	err = query.Submit()
 	checkError(err)
-
-	// Print out the results.
-	elements, err := query.ResultBufferElements()
-	checkError(err)
-	resultNum := elements["a"][1]
-	for r := 0; r < int(resultNum); r++ {
-		i := coords[2*r]
-		j := coords[2*r+1]
-		a := data[r]
-		fmt.Printf("Cell (%d, %d) has data %d\n", i, j, a)
-	}
-
 	err = array.Close()
 	checkError(err)
+
+	// Print out the results.
+	fmt.Println(data)
 }
 
-// ExampleSparseArray shows and example creation, writing and reading of a
-// sparse array
-func ExampleSparseArray() {
-	createSparseArray()
-	writeSparseArray()
-	readSparseArray()
+func ExampleWritingDensePadding() {
+	createDensePaddingArray()
+	writeDensePaddingArray()
+	readDensePaddingArray()
 
 	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(sparseArrayName); err == nil {
-		err = os.RemoveAll(sparseArrayName)
+	if _, err := os.Stat(densePaddingArrayName); err == nil {
+		err = os.RemoveAll(densePaddingArrayName)
 		checkError(err)
 	}
 
-	// Output: Cell (2, 3) has data 3
-	// Cell (2, 4) has data 2
+	// Output: [-2147483648 -2147483648 -2147483648 -2147483648 1 2 -2147483648 -2147483648 3 4 -2147483648 -2147483648 -2147483648 -2147483648 -2147483648 -2147483648]
 }

--- a/examples/writing_sparse_global_test.go
+++ b/examples/writing_sparse_global_test.go
@@ -1,5 +1,5 @@
 /**
- * @file   quickstart_sparse_test.go
+ * @file   writing_sparse_global_test.go
  *
  * @section LICENSE
  *
@@ -27,12 +27,11 @@
  *
  * @section DESCRIPTION
  *
- * This is a part of the TileDB quickstart tutorial:
- * 	 https://docs.tiledb.io/en/latest/quickstart.html
+ * This is a part of the TileDB tutorial:
+ *   https://docs.tiledb.io/en/latest/tutorials/writing-sparse.html
  *
- * When run, this program will create a simple 2D dense array, write some data
- * to it, and read a slice of the data back in the layout of the user's choice
- * (passed as an argument to the program: "row", "col", or "global").
+ * When run, this program will create a simple 2D sparse array, write some data
+ * to it in global order, and read the data back.
  *
  */
 
@@ -40,14 +39,14 @@ package examples
 
 import (
 	"fmt"
-	tiledb "github.com/TileDB-Inc/TileDB-Go"
+	"github.com/TileDB-Inc/TileDB-Go"
 	"os"
 )
 
 // Name of array.
-var sparseArrayName = "quickstart_sparse"
+var sparseGlobalArrayName = "writing_sparse_global_array"
 
-func createSparseArray() {
+func createSparseGlobalArray() {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -74,66 +73,82 @@ func createSparseArray() {
 	checkError(err)
 
 	// Add a single attribute "a" so each (i,j) cell can store an integer.
-	a, err := tiledb.NewAttribute(ctx, "a", tiledb.TILEDB_UINT32)
+	a, err := tiledb.NewAttribute(ctx, "a", tiledb.TILEDB_INT32)
 	checkError(err)
 	err = schema.AddAttributes(a)
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	array, err := tiledb.NewArray(ctx, sparseGlobalArrayName)
 	checkError(err)
 	err = array.Create(schema)
 	checkError(err)
 }
 
-func writeSparseArray() {
+func writeSparseGlobalArray() {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
-	// Write some simple data to cells (1, 1), (2, 4) and (2, 3).
-	coords := []int32{1, 1, 2, 4, 2, 3}
-	data := []uint32{1, 2, 3}
-
-	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	// Open the array for writing.
+	array, err := tiledb.NewArray(ctx, sparseGlobalArrayName)
 	checkError(err)
 	err = array.Open(tiledb.TILEDB_WRITE)
 	checkError(err)
 	query, err := tiledb.NewQuery(ctx, array)
 	checkError(err)
-	err = query.SetLayout(tiledb.TILEDB_UNORDERED)
-	checkError(err)
-	_, err = query.SetBuffer("a", data)
-	checkError(err)
-	_, err = query.SetCoordinates(coords)
+	err = query.SetLayout(tiledb.TILEDB_GLOBAL_ORDER)
 	checkError(err)
 
-	// Perform the write and close the array.
+	// First submission
+	coords1 := []int32{1, 1, 2, 4}
+	data1 := []int32{1, 2}
+	_, err = query.SetBuffer("a", data1)
+	checkError(err)
+	_, err = query.SetCoordinates(coords1)
+	checkError(err)
+
+	// Perform the write.
 	err = query.Submit()
+	checkError(err)
+
+	// Submit second query
+	coords2 := []int32{2, 3}
+	data2 := []int32{3}
+	_, err = query.SetBuffer("a", data2)
+	checkError(err)
+	_, err = query.SetCoordinates(coords2)
+	checkError(err)
+
+	// Perform the write.
+	err = query.Submit()
+	checkError(err)
+
+	// IMPORTANT!
+	err = query.Finalize()
 	checkError(err)
 	err = array.Close()
 	checkError(err)
 }
 
-func readSparseArray() {
+func readSparseGlobalArray() {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	array, err := tiledb.NewArray(ctx, sparseGlobalArrayName)
 	checkError(err)
 	err = array.Open(tiledb.TILEDB_READ)
 	checkError(err)
 
-	// Slice only rows 1, 2 and cols 2, 3, 4
-	subArray := []int32{1, 2, 2, 4}
+	// Read the whole array
+	subArray := []int32{1, 4, 1, 4}
 
 	// Prepare the vector that will hold the results
 	// We take the upper bound on the result size as we do not know how large
 	// a buffer is needed since the array is sparse
 	maxElements, err := array.MaxBufferElements(subArray)
 	checkError(err)
-	data := make([]uint32, maxElements["a"][1])
+	data := make([]int32, maxElements["a"][1])
 	coords := make([]int32, maxElements[tiledb.TILEDB_COORDS][1])
 
 	// Prepare the query
@@ -167,19 +182,18 @@ func readSparseArray() {
 	checkError(err)
 }
 
-// ExampleSparseArray shows and example creation, writing and reading of a
-// sparse array
-func ExampleSparseArray() {
-	createSparseArray()
-	writeSparseArray()
-	readSparseArray()
+func ExampleWritingSparseGlobal() {
+	createSparseGlobalArray()
+	writeSparseGlobalArray()
+	readSparseGlobalArray()
 
 	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(sparseArrayName); err == nil {
-		err = os.RemoveAll(sparseArrayName)
+	if _, err := os.Stat(sparseGlobalArrayName); err == nil {
+		err = os.RemoveAll(sparseGlobalArrayName)
 		checkError(err)
 	}
 
-	// Output: Cell (2, 3) has data 3
+	// Output: Cell (1, 1) has data 1
+	// Cell (2, 3) has data 3
 	// Cell (2, 4) has data 2
 }

--- a/vfs.go
+++ b/vfs.go
@@ -82,6 +82,21 @@ func (v *VFS) Free() {
 	}
 }
 
+// Config retrieves a copy of the config from vfs
+func (v *VFS) Config() (*Config, error) {
+	config := &Config{}
+	ret := C.tiledb_vfs_get_config(v.context.tiledbContext, v.tiledbVFS,
+		&config.tiledbConfig)
+
+	if ret == C.TILEDB_OOM {
+		return nil, fmt.Errorf("Out of Memory error in GetConfig")
+	} else if ret != C.TILEDB_OK {
+		return nil, fmt.Errorf("Unknown error in GetConfig")
+	}
+
+	return config, nil
+}
+
 // CreateBucket creates an object-store bucket with the input URI.
 func (v *VFS) CreateBucket(uri string) error {
 	curi := C.CString(uri)


### PR DESCRIPTION
This pull request is not ready to be merged
For reviewing the work so far

known facts:
- reading_incomplete should use ResultBufferElements

missing examples:
- fragments_consolidation
- map
- multi_attribute
- object
- quickstart_map
- using_tiledb_stats
- variable_length

