### PR TITLE
Add Get Range By Name support

### DIFF
--- a/examples/range_test.go
+++ b/examples/range_test.go
@@ -162,6 +162,12 @@ func getRangeNum() {
 
 	fmt.Printf("Number of ranges across dimension 0 is: %d\n", *rangeNum)
 
+	// Try using valid dim name
+	rangeNum, err = query.GetRangeNumFromName("rows")
+	checkError(err)
+
+	fmt.Printf("Number of ranges across dimension `rows` is: %d\n", *rangeNum)
+
 	err = array.Close()
 	checkError(err)
 }
@@ -209,6 +215,7 @@ func ExampleRange() {
 	// Output: Error adding query range: [TileDB::Dimension] Error: Range [1065353216, 1077936128] is out of domain bounds [1, 4] on dimension 'rows'
 	// Error adding query range: [TileDB::Query] Error: Cannot add range; Invalid dimension index
 	// Number of ranges across dimension 0 is: 1
+	// Number of ranges across dimension `rows` is: 1
 	// Range start for dimension 0, range 0 is: 1
 	// Range end for dimension 0, range 0 is: 4
 }


### PR DESCRIPTION
Adds support for:

```
int32_t tiledb_query_add_range_by_name(
    tiledb_ctx_t* ctx,
    tiledb_query_t* query,
    const char* dim_name,
    const void* start,
    const void* end,
    const void* stride);

TILEDB_EXPORT int32_t tiledb_query_add_range_var_by_name(
    tiledb_ctx_t* ctx,
    tiledb_query_t* query,
    const char* dim_name,
    const void* start,
    uint64_t start_size,
    const void* end,
    uint64_t end_size);

TILEDB_EXPORT int32_t tiledb_query_get_range_num_from_name(
    tiledb_ctx_t* ctx,
    const tiledb_query_t* query,
    const char* dim_name,
    uint64_t* range_num);

TILEDB_EXPORT int32_t tiledb_query_get_range_from_name(
    tiledb_ctx_t* ctx,
    const tiledb_query_t* query,
    const char* dim_name,
    uint64_t range_idx,
    const void** start,
    const void** end,
    const void** stride);

TILEDB_EXPORT int32_t tiledb_query_get_range_var_size_from_name(
    tiledb_ctx_t* ctx,
    const tiledb_query_t* query,
    const char* dim_name,
    uint64_t range_idx,
    uint64_t* start_size,
    uint64_t* end_size);

TILEDB_EXPORT int32_t tiledb_query_get_range_var_from_name(
    tiledb_ctx_t* ctx,
    const tiledb_query_t* query,
    const char* dim_name,
    uint64_t range_idx,
    void* start,
    void* end);
```