### PR TITLE
Use consistent naming for a tiledb context type

### DIFF
--- a/array.go
+++ b/array.go
@@ -51,10 +51,10 @@ type NonEmptyDomain struct {
 }
 
 // NewArray alloc a new array
-func NewArray(ctx *Context, uri string) (*Array, error) {
+func NewArray(tdbCtx *Context, uri string) (*Array, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	array := Array{context: ctx, uri: uri}
+	array := Array{context: tdbCtx, uri: uri}
 	ret := C.tiledb_array_alloc(array.context.tiledbContext, curi, &array.tiledbArray)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb array: %s", array.context.LastError())

--- a/array_schema.go
+++ b/array_schema.go
@@ -109,8 +109,8 @@ func (a *ArraySchema) UnmarshalJSON(b []byte) error {
 }
 
 // NewArraySchema alloc a new ArraySchema
-func NewArraySchema(ctx *Context, arrayType ArrayType) (*ArraySchema, error) {
-	arraySchema := ArraySchema{context: ctx}
+func NewArraySchema(tdbCtx *Context, arrayType ArrayType) (*ArraySchema, error) {
+	arraySchema := ArraySchema{context: tdbCtx}
 	ret := C.tiledb_array_schema_alloc(arraySchema.context.tiledbContext, C.tiledb_array_type_t(arrayType), &arraySchema.tiledbArraySchema)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb arraySchema: %s", arraySchema.context.LastError())

--- a/domain.go
+++ b/domain.go
@@ -25,8 +25,8 @@ type Domain struct {
 }
 
 // NewDomain alloc a new domainuration
-func NewDomain(ctx *Context) (*Domain, error) {
-	domain := Domain{context: ctx}
+func NewDomain(tdbCtx *Context) (*Domain, error) {
+	domain := Domain{context: tdbCtx}
 	ret := C.tiledb_domain_alloc(domain.context.tiledbContext, &domain.tiledbDomain)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb domain: %s", domain.context.LastError())

--- a/examples_lib/writing_sparse_global.go
+++ b/examples_lib/writing_sparse_global.go
@@ -62,9 +62,9 @@ func createSparseGlobalArray() {
 	checkError(err)
 }
 
-func execQueryGlobalOrder(ctx *tiledb.Context, array *tiledb.Array,
+func execQueryGlobalOrder(tdbCtx *tiledb.Context, array *tiledb.Array,
 	data []int32, buffD1 []int32, buffD2 []int32) {
-	query, err := tiledb.NewQuery(ctx, array)
+	query, err := tiledb.NewQuery(tdbCtx, array)
 	checkError(err)
 	defer query.Free()
 

--- a/examples_lib/writing_sparse_multiple.go
+++ b/examples_lib/writing_sparse_multiple.go
@@ -62,9 +62,9 @@ func createMultipleWritesSparseArray() {
 	checkError(err)
 }
 
-func execQueryUnordered(ctx *tiledb.Context, array *tiledb.Array,
+func execQueryUnordered(tdbCtx *tiledb.Context, array *tiledb.Array,
 	data []int32, buffD1 []int32, buffD2 []int32) {
-	query, err := tiledb.NewQuery(ctx, array)
+	query, err := tiledb.NewQuery(tdbCtx, array)
 	checkError(err)
 	defer query.Free()
 

--- a/fragment_info.go
+++ b/fragment_info.go
@@ -31,10 +31,10 @@ type FragmentInfo struct {
 
 // NewFragmentInfo alloc a new fragment info for a given array and fetches all
 // the fragment information for that array.
-func NewFragmentInfo(ctx *Context, uri string) (*FragmentInfo, error) {
+func NewFragmentInfo(tdbCtx *Context, uri string) (*FragmentInfo, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	fI := FragmentInfo{context: ctx, uri: uri}
+	fI := FragmentInfo{context: tdbCtx, uri: uri}
 	ret := C.tiledb_fragment_info_alloc(fI.context.tiledbContext,
 		curi, &fI.tiledbFragmentInfo)
 	if ret != C.TILEDB_OK {

--- a/object.go
+++ b/object.go
@@ -17,18 +17,18 @@ import (
 
 // ObjectType returns the object type
 // A TileDB "object" is currently either a TileDB array or a TileDB group.
-func ObjectType(ctx *Context, path string) (ObjectTypeEnum, error) {
-	if ctx == nil {
+func ObjectType(tdbCtx *Context, path string) (ObjectTypeEnum, error) {
+	if tdbCtx == nil {
 		return TILEDB_INVALID, fmt.Errorf("error getting object type, context is nil")
 	}
 
 	var objectTypeEnum C.tiledb_object_t
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
-	ret := C.tiledb_object_type(ctx.tiledbContext, cpath, &objectTypeEnum)
+	ret := C.tiledb_object_type(tdbCtx.tiledbContext, cpath, &objectTypeEnum)
 	if ret != C.TILEDB_OK {
 		return TILEDB_INVALID, fmt.Errorf("Cannot get object type from path %s: %s",
-			path, ctx.LastError())
+			path, tdbCtx.LastError())
 	}
 
 	return ObjectTypeEnum(objectTypeEnum), nil
@@ -64,8 +64,8 @@ func objectsInPath(path *C.cchar_t, objectTypeEnum C.tiledb_object_t, data unsaf
 // The iteration continues for as long the callback returns non-zero, and stops
 // when the callback returns 0. Note that this function ignores any object
 // (e.g., file or directory) that is not TileDB-related.
-func ObjectWalk(ctx *Context, path string, walkOrder WalkOrder) (*ObjectList, error) {
-	if ctx == nil {
+func ObjectWalk(tdbCtx *Context, path string, walkOrder WalkOrder) (*ObjectList, error) {
+	if tdbCtx == nil {
 		return nil, fmt.Errorf("error walking object, context is nil")
 	}
 
@@ -77,22 +77,22 @@ func ObjectWalk(ctx *Context, path string, walkOrder WalkOrder) (*ObjectList, er
 	}
 	data := pointer.Save(&objectList)
 
-	ret := C._tiledb_object_walk(ctx.tiledbContext, cpath,
+	ret := C._tiledb_object_walk(tdbCtx.tiledbContext, cpath,
 		C.tiledb_walk_order_t(walkOrder), unsafe.Pointer(data))
 
 	fmt.Println(objectList)
 
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Cannot walk in path %s: %s", path,
-			ctx.LastError())
+			tdbCtx.LastError())
 	}
 	return &objectList, nil
 }
 
 // ObjectLs is similar to `tiledb_walk`, but now the function visits only the children
 // of `path` (it does not recursively continue to the children directories).
-func ObjectLs(ctx *Context, path string) (*ObjectList, error) {
-	if ctx == nil {
+func ObjectLs(tdbCtx *Context, path string) (*ObjectList, error) {
+	if tdbCtx == nil {
 		return nil, fmt.Errorf("error listing object, context is nil")
 	}
 
@@ -104,20 +104,20 @@ func ObjectLs(ctx *Context, path string) (*ObjectList, error) {
 	}
 	data := pointer.Save(&objectList)
 
-	ret := C._tiledb_object_ls(ctx.tiledbContext, cpath,
+	ret := C._tiledb_object_ls(tdbCtx.tiledbContext, cpath,
 		unsafe.Pointer(data))
 
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Cannot walk in path %s: %s", path,
-			ctx.LastError())
+			tdbCtx.LastError())
 	}
 	return &objectList, nil
 }
 
 // ObjectMove moves a TileDB resource (group, array, key-value).
 // Param path is the new path to move to
-func ObjectMove(ctx *Context, path string, newPath string) error {
-	if ctx == nil {
+func ObjectMove(tdbCtx *Context, path string, newPath string) error {
+	if tdbCtx == nil {
 		return fmt.Errorf("error moving object, context is nil")
 	}
 
@@ -125,26 +125,26 @@ func ObjectMove(ctx *Context, path string, newPath string) error {
 	defer C.free(unsafe.Pointer(cpath))
 	cnewPath := C.CString(newPath)
 	defer C.free(unsafe.Pointer(cnewPath))
-	ret := C.tiledb_object_move(ctx.tiledbContext, cpath, cnewPath)
+	ret := C.tiledb_object_move(tdbCtx.tiledbContext, cpath, cnewPath)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Cannot move object from %s to %s: %s", path,
-			newPath, ctx.LastError())
+			newPath, tdbCtx.LastError())
 	}
 
 	return nil
 }
 
 // ObjectRemove deletes a TileDB resource (group, array, key-value).
-func ObjectRemove(ctx *Context, path string) error {
-	if ctx == nil {
+func ObjectRemove(tdbCtx *Context, path string) error {
+	if tdbCtx == nil {
 		return fmt.Errorf("error removing object, context is nil")
 	}
 
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
-	ret := C.tiledb_object_remove(ctx.tiledbContext, cpath)
+	ret := C.tiledb_object_remove(tdbCtx.tiledbContext, cpath)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Cannot delete object %s: %s", path, ctx.LastError())
+		return fmt.Errorf("Cannot delete object %s: %s", path, tdbCtx.LastError())
 	}
 	return nil
 }

--- a/query.go
+++ b/query.go
@@ -56,7 +56,7 @@ This means multiple read and write queries to the same array can be made
 concurrently (in TileDB, only consolidation requires an exclusive lock for
 a short period of time).
 */
-func NewQuery(ctx *Context, array *Array) (*Query, error) {
+func NewQuery(tdbCtx *Context, array *Array) (*Query, error) {
 	if array == nil {
 		return nil, fmt.Errorf("Error creating tiledb query: passed array is nil")
 	}
@@ -66,7 +66,7 @@ func NewQuery(ctx *Context, array *Array) (*Query, error) {
 		return nil, fmt.Errorf("Error getting QueryType from passed array %s", err)
 	}
 
-	query := Query{context: ctx, array: array}
+	query := Query{context: tdbCtx, array: array}
 	ret := C.tiledb_query_alloc(query.context.tiledbContext, array.tiledbArray, C.tiledb_query_type_t(queryType), &query.tiledbQuery)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb query: %s", query.context.LastError())


### PR DESCRIPTION
Uses the same naming schema for the tiledb context type