### PR TITLE
Add `Query.SetConfig()`

### DIFF
--- a/query.go
+++ b/query.go
@@ -22,6 +22,7 @@ type Query struct {
 	tiledbQuery          *C.tiledb_query_t
 	array                *Array
 	context              *Context
+	config               *Config
 	buffers              []interface{}
 	bufferMutex          sync.Mutex
 	resultBufferElements map[string][3]*uint64
@@ -1080,7 +1081,7 @@ func (q *Query) GetRange(dimIdx uint32, rangeNum uint64) (interface{}, interface
 	return start, end, nil
 }
 
-// GetRange retrieves a specific range of the query subarray
+// GetRangeFromName retrieves a specific range of the query subarray
 // along a given dimension.
 // Returns (start, end, error)
 // If start size or end size is 0 returns nil, nil, nil
@@ -3222,6 +3223,7 @@ func (q *Query) GetFragmentTimestampRange(num uint64) (*uint64, *uint64, error) 
 	return &t1, &t2, nil
 }
 
+// Array returns array used by query
 func (q *Query) Array() (*Array, error) {
 	array := Array{context: q.context}
 	ret := C.tiledb_query_get_array(q.context.tiledbContext, q.tiledbQuery, &array.tiledbArray)
@@ -3229,4 +3231,16 @@ func (q *Query) Array() (*Array, error) {
 		return nil, fmt.Errorf("Error getting array from query: %s", q.context.LastError())
 	}
 	return &array, nil
+}
+
+// SetConfig config on query
+func (q *Query) SetConfig(config *Config) error {
+	q.config = config
+
+	ret := C.tiledb_query_set_config(q.context.tiledbContext, q.tiledbQuery, q.config.tiledbConfig)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error setting config on query: %s", q.context.LastError())
+	}
+
+	return nil
 }

--- a/query_test.go
+++ b/query_test.go
@@ -2101,3 +2101,189 @@ func TestSparseQueryWriteHilbertLayout(t *testing.T) {
 	err = query.Finalize()
 	assert.Nil(t, err)
 }
