### PR TITLE
Test fragment info have version greater than zero

### DIFF
--- a/.github/scripts/install_tiledb_linux.sh
+++ b/.github/scripts/install_tiledb_linux.sh
@@ -1,4 +1,4 @@
 set -e -x
-curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.2.1/tiledb-linux-2.2.1-4744a3f-full.tar.gz \
+curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.2.3/tiledb-linux-2.2.3-dbaf5ff-full.tar.gz \
 && sudo tar -C /usr/local -xf tiledb.tar.gz
 sudo ldconfig /usr/local/lib

--- a/.github/scripts/install_tiledb_macos.sh
+++ b/.github/scripts/install_tiledb_macos.sh
@@ -1,3 +1,3 @@
 set -e -x
-curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.2.1/tiledb-macos-2.2.1-4744a3f-full.tar.gz \
+curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.2.3/tiledb-macos-2.2.3-dbaf5ff-full.tar.gz \
 && sudo tar -C /usr/local -xf tiledb.tar.gz

--- a/fragment_info_test.go
+++ b/fragment_info_test.go
@@ -142,7 +142,7 @@ func TestFragmentInfo(t *testing.T) {
 
 	version, err := fI.GetVersion(0)
 	assert.Nil(t, err)
-	assert.Equal(t, uint32(7), version)
+	assert.Greater(t, version, uint32(0))
 
 	hasConsolidatedMetadata, err := fI.HasConsolidatedMetadata(0)
 	assert.Nil(t, err)
@@ -260,7 +260,7 @@ func TestFragmentInfoEncryption(t *testing.T) {
 
 	version, err := fI.GetVersion(0)
 	assert.Nil(t, err)
-	assert.Equal(t, uint32(7), version)
+	assert.Greater(t, version, uint32(0))
 
 	hasConsolidatedMetadata, err := fI.HasConsolidatedMetadata(0)
 	assert.Nil(t, err)


### PR DESCRIPTION
`FragmentInfo` can be queried for version, which can change as TileDB Core evolves. This means we need to test fragment info version produced in our tests to be correct against TileDB Core version, TileDB-Go is used each time, for example Fragmet Info version `7` was true for TileDB Core versions `2.2.1`, `2.2.2`.

In this PR we relax the condition and ask for fragment info version to be greater than 0 to accommodate for future updates from TileDB Core

https://github.com/TileDB-Inc/TileDB-Go/issues/154