### PR TITLE
adds support for dl in LDFLAGS (CGO) for (ubuntu) linux

### DIFF
--- a/array.go
+++ b/array.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/array_schema.go
+++ b/array_schema.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/attribute.go
+++ b/attribute.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/context.go
+++ b/context.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/dimension.go
+++ b/dimension.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/domain.go
+++ b/domain.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/enums.go
+++ b/enums.go
@@ -3,6 +3,7 @@ package tiledb
 /*
 #cgo CFLAGS: -I/usr/local/include
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <tiledb/tiledb_enum.h>
 */

--- a/filter.go
+++ b/filter.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/filter_list.go
+++ b/filter_list.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/group.go
+++ b/group.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/kv.go
+++ b/kv.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/kv_item.go
+++ b/kv_item.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/kv_iter.go
+++ b/kv_iter.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/kv_schema.go
+++ b/kv_schema.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/query.go
+++ b/query.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/stats.go
+++ b/stats.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/version.go
+++ b/version.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 */
 import "C"

--- a/vfs.go
+++ b/vfs.go
@@ -2,6 +2,7 @@ package tiledb
 
 /*
 #cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */


### PR DESCRIPTION
Running examples in ubuntu result in following error:

/usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu/libtiledb.so: undefined reference to `dlclose'

Adding dl in list of LDFLAGS resolves the issue

Tested on OSX and found to work as expected