### PR TITLE
Add function to fetch metadata with limited value

### DIFF
--- a/scripts/ci_install_tiledb.sh
+++ b/scripts/ci_install_tiledb.sh
@@ -4,9 +4,9 @@ set -v -x
 
 original_dir=$PWD
 
-# Install tiledb using 1.6 release
+# Install tiledb using 1.7.7 release
 mkdir build_deps && cd build_deps \
-&& git clone https://github.com/TileDB-Inc/TileDB.git && cd TileDB \
+&& git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.7 && cd TileDB \
 && export deps_args="" \
 && export bootstrap_args="--enable=verbose,static-tiledb,serialization" \
 && mkdir -p build && cd build
@@ -14,7 +14,7 @@ mkdir build_deps && cd build_deps \
 # Configure and build TileDB
 ../bootstrap $bootstrap_args \
 && make -j4 \
-&& make -C tiledb install
+&& make -j4 -C tiledb install
 
 cd $original_dir
 


### PR DESCRIPTION
Add function to fetch metadata with limited value. This is helpful to get a sample of the metadata if the values are very large.