### PR TITLE
Add additional stats functions

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -77,3 +77,77 @@ func StatsDump(path string) error {
 	}
 	return nil
 }
+
+// Stats returns internal stats as string
+func Stats() (string, error) {
+	var msg *C.char
+
+	// Dump stats to string
+	ret := C.tiledb_stats_dump_str(&msg)
+	if ret != C.TILEDB_OK {
+		return "", fmt.Errorf("Error dumping stats to string")
+	}
+	s := C.GoString(msg)
+
+	ret = C.tiledb_stats_free_str(&msg)
+	if ret != C.TILEDB_OK {
+		return "", fmt.Errorf("Error freeing string from dumping stats to string")
+	}
+
+	return s, nil
+}
+
+// StatsRawDumpSTDOUT prints internal raw (json) stats to stdout
+func StatsRawDumpSTDOUT() error {
+	ret := C.tiledb_stats_raw_dump(C.stdout)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error dumping stats to stdout")
+	}
+	return nil
+}
+
+// StatsRawDump prints internal raw (json) stats to file path given
+func StatsRawDump(path string) error {
+
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("Error path already %s exists", path)
+	}
+
+	// Convert to char *
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	// Set mode as char*
+	cMode := C.CString("w")
+	defer C.free(unsafe.Pointer(cMode))
+
+	// Open file to get FILE*
+	cFile := C.fopen(cPath, cMode)
+	defer C.fclose(cFile)
+
+	// Dump stats to file
+	ret := C.tiledb_stats_raw_dump(cFile)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error dumping stats to file %s", path)
+	}
+	return nil
+}
+
+// StatsRaw returns internal raw (json) stats as string
+func StatsRaw() (string, error) {
+	var msg *C.char
+
+	// Dump stats to string
+	ret := C.tiledb_stats_raw_dump_str(&msg)
+	if ret != C.TILEDB_OK {
+		return "", fmt.Errorf("Error dumping raw stats to string")
+	}
+	s := C.GoString(msg)
+
+	ret = C.tiledb_stats_free_str(&msg)
+	if ret != C.TILEDB_OK {
+		return "", fmt.Errorf("Error freeing string from dumping raw stats to string")
+	}
+
+	return s, nil
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -56,6 +56,55 @@ func TestStats(t *testing.T) {
 	err = StatsDump(tmpPath)
 	assert.NotNil(t, err)
 
+	// Get statistics as string
+	stats, err := Stats()
+	assert.Nil(t, err)
+	assert.NotEmpty(t, stats)
+
+	// Disable statistics
+	err = StatsDisable()
+	assert.Nil(t, err)
+}
+
+// Test statistics
+func TestStatsRaw(t *testing.T) {
+	// Enable statistics
+	err := StatsEnable()
+	assert.Nil(t, err)
+
+	// Reset all internal counters to 0
+	err = StatsReset()
+	assert.Nil(t, err)
+
+	// Dump raw (json) statistics to stdout
+	err = StatsRawDumpSTDOUT()
+	assert.Nil(t, err)
+
+	tmpPath := os.TempDir() + string(os.PathSeparator) + "tiledb_stats_test"
+	// Cleanup group when test ends
+	defer os.RemoveAll(tmpPath)
+	if _, err = os.Stat(tmpPath); err == nil {
+		os.RemoveAll(tmpPath)
+	}
+
+	// Dump raw (json) statistics to file
+	err = StatsRawDump(tmpPath)
+	assert.Nil(t, err)
+
+	// Validate dumped file is non-empty
+	fileInfo, err := os.Stat(tmpPath)
+	assert.Nil(t, err)
+	assert.NotZero(t, fileInfo.Size())
+
+	// Dump raw (json) statistics to existing file should error
+	err = StatsRawDump(tmpPath)
+	assert.NotNil(t, err)
+
+	// Get raw (json) statistics as string
+	stats, err := StatsRaw()
+	assert.Nil(t, err)
+	assert.NotEmpty(t, stats)
+
 	// Disable statistics
 	err = StatsDisable()
 	assert.Nil(t, err)


### PR DESCRIPTION
This allows returning TileDB Statistics as a string and also additional functions for returning or dumping the raw statistics which are in JSON form.