+
+func TestQueryConfig(t *testing.T) {
+	// Create configuration
+	config, err := NewConfig()
+	assert.Nil(t, err)
+
+	// Test context with config
+	context, err := NewContext(config)
+	assert.Nil(t, err)
+
+	// Test create row dimension
+	rowDim, err := NewDimension(context, "rows", []int32{1, 4}, int32(2))
+	assert.Nil(t, err)
+	assert.NotNil(t, rowDim)
+
+	// Test create row dimension
+	colDim, err := NewDimension(context, "cols", []int32{1, 4}, int32(2))
+	assert.Nil(t, err)
+	assert.NotNil(t, colDim)
+
+	// Test creating domain
+	domain, err := NewDomain(context)
+	assert.Nil(t, err)
+	assert.NotNil(t, domain)
+
+	// Add dimensions
+	err = domain.AddDimensions(rowDim, colDim)
+	assert.Nil(t, err)
+
+	// Create array schema
+	arraySchema, err := NewArraySchema(context, TILEDB_SPARSE)
+	assert.Nil(t, err)
+	assert.NotNil(t, arraySchema)
+
+	err = arraySchema.SetAllowsDups(true)
+	assert.Nil(t, err)
+
+	allowDups, err := arraySchema.AllowsDups()
+	assert.Nil(t, err)
+	assert.Equal(t, true, allowDups)
+
+	err = arraySchema.SetAllowsDups(false)
+	assert.Nil(t, err)
+
+	// Dense array, allowDups should be false
+	allowDups, err = arraySchema.AllowsDups()
+	assert.Nil(t, err)
+	assert.Equal(t, false, allowDups)
+
+	err = arraySchema.SetCellOrder(TILEDB_ROW_MAJOR)
+	assert.Nil(t, err)
+	err = arraySchema.SetTileOrder(TILEDB_ROW_MAJOR)
+	assert.Nil(t, err)
+
+	// Create attribute to add to schema
+	attribute, err := NewAttribute(context, "a1", TILEDB_INT32)
+	assert.Nil(t, err)
+	assert.NotNil(t, attribute)
+
+	// Set a1 to be variable length
+	err = attribute.SetCellValNum(TILEDB_VAR_NUM)
+	assert.Nil(t, err)
+
+	// Add Attribute
+	err = arraySchema.AddAttributes(attribute)
+	assert.Nil(t, err)
+
+	// Set Domain
+	err = arraySchema.SetDomain(domain)
+	assert.Nil(t, err)
+
+	// Validate Schema
+	err = arraySchema.Check()
+	assert.Nil(t, err)
+
+	// create temp group name
+	tmpArrayPath := os.TempDir() + string(os.PathSeparator) +
+		"tiledb_effective_buffer_size_array"
+	// Cleanup group when test ends
+	defer os.RemoveAll(tmpArrayPath)
+	if _, err = os.Stat(tmpArrayPath); err == nil {
+		os.RemoveAll(tmpArrayPath)
+	}
+	// Create new array struct
+	array, err := NewArray(context, tmpArrayPath)
+	assert.Nil(t, err)
+	assert.NotNil(t, array)
+
+	// Prepare some data for the array
+	buffD1 := []int32{1, 2, 2}
+	buffD2 := []int32{1, 1, 2}
+	a1DataWrite := []int32{1, 2, 3}
+	a1OffWrite := []uint64{0, 4, 8}
+
+	// Create array on disk
+	err = array.Create(arraySchema)
+	assert.Nil(t, err)
+
+	err = array.Open(TILEDB_WRITE)
+	assert.Nil(t, err)
+	query, err := NewQuery(context, array)
+	assert.Nil(t, err)
+	assert.NotNil(t, query)
+	err = query.SetLayout(TILEDB_GLOBAL_ORDER)
+	assert.Nil(t, err)
+	_, _, err = query.SetBufferVar("a1", a1OffWrite, a1DataWrite)
+	assert.Nil(t, err)
+	_, err = query.SetBuffer("rows", buffD1)
+	assert.Nil(t, err)
+	_, err = query.SetBuffer("cols", buffD2)
+	assert.Nil(t, err)
+
+	// Check the buffer sizes
+	offsetSize, dataSize, err := query.BufferSizeVar("a1")
+	assert.Nil(t, err)
+	assert.Equal(t, len(a1OffWrite), int(offsetSize))
+	assert.Equal(t, len(a1DataWrite), int(dataSize))
+	rowsDataSize, err := query.BufferSize("rows")
+	assert.Nil(t, err)
+	assert.Equal(t, len(buffD1), int(rowsDataSize))
+	colsDataSize, err := query.BufferSize("cols")
+	assert.Nil(t, err)
+	assert.Equal(t, len(buffD2), int(colsDataSize))
+
+	// Perform the write, finalize and close the array.
+	err = query.Submit()
+	assert.Nil(t, err)
+	err = query.Finalize()
+	assert.Nil(t, err)
+	err = array.Close()
+	assert.Nil(t, err)
+
+	err = array.Open(TILEDB_READ)
+	assert.Nil(t, err)
+
+	// Prepare buffers
+	rows := make([]int32, 4)
+	cols := make([]int32, 4)
+	// Allocate 4 bytes to store the read result
+	a1DataRead := make([]int32, 12)
+	a1OffRead := make([]uint64, 12)
+
+	// Prepare the query
+	query, err = NewQuery(context, array)
+	assert.Nil(t, err)
+	assert.NotNil(t, query)
+
+	// Read value at cell 2, 2
+	err = query.AddRange(0, 1, 2)
+	assert.Nil(t, err)
+	err = query.AddRange(1, 1, 2)
+	assert.Nil(t, err)
+
+	// Create configuration
+	configQuery, err := NewConfig()
+	assert.Nil(t, err)
+
+	err = configQuery.Set("sm.var_offsets.mode", "elements")
+	assert.Nil(t, err)
+	err = query.SetConfig(configQuery)
+	assert.Nil(t, err)
+
+	err = query.SetLayout(TILEDB_ROW_MAJOR)
+	assert.Nil(t, err)
+	_, _, err = query.SetBufferVar("a1",
+		a1OffRead, a1DataRead)
+	assert.Nil(t, err)
+	assert.NotNil(t, query)
+	_, err = query.SetBuffer("rows", rows)
+	assert.Nil(t, err)
+	_, err = query.SetBuffer("cols", cols)
+	assert.Nil(t, err)
+
+	// Submit the query
+	err = query.Submit()
+	assert.Nil(t, err)
+
+	// Data buffer contains [3], has size of 4
+	assert.EqualValues(t, 12, len(a1DataRead))
+	assert.EqualValues(t, 12, len(a1OffRead))
+
+	// Offsets will be element count due to config setting of "sm.var_offsets.mode"
+	assert.EqualValues(t, 1, a1OffRead[1])
+
+	query.Free()
+}


### PR DESCRIPTION
This allows setting the config on a query object.