### PR TITLE
Make all examples write into a temporary directory.

### DIFF
--- a/examples_lib/array_metadata.go
+++ b/examples_lib/array_metadata.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Name of array.
-var arrayMetadataArrayName = "metadata_array"
+const arrayMetadataArrayName = "metadata_array"
 
 func createArrayMetadataArray() {
 	// Create a TileDB context.

--- a/examples_lib/array_metadata.go
+++ b/examples_lib/array_metadata.go
@@ -3,15 +3,11 @@ package examples_lib
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const arrayMetadataArrayName = "metadata_array"
-
-func createArrayMetadataArray() {
+func createArrayMetadataArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -50,7 +46,7 @@ func createArrayMetadataArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, arrayMetadataArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 
 	err = array.Create(schema)
@@ -59,13 +55,13 @@ func createArrayMetadataArray() {
 	array.Free()
 }
 
-func writeArrayMetadata() {
+func writeArrayMetadata(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, arrayMetadataArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	defer array.Free()
 	checkError(err)
 	err = array.Open(tiledb.TILEDB_WRITE)
@@ -91,13 +87,13 @@ func writeArrayMetadata() {
 	checkError(err)
 }
 
-func readArrayMetadata() {
+func readArrayMetadata(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, arrayMetadataArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 	err = array.Open(tiledb.TILEDB_READ)
@@ -181,13 +177,13 @@ func readArrayMetadata() {
 	fmt.Println(string(jsonData))
 }
 
-func clearArrayMetadata() {
+func clearArrayMetadata(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for writing
-	array, err := tiledb.NewArray(ctx, arrayMetadataArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -221,14 +217,11 @@ func clearArrayMetadata() {
 // RunArrayMetadataArray shows and example creation, writing and reading of a
 // sparse array
 func RunArrayMetadataArray() {
-	createArrayMetadataArray()
-	writeArrayMetadata()
-	readArrayMetadata()
-	clearArrayMetadata()
+	tempDir := temp("metadata_array")
+	defer cleanup(tempDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(arrayMetadataArrayName); err == nil {
-		err = os.RemoveAll(arrayMetadataArrayName)
-		checkError(err)
-	}
+	createArrayMetadataArray(tempDir)
+	writeArrayMetadata(tempDir)
+	readArrayMetadata(tempDir)
+	clearArrayMetadata(tempDir)
 }

--- a/examples_lib/async.go
+++ b/examples_lib/async.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const asyncArrayName = "async_array"
-
-func createAsyncArray() {
+func createAsyncArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -56,7 +52,7 @@ func createAsyncArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, asyncArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	err = array.Create(schema)
 	checkError(err)
@@ -64,7 +60,7 @@ func createAsyncArray() {
 	array.Free()
 }
 
-func writeAsyncArray() {
+func writeAsyncArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -75,7 +71,7 @@ func writeAsyncArray() {
 	data := []uint32{1, 2, 3, 4}
 
 	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, asyncArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -118,13 +114,13 @@ func writeAsyncArray() {
 	checkError(err)
 }
 
-func readAsyncArray() {
+func readAsyncArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, asyncArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -189,13 +185,10 @@ func readAsyncArray() {
 }
 
 func RunAsyncArray() {
-	createAsyncArray()
-	writeAsyncArray()
-	readAsyncArray()
+	tempDir := temp("async_array")
+	defer cleanup(tempDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(asyncArrayName); err == nil {
-		err = os.RemoveAll(asyncArrayName)
-		checkError(err)
-	}
+	createAsyncArray(tempDir)
+	writeAsyncArray(tempDir)
+	readAsyncArray(tempDir)
 }

--- a/examples_lib/async.go
+++ b/examples_lib/async.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var asyncArrayName = "async_array"
+const asyncArrayName = "async_array"
 
 func createAsyncArray() {
 	// Create a TileDB context.

--- a/examples_lib/config.go
+++ b/examples_lib/config.go
@@ -2,7 +2,7 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
+	"path/filepath"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
@@ -303,6 +303,9 @@ func printDefault() {
 }
 
 func saveLoadConfig() {
+	dir := temp("tiledb_config")
+	defer cleanup(dir)
+	file := filepath.Join(dir, configFileName)
 	fmt.Println("Save and load config")
 
 	// Create config object
@@ -315,11 +318,11 @@ func saveLoadConfig() {
 	checkError(err)
 
 	// Save to disk
-	err = config.SaveToFile(configFileName)
+	err = config.SaveToFile(file)
 	checkError(err)
 
 	// Load config from file
-	newConfig, err := tiledb.LoadConfig(configFileName)
+	newConfig, err := tiledb.LoadConfig(file)
 	checkError(err)
 
 	// Print the retrieved value
@@ -327,10 +330,6 @@ func saveLoadConfig() {
 	checkError(err)
 	fmt.Printf("\"sm.tile_cache_size\" : \"%s\"\n",
 		smTileCacheSize)
-
-	// Clean up
-	err = os.RemoveAll(configFileName)
-	checkError(err)
 
 	newConfig.Free()
 }

--- a/examples_lib/config.go
+++ b/examples_lib/config.go
@@ -7,7 +7,7 @@ import (
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-var configFileName = "tiledb_config.txt"
+const configFileName = "tiledb_config.txt"
 
 func setGetConfigCtxVfs() {
 	// Create config objects

--- a/examples_lib/encryption.go
+++ b/examples_lib/encryption.go
@@ -8,10 +8,10 @@ import (
 )
 
 // Name of array.
-var encryptedArrayName = "encrypted_array"
+const encryptedArrayName = "encrypted_array"
 
 // The 256-bit encryption key, stored as a string for convenience.
-var encryption_key = "0123456789abcdeF0123456789abcdeF"
+const encryption_key = "0123456789abcdeF0123456789abcdeF"
 
 func createEncryptedArray() {
 	// Create a TileDB context.

--- a/examples_lib/encryption.go
+++ b/examples_lib/encryption.go
@@ -2,18 +2,14 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const encryptedArrayName = "encrypted_array"
-
 // The 256-bit encryption key, stored as a string for convenience.
 const encryption_key = "0123456789abcdeF0123456789abcdeF"
 
-func createEncryptedArray() {
+func createEncryptedArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -52,7 +48,7 @@ func createEncryptedArray() {
 	checkError(err)
 
 	// Create the (empty) encrypted array with AES-256-GCM.
-	array, err := tiledb.NewArray(ctx, encryptedArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -60,7 +56,7 @@ func createEncryptedArray() {
 	checkError(err)
 }
 
-func writeEncryptedArray() {
+func writeEncryptedArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -70,7 +66,7 @@ func writeEncryptedArray() {
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 
 	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, encryptedArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -93,13 +89,13 @@ func writeEncryptedArray() {
 	checkError(err)
 }
 
-func readEncryptedArray() {
+func readEncryptedArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, encryptedArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -135,13 +131,10 @@ func readEncryptedArray() {
 }
 
 func RunEncryptedArray() {
-	createEncryptedArray()
-	writeEncryptedArray()
-	readEncryptedArray()
+	tempDir := temp("encrypted_array")
+	defer cleanup(tempDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(encryptedArrayName); err == nil {
-		err = os.RemoveAll(encryptedArrayName)
-		checkError(err)
-	}
+	createEncryptedArray(tempDir)
+	writeEncryptedArray(tempDir)
+	readEncryptedArray(tempDir)
 }

--- a/examples_lib/error_check.go
+++ b/examples_lib/error_check.go
@@ -1,7 +1,0 @@
-package examples_lib
-
-func checkError(err error) {
-	if err != nil {
-		panic(err)
-	}
-}

--- a/examples_lib/errors.go
+++ b/examples_lib/errors.go
@@ -10,10 +10,10 @@ import (
 )
 
 // Name of the group
-var groupName = "my_group"
+const groupName = "my_group"
 
 // Type of file system (e.g. file://, s3://)
-var fileSystem = "file://"
+const fileSystem = "file://"
 
 func RunErrors() {
 	// Get filename of current file

--- a/examples_lib/filters.go
+++ b/examples_lib/filters.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var filtersArrayName = "filters_array"
+const filtersArrayName = "filters_array"
 
 func createFilterArray() {
 	// Create a TileDB context.

--- a/examples_lib/filters.go
+++ b/examples_lib/filters.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const filtersArrayName = "filters_array"
-
-func createFilterArray() {
+func createFilterArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -97,7 +93,7 @@ func createFilterArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, filtersArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -105,7 +101,7 @@ func createFilterArray() {
 	checkError(err)
 }
 
-func writeFiltersArray() {
+func writeFiltersArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -117,7 +113,7 @@ func writeFiltersArray() {
 	dataA2 := []int32{-1, -2, -3}
 
 	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, filtersArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -148,13 +144,13 @@ func writeFiltersArray() {
 	checkError(err)
 }
 
-func readFiltersArray() {
+func readFiltersArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, filtersArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -213,13 +209,10 @@ func readFiltersArray() {
 // RunFiltersArray shows and example creation, writing and reading of a
 // sparse array
 func RunFiltersArray() {
-	createFilterArray()
-	writeFiltersArray()
-	readFiltersArray()
+	tmpDir := temp("filters_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(filtersArrayName); err == nil {
-		err = os.RemoveAll(filtersArrayName)
-		checkError(err)
-	}
+	createFilterArray(tmpDir)
+	writeFiltersArray(tmpDir)
+	readFiltersArray(tmpDir)
 }

--- a/examples_lib/fragments_consolidation.go
+++ b/examples_lib/fragments_consolidation.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var fragmentsConsolidationArrayName = "fragments_consolidation_array"
+const fragmentsConsolidationArrayName = "fragments_consolidation_array"
 
 func createFragmentsConsolidationArray() {
 	// Create a TileDB context.

--- a/examples_lib/fragments_consolidation.go
+++ b/examples_lib/fragments_consolidation.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const fragmentsConsolidationArrayName = "fragments_consolidation_array"
-
-func createFragmentsConsolidationArray() {
+func createFragmentsConsolidationArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -52,7 +48,7 @@ func createFragmentsConsolidationArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, fragmentsConsolidationArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -60,7 +56,7 @@ func createFragmentsConsolidationArray() {
 	checkError(err)
 }
 
-func writeFragmentsConsolidationArray1() {
+func writeFragmentsConsolidationArray1(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -70,7 +66,7 @@ func writeFragmentsConsolidationArray1() {
 	subarray := []int32{1, 2, 1, 4}
 
 	// Create the query
-	array, err := tiledb.NewArray(ctx, fragmentsConsolidationArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -97,7 +93,7 @@ func writeFragmentsConsolidationArray1() {
 	checkError(err)
 }
 
-func writeFragmentsConsolidationArray2() {
+func writeFragmentsConsolidationArray2(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -107,7 +103,7 @@ func writeFragmentsConsolidationArray2() {
 	subarray := []int32{2, 3, 2, 3}
 
 	// Create the query
-	array, err := tiledb.NewArray(ctx, fragmentsConsolidationArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -134,7 +130,7 @@ func writeFragmentsConsolidationArray2() {
 	checkError(err)
 }
 
-func writeFragmentsConsolidationArray3() {
+func writeFragmentsConsolidationArray3(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
@@ -144,7 +140,7 @@ func writeFragmentsConsolidationArray3() {
 	data := []int32{201, 202}
 
 	// Create the query
-	array, err := tiledb.NewArray(ctx, fragmentsConsolidationArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -185,14 +181,14 @@ func writeFragmentsConsolidationArray3() {
 	checkError(err)
 }
 
-func readFragmentsConsolidationArray() {
+func readFragmentsConsolidationArray(dir string) {
 	// Create TileDB context
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, fragmentsConsolidationArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -248,15 +244,12 @@ func readFragmentsConsolidationArray() {
 }
 
 func RunFragmentsConsolidationArray() {
-	createFragmentsConsolidationArray()
-	writeFragmentsConsolidationArray1()
-	writeFragmentsConsolidationArray2()
-	writeFragmentsConsolidationArray3()
-	readFragmentsConsolidationArray()
+	tmpDir := temp("fragments_conslidation_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(fragmentsConsolidationArrayName); err == nil {
-		err = os.RemoveAll(fragmentsConsolidationArrayName)
-		checkError(err)
-	}
+	createFragmentsConsolidationArray(tmpDir)
+	writeFragmentsConsolidationArray1(tmpDir)
+	writeFragmentsConsolidationArray2(tmpDir)
+	writeFragmentsConsolidationArray3(tmpDir)
+	readFragmentsConsolidationArray(tmpDir)
 }

--- a/examples_lib/multi_attribute.go
+++ b/examples_lib/multi_attribute.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var multiAttributeArrayName = "multi_attribute_array"
+const multiAttributeArrayName = "multi_attribute_array"
 
 func createMultiAttributeArray() {
 	// Create a TileDB context.

--- a/examples_lib/multi_attribute.go
+++ b/examples_lib/multi_attribute.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const multiAttributeArrayName = "multi_attribute_array"
-
-func createMultiAttributeArray() {
+func createMultiAttributeArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -62,7 +58,7 @@ func createMultiAttributeArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, multiAttributeArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -70,7 +66,7 @@ func createMultiAttributeArray() {
 	checkError(err)
 }
 
-func writeMultiAttributeArray() {
+func writeMultiAttributeArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -84,7 +80,7 @@ func writeMultiAttributeArray() {
 		13.1, 13.2, 14.1, 14.2, 15.1, 15.2, 16.1, 16.2}
 
 	// Create the query
-	array, err := tiledb.NewArray(ctx, multiAttributeArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -111,14 +107,14 @@ func writeMultiAttributeArray() {
 	checkError(err)
 }
 
-func readMultiAttributeArray() {
+func readMultiAttributeArray(dir string) {
 	// Create TileDB context
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, multiAttributeArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -167,14 +163,14 @@ func readMultiAttributeArray() {
 	fmt.Printf("\n")
 }
 
-func readMultiAttributeArraySubSelect() {
+func readMultiAttributeArraySubSelect(dir string) {
 	// Create TileDB context
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, multiAttributeArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -219,14 +215,11 @@ func readMultiAttributeArraySubSelect() {
 }
 
 func RunMultiAttributeArray() {
-	createMultiAttributeArray()
-	writeMultiAttributeArray()
-	readMultiAttributeArray()
-	readMultiAttributeArraySubSelect()
+	tmpDir := temp("multi_attribute_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(multiAttributeArrayName); err == nil {
-		err = os.RemoveAll(multiAttributeArrayName)
-		checkError(err)
-	}
+	createMultiAttributeArray(tmpDir)
+	writeMultiAttributeArray(tmpDir)
+	readMultiAttributeArray(tmpDir)
+	readMultiAttributeArraySubSelect(tmpDir)
 }

--- a/examples_lib/quickstart_dense.go
+++ b/examples_lib/quickstart_dense.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const denseArrayName = "quickstart_dense"
-
-func createDenseArray() {
+func createDenseArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -53,7 +49,7 @@ func createDenseArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, denseArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -61,7 +57,7 @@ func createDenseArray() {
 	checkError(err)
 }
 
-func writeDenseArray() {
+func writeDenseArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -71,7 +67,7 @@ func writeDenseArray() {
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 
 	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, denseArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -96,13 +92,13 @@ func writeDenseArray() {
 	checkError(err)
 }
 
-func readDenseArray() {
+func readDenseArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, denseArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -140,13 +136,10 @@ func readDenseArray() {
 }
 
 func RunDenseArray() {
-	createDenseArray()
-	writeDenseArray()
-	readDenseArray()
+	tmpDir := temp("dense_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(denseArrayName); err == nil {
-		err = os.RemoveAll(denseArrayName)
-		checkError(err)
-	}
+	createDenseArray(tmpDir)
+	writeDenseArray(tmpDir)
+	readDenseArray(tmpDir)
 }

--- a/examples_lib/quickstart_dense.go
+++ b/examples_lib/quickstart_dense.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var denseArrayName = "quickstart_dense"
+const denseArrayName = "quickstart_dense"
 
 func createDenseArray() {
 	// Create a TileDB context.

--- a/examples_lib/quickstart_sparse.go
+++ b/examples_lib/quickstart_sparse.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Name of array.
-var sparseArrayName = "quickstart_sparse"
+const sparseArrayName = "quickstart_sparse"
 
 func createSparseArray() {
 	// Create a TileDB context.

--- a/examples_lib/quickstart_sparse.go
+++ b/examples_lib/quickstart_sparse.go
@@ -2,16 +2,12 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 	"github.com/TileDB-Inc/TileDB-Go/bytesizes"
 )
 
-// Name of array.
-const sparseArrayName = "quickstart_sparse"
-
-func createSparseArray() {
+func createSparseArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -55,7 +51,7 @@ func createSparseArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -63,7 +59,7 @@ func createSparseArray() {
 	checkError(err)
 }
 
-func writeSparseArray() {
+func writeSparseArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -74,7 +70,7 @@ func writeSparseArray() {
 	data := []uint32{1, 2, 3}
 
 	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -103,13 +99,13 @@ func writeSparseArray() {
 	checkError(err)
 }
 
-func readSparseArray() {
+func readSparseArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, sparseArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -166,13 +162,10 @@ func readSparseArray() {
 // RunSparseArray shows and example creation, writing and reading of a
 // sparse array
 func RunSparseArray() {
-	createSparseArray()
-	writeSparseArray()
-	readSparseArray()
+	tmpDir := temp("sparse_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(sparseArrayName); err == nil {
-		err = os.RemoveAll(sparseArrayName)
-		checkError(err)
-	}
+	createSparseArray(tmpDir)
+	writeSparseArray(tmpDir)
+	readSparseArray(tmpDir)
 }

--- a/examples_lib/range.go
+++ b/examples_lib/range.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var rangeArrayName = "range_array"
+const rangeArrayName = "range_array"
 
 func createRangeArray() {
 	// Create a TileDB context.

--- a/examples_lib/range.go
+++ b/examples_lib/range.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const rangeArrayName = "range_array"
-
-func createRangeArray() {
+func createRangeArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -53,7 +49,7 @@ func createRangeArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, rangeArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -61,7 +57,7 @@ func createRangeArray() {
 	checkError(err)
 }
 
-func writeRangeArray() {
+func writeRangeArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -71,7 +67,7 @@ func writeRangeArray() {
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 
 	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, rangeArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -96,13 +92,13 @@ func writeRangeArray() {
 	checkError(err)
 }
 
-func addRange() {
+func addRange(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, rangeArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -131,12 +127,12 @@ func addRange() {
 	checkError(err)
 }
 
-func getRangeNum() {
+func getRangeNum(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, rangeArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -165,13 +161,13 @@ func getRangeNum() {
 	checkError(err)
 }
 
-func getRange() {
+func getRange(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, rangeArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -198,15 +194,12 @@ func getRange() {
 // RunRange shows an example of creation, writing of a dense array
 // and usage of range functions
 func RunRange() {
-	createRangeArray()
-	writeRangeArray()
-	addRange()
-	getRangeNum()
-	getRange()
+	tmpDir := temp("range_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(rangeArrayName); err == nil {
-		err = os.RemoveAll(rangeArrayName)
-		checkError(err)
-	}
+	createRangeArray(tmpDir)
+	writeRangeArray(tmpDir)
+	addRange(tmpDir)
+	getRangeNum(tmpDir)
+	getRange(tmpDir)
 }

--- a/examples_lib/reading_dense_layouts.go
+++ b/examples_lib/reading_dense_layouts.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const readingDenseLayoutsArrayName = "reading_dense_layouts_array"
-
-func createReadingDenseLayoutsArray() {
+func createReadingDenseLayoutsArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -53,7 +49,7 @@ func createReadingDenseLayoutsArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, readingDenseLayoutsArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -61,7 +57,7 @@ func createReadingDenseLayoutsArray() {
 	checkError(err)
 }
 
-func writeReadingDenseLayoutsArray() {
+func writeReadingDenseLayoutsArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -71,7 +67,7 @@ func writeReadingDenseLayoutsArray() {
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 
 	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, readingDenseLayoutsArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -96,13 +92,13 @@ func writeReadingDenseLayoutsArray() {
 	checkError(err)
 }
 
-func readReadingDenseLayoutsArray() {
+func readReadingDenseLayoutsArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, readingDenseLayoutsArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -164,13 +160,10 @@ func readReadingDenseLayoutsArray() {
 }
 
 func RunReadingDenseLayouts() {
-	createReadingDenseLayoutsArray()
-	writeReadingDenseLayoutsArray()
-	readReadingDenseLayoutsArray()
+	tmpDir := temp("reading_dense_layouts")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(readingDenseLayoutsArrayName); err == nil {
-		err = os.RemoveAll(readingDenseLayoutsArrayName)
-		checkError(err)
-	}
+	createReadingDenseLayoutsArray(tmpDir)
+	writeReadingDenseLayoutsArray(tmpDir)
+	readReadingDenseLayoutsArray(tmpDir)
 }

--- a/examples_lib/reading_dense_layouts.go
+++ b/examples_lib/reading_dense_layouts.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var readingDenseLayoutsArrayName = "reading_dense_layouts_array"
+const readingDenseLayoutsArrayName = "reading_dense_layouts_array"
 
 func createReadingDenseLayoutsArray() {
 	// Create a TileDB context.

--- a/examples_lib/reading_incomplete.go
+++ b/examples_lib/reading_incomplete.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Name of array.
-var readingIncompleteArrayName = "reading_incomplete_array"
+const readingIncompleteArrayName = "reading_incomplete_array"
 
 func createReadingIncompleteArray() {
 	// Create a TileDB context.

--- a/examples_lib/reading_incomplete.go
+++ b/examples_lib/reading_incomplete.go
@@ -2,16 +2,12 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 	"github.com/TileDB-Inc/TileDB-Go/bytesizes"
 )
 
-// Name of array.
-const readingIncompleteArrayName = "reading_incomplete_array"
-
-func createReadingIncompleteArray() {
+func createReadingIncompleteArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -65,7 +61,7 @@ func createReadingIncompleteArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, readingIncompleteArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -73,7 +69,7 @@ func createReadingIncompleteArray() {
 	checkError(err)
 }
 
-func writeReadingIncompleteArray() {
+func writeReadingIncompleteArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -86,7 +82,7 @@ func writeReadingIncompleteArray() {
 	a2Off := []uint64{0, 1, 3}
 
 	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, readingIncompleteArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -181,13 +177,13 @@ func printResultsReadingIncomplete(
 	}
 }
 
-func readReadingIncompleteArray() {
+func readReadingIncompleteArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, readingIncompleteArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -265,13 +261,10 @@ func readReadingIncompleteArray() {
 }
 
 func RunReadingIncompleteArray() {
-	createReadingIncompleteArray()
-	writeReadingIncompleteArray()
-	readReadingIncompleteArray()
+	tmpDir := temp("reading_incomplete_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(readingIncompleteArrayName); err == nil {
-		err = os.RemoveAll(readingIncompleteArrayName)
-		checkError(err)
-	}
+	createReadingIncompleteArray(tmpDir)
+	writeReadingIncompleteArray(tmpDir)
+	readReadingIncompleteArray(tmpDir)
 }

--- a/examples_lib/reading_range.go
+++ b/examples_lib/reading_range.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Name of array.
-var readRangeArrayName = "read_range_array"
+const readRangeArrayName = "read_range_array"
 
 func createReadRangeArray() {
 	// Create a TileDB context.

--- a/examples_lib/reading_range.go
+++ b/examples_lib/reading_range.go
@@ -3,15 +3,11 @@ package examples_lib
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const readRangeArrayName = "read_range_array"
-
-func createReadRangeArray() {
+func createReadRangeArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -54,7 +50,7 @@ func createReadRangeArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, readRangeArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -62,7 +58,7 @@ func createReadRangeArray() {
 	checkError(err)
 }
 
-func writeRearRangeArray() {
+func writeRearRangeArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -72,7 +68,7 @@ func writeRearRangeArray() {
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 
 	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, readRangeArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -97,13 +93,13 @@ func writeRearRangeArray() {
 	checkError(err)
 }
 
-func readReadRangeArray(dimIdx uint32) {
+func readReadRangeArray(dir string, dimIdx uint32) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, readRangeArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -163,18 +159,15 @@ func readReadRangeArray(dimIdx uint32) {
 // RunReadRangeArray shows and example creation, writing and range reading
 // of a dense array
 func RunReadRangeArray() {
-	createReadRangeArray()
-	writeRearRangeArray()
-	// Rows
-	readReadRangeArray(0)
-	// Columns
-	readReadRangeArray(1)
+	tmpDir := temp("read_range_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(readRangeArrayName); err == nil {
-		err = os.RemoveAll(readRangeArrayName)
-		checkError(err)
-	}
+	createReadRangeArray(tmpDir)
+	writeRearRangeArray(tmpDir)
+	// Rows
+	readReadRangeArray(tmpDir, 0)
+	// Columns
+	readReadRangeArray(tmpDir, 1)
 }
 
 //  1  2  3  4

--- a/examples_lib/reading_sparse_layouts.go
+++ b/examples_lib/reading_sparse_layouts.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const readingSparseLayoutsArrayName = "reading_sparse_layouts_array"
-
-func createReadingSparseLayoutsArray() {
+func createReadingSparseLayoutsArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -54,7 +50,7 @@ func createReadingSparseLayoutsArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, readingSparseLayoutsArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -62,7 +58,7 @@ func createReadingSparseLayoutsArray() {
 	checkError(err)
 }
 
-func writeReadingSparseLayoutsArray() {
+func writeReadingSparseLayoutsArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -73,7 +69,7 @@ func writeReadingSparseLayoutsArray() {
 	data := []uint32{1, 2, 3, 4, 5, 6}
 
 	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, readingSparseLayoutsArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -102,13 +98,13 @@ func writeReadingSparseLayoutsArray() {
 	checkError(err)
 }
 
-func readReadingSparseLayoutsArray() {
+func readReadingSparseLayoutsArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, readingSparseLayoutsArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -184,13 +180,10 @@ func readReadingSparseLayoutsArray() {
 }
 
 func RunReadingSparseLayouts() {
-	createReadingSparseLayoutsArray()
-	writeReadingSparseLayoutsArray()
-	readReadingSparseLayoutsArray()
+	tmpDir := temp("reading_sparse_layouts_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(readingSparseLayoutsArrayName); err == nil {
-		err = os.RemoveAll(readingSparseLayoutsArrayName)
-		checkError(err)
-	}
+	createReadingSparseLayoutsArray(tmpDir)
+	writeReadingSparseLayoutsArray(tmpDir)
+	readReadingSparseLayoutsArray(tmpDir)
 }

--- a/examples_lib/reading_sparse_layouts.go
+++ b/examples_lib/reading_sparse_layouts.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var readingSparseLayoutsArrayName = "reading_sparse_layouts_array"
+const readingSparseLayoutsArrayName = "reading_sparse_layouts_array"
 
 func createReadingSparseLayoutsArray() {
 	// Create a TileDB context.

--- a/examples_lib/reading_timestamp.go
+++ b/examples_lib/reading_timestamp.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Name of array.
-var timestampArrayName = "timestamp_metadata"
+const timestampArrayName = "timestamp_metadata"
 
 func createTimestampArray() {
 	// Create a TileDB context.

--- a/examples_lib/string_dim.go
+++ b/examples_lib/string_dim.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var stringDimArrayName = "string_dim"
+const stringDimArrayName = "string_dim"
 
 func createStringDimArray() {
 	// Create a TileDB context.

--- a/examples_lib/string_dim.go
+++ b/examples_lib/string_dim.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const stringDimArrayName = "string_dim"
-
-func createStringDimArray() {
+func createStringDimArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -46,7 +42,7 @@ func createStringDimArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, stringDimArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -54,13 +50,13 @@ func createStringDimArray() {
 	checkError(err)
 }
 
-func writeStringDimArray() {
+func writeStringDimArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Open the array for writing
-	array, err := tiledb.NewArray(ctx, stringDimArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -93,13 +89,13 @@ func writeStringDimArray() {
 	checkError(err)
 }
 
-func readStringDimArray() {
+func readStringDimArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, stringDimArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -152,13 +148,10 @@ func readStringDimArray() {
 // RunStringDimArray shows an example of creation, writing and reading of a
 // sparse array with string dim
 func RunStringDimArray() {
-	createStringDimArray()
-	writeStringDimArray()
-	readStringDimArray()
+	tmpDir := temp("string_dim_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(stringDimArrayName); err == nil {
-		err = os.RemoveAll(stringDimArrayName)
-		checkError(err)
-	}
+	createStringDimArray(tmpDir)
+	writeStringDimArray(tmpDir)
+	readStringDimArray(tmpDir)
 }

--- a/examples_lib/using_tiledb_stats.go
+++ b/examples_lib/using_tiledb_stats.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Name of array.
-var statsArrayName = "stats_array"
+const statsArrayName = "stats_array"
 
 func createStatsArray(rowTileExtent uint32, colTileExtent uint32) {
 	// Create a TileDB context.

--- a/examples_lib/using_tiledb_stats.go
+++ b/examples_lib/using_tiledb_stats.go
@@ -1,15 +1,10 @@
 package examples_lib
 
 import (
-	"os"
-
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const statsArrayName = "stats_array"
-
-func createStatsArray(rowTileExtent uint32, colTileExtent uint32) {
+func createStatsArray(dir string, rowTileExtent uint32, colTileExtent uint32) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -54,7 +49,7 @@ func createStatsArray(rowTileExtent uint32, colTileExtent uint32) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, statsArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -62,7 +57,7 @@ func createStatsArray(rowTileExtent uint32, colTileExtent uint32) {
 	checkError(err)
 }
 
-func writeStatsArray() {
+func writeStatsArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -74,7 +69,7 @@ func writeStatsArray() {
 	}
 
 	// Create the query
-	array, err := tiledb.NewArray(ctx, statsArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -99,14 +94,14 @@ func writeStatsArray() {
 	checkError(err)
 }
 
-func readStatsArray() {
+func readStatsArray(dir string) {
 	// Create TileDB context
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, statsArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -155,13 +150,10 @@ func readStatsArray() {
 }
 
 func RunUsingTileDBStats() {
-	createStatsArray(1, 12000)
-	writeStatsArray()
-	readStatsArray()
+	tmpDir := temp("using_tiledb_stats")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(statsArrayName); err == nil {
-		err = os.RemoveAll(statsArrayName)
-		checkError(err)
-	}
+	createStatsArray(tmpDir, 1, 12000)
+	writeStatsArray(tmpDir)
+	readStatsArray(tmpDir)
 }

--- a/examples_lib/utils.go
+++ b/examples_lib/utils.go
@@ -1,0 +1,25 @@
+package examples_lib
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+func checkError(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+// temp creates a temporary directory which contains the given name,
+// or panics if it cannot.
+func temp(name string) string {
+	dir, err := ioutil.TempDir("", name)
+	checkError(err)
+	return dir
+}
+
+// cleanup os.RemoveAlls the given path, or panics if it cannot.
+func cleanup(name string) {
+	checkError(os.RemoveAll(name))
+}

--- a/examples_lib/vacuum.go
+++ b/examples_lib/vacuum.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Name of array.
-var vaccuumSparseArrayName = "vacuum_sparse"
+const vaccuumSparseArrayName = "vacuum_sparse"
 
 func createVacuumSparseArray() {
 	// Create a TileDB context.

--- a/examples_lib/variable_length.go
+++ b/examples_lib/variable_length.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Name of array.
-var variableLengthArrayName = "variable_length_array"
+const variableLengthArrayName = "variable_length_array"
 
 const rowsVariableLengthTileExtent = 4
 const colsVariableLengthTileExtent = 4

--- a/examples_lib/variable_length.go
+++ b/examples_lib/variable_length.go
@@ -2,19 +2,15 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 	"github.com/TileDB-Inc/TileDB-Go/bytesizes"
 )
 
-// Name of array.
-const variableLengthArrayName = "variable_length_array"
-
 const rowsVariableLengthTileExtent = 4
 const colsVariableLengthTileExtent = 4
 
-func createVariableLengthArray() {
+func createVariableLengthArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -70,7 +66,7 @@ func createVariableLengthArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, variableLengthArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -78,7 +74,7 @@ func createVariableLengthArray() {
 	checkError(err)
 }
 
-func writeVariableLengthArray() {
+func writeVariableLengthArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -100,7 +96,7 @@ func writeVariableLengthArray() {
 	}
 
 	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, variableLengthArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -181,14 +177,14 @@ func printResultsVariableLength(
 	}
 }
 
-func readVariableLengthArray() {
+func readVariableLengthArray(dir string) {
 	// Create TileDB context
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, variableLengthArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -244,13 +240,10 @@ func readVariableLengthArray() {
 }
 
 func RunVariableLengthArray() {
-	createVariableLengthArray()
-	writeVariableLengthArray()
-	readVariableLengthArray()
+	tmpDir := temp("variable_length_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(variableLengthArrayName); err == nil {
-		err = os.RemoveAll(variableLengthArrayName)
-		checkError(err)
-	}
+	createVariableLengthArray(tmpDir)
+	writeVariableLengthArray(tmpDir)
+	readVariableLengthArray(tmpDir)
 }

--- a/examples_lib/vfs.go
+++ b/examples_lib/vfs.go
@@ -10,7 +10,7 @@ import (
 	"github.com/TileDB-Inc/TileDB-Go/bytesizes"
 )
 
-var vfsFileName = "tiledb_vfs.bin"
+const vfsFileName = "tiledb_vfs.bin"
 
 func dirsFiles() {
 	// Create a TileDB context.

--- a/examples_lib/vfs.go
+++ b/examples_lib/vfs.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"os"
+	"path/filepath"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 	"github.com/TileDB-Inc/TileDB-Go/bytesizes"
@@ -12,7 +12,7 @@ import (
 
 const vfsFileName = "tiledb_vfs.bin"
 
-func dirsFiles() {
+func dirsFiles(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -28,11 +28,12 @@ func dirsFiles() {
 	checkError(err)
 	defer vfs.Free()
 
-	isDir, err := vfs.IsDir("dir_A")
+	dirA := filepath.Join(dir, "dir_A")
+	isDir, err := vfs.IsDir(dirA)
 	checkError(err)
 
 	if !isDir {
-		err = vfs.CreateDir("dir_A")
+		err = vfs.CreateDir(dirA)
 		checkError(err)
 		fmt.Println("Created 'dir_A'")
 	} else {
@@ -40,11 +41,12 @@ func dirsFiles() {
 	}
 
 	// Creating an (empty) file
-	isFile, err := vfs.IsFile("dir_A/file_A")
+	dirAFileA := filepath.Join(dirA, "file_A")
+	isFile, err := vfs.IsFile(dirAFileA)
 	checkError(err)
 
 	if !isFile {
-		err = vfs.Touch("dir_A/file_A")
+		err = vfs.Touch(dirAFileA)
 		checkError(err)
 		fmt.Println("Created empty file 'dir_A/file_A'")
 	} else {
@@ -52,20 +54,21 @@ func dirsFiles() {
 	}
 
 	// Getting the file size
-	fileSize, err := vfs.FileSize("dir_A/file_A")
+	fileSize, err := vfs.FileSize(dirAFileA)
 	checkError(err)
 	fmt.Printf("Size of file 'dir_A/file_A': %d\n", fileSize)
 
 	// Moving files (moving directories is similar)
+	dirAFileB := filepath.Join(dirA, "file_B")
 	fmt.Println("Moving file 'dir_A/file_A' to 'dir_A/file_B'")
-	err = vfs.MoveFile("dir_A/file_A", "dir_A/file_B")
+	err = vfs.MoveFile(dirAFileA, dirAFileB)
 	checkError(err)
 
 	// Deleting files and directories
 	fmt.Println("Deleting 'dir_A/file_B' and 'dir_A'")
-	err = vfs.RemoveFile("dir_A/file_B")
+	err = vfs.RemoveFile(dirAFileB)
 	checkError(err)
-	err = vfs.RemoveDir("dir_A")
+	err = vfs.RemoveDir(dirA)
 	checkError(err)
 }
 
@@ -82,7 +85,7 @@ func float32ToBytes(float float32) []byte {
 	return bytes
 }
 
-func write() {
+func write(dir string) {
 	// Create TileDB context
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -98,11 +101,13 @@ func write() {
 	checkError(err)
 	defer vfs.Free()
 
+	file := filepath.Join(dir, vfsFileName)
+
 	// Write binary data
-	fh1, err := vfs.Open(vfsFileName, tiledb.TILEDB_VFS_WRITE)
+	fh1, err := vfs.Open(file, tiledb.TILEDB_VFS_WRITE)
 	defer vfs.Close(fh1)
 	if err != nil {
-		fmt.Printf("Error opening file '%s'\n", vfsFileName)
+		fmt.Printf("Error opening file '%s'\n", file)
 	}
 
 	var f1 float32 = 153.0
@@ -113,10 +118,10 @@ func write() {
 	checkError(err)
 
 	// Write binary data again - this will overwrite the previous file
-	fh2, err := vfs.Open("tiledb_vfs.bin", tiledb.TILEDB_VFS_WRITE)
+	fh2, err := vfs.Open(file, tiledb.TILEDB_VFS_WRITE)
 	defer vfs.Close(fh2)
 	if err != nil {
-		fmt.Printf("Error opening file '%s' for write.\n", vfsFileName)
+		fmt.Printf("Error opening file '%s' for write.\n", file)
 	}
 
 	var f2 float32 = 153.1
@@ -127,10 +132,10 @@ func write() {
 	checkError(err)
 
 	// Append binary data to existing file (this will NOT work on S3)
-	fh3, err := vfs.Open("tiledb_vfs.bin", tiledb.TILEDB_VFS_APPEND)
+	fh3, err := vfs.Open(file, tiledb.TILEDB_VFS_APPEND)
 	defer vfs.Close(fh3)
 	if err != nil {
-		fmt.Printf("Error opening file '%s' for append.\n", vfsFileName)
+		fmt.Printf("Error opening file '%s' for append.\n", file)
 	}
 
 	s3 := "ghijkl"
@@ -138,7 +143,7 @@ func write() {
 	checkError(err)
 }
 
-func read() {
+func read(dir string) {
 	// Create TileDB context
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -154,14 +159,16 @@ func read() {
 	checkError(err)
 	defer vfs.Free()
 
+	file := filepath.Join(dir, vfsFileName)
+
 	// Read binary data
-	fh, err := vfs.Open("tiledb_vfs.bin", tiledb.TILEDB_VFS_READ)
+	fh, err := vfs.Open(file, tiledb.TILEDB_VFS_READ)
 	defer vfs.Close(fh)
 	if err != nil {
-		fmt.Printf("Error opening file '%s'\n", vfsFileName)
+		fmt.Printf("Error opening file '%s'\n", file)
 	}
 
-	sizefFile, err := vfs.FileSize(vfsFileName)
+	sizefFile, err := vfs.FileSize(file)
 	checkError(err)
 
 	f1, err := vfs.Read(fh, 0, bytesizes.Float32)
@@ -172,14 +179,13 @@ func read() {
 	fmt.Println("Binary read:")
 	fmt.Println(float32FromBytes(f1))
 	fmt.Println(string(s1))
-
-	// Clean up
-	err = os.RemoveAll(vfsFileName)
-	checkError(err)
 }
 
 func RunVfs() {
-	dirsFiles()
-	write()
-	read()
+	tmpDir := temp("VFS")
+	defer cleanup(tmpDir)
+
+	dirsFiles(tmpDir)
+	write(tmpDir)
+	read(tmpDir)
 }

--- a/examples_lib/writing_dense_global.go
+++ b/examples_lib/writing_dense_global.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const denseGlobalArrayName = "writing_dense_global_array"
-
-func createDenseGlobalArray() {
+func createDenseGlobalArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -54,7 +50,7 @@ func createDenseGlobalArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, denseGlobalArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -62,7 +58,7 @@ func createDenseGlobalArray() {
 	checkError(err)
 }
 
-func writeDenseGlobalArray() {
+func writeDenseGlobalArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -70,7 +66,7 @@ func writeDenseGlobalArray() {
 	subarray := []int32{1, 4, 1, 2}
 
 	// Open the array for writing.
-	array, err := tiledb.NewArray(ctx, denseGlobalArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -107,13 +103,13 @@ func writeDenseGlobalArray() {
 	checkError(err)
 }
 
-func readDenseGlobalArray() {
+func readDenseGlobalArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, denseGlobalArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -148,13 +144,10 @@ func readDenseGlobalArray() {
 }
 
 func RunWritingDenseGlobal() {
-	createDenseGlobalArray()
-	writeDenseGlobalArray()
-	readDenseGlobalArray()
+	tmpDir := temp("writing_dense_global_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(denseGlobalArrayName); err == nil {
-		err = os.RemoveAll(denseGlobalArrayName)
-		checkError(err)
-	}
+	createDenseGlobalArray(tmpDir)
+	writeDenseGlobalArray(tmpDir)
+	readDenseGlobalArray(tmpDir)
 }

--- a/examples_lib/writing_dense_global.go
+++ b/examples_lib/writing_dense_global.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var denseGlobalArrayName = "writing_dense_global_array"
+const denseGlobalArrayName = "writing_dense_global_array"
 
 func createDenseGlobalArray() {
 	// Create a TileDB context.

--- a/examples_lib/writing_dense_global_expansion.go
+++ b/examples_lib/writing_dense_global_expansion.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const denseGlobalExpansionName = "writing_dense_global_expansion_array"
-
-func createDenseGlobalExpansionArray() {
+func createDenseGlobalExpansionArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -50,7 +46,7 @@ func createDenseGlobalExpansionArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, denseGlobalExpansionName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -58,7 +54,7 @@ func createDenseGlobalExpansionArray() {
 	checkError(err)
 }
 
-func writeDenseGlobalExpansionArray() {
+func writeDenseGlobalExpansionArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -66,7 +62,7 @@ func writeDenseGlobalExpansionArray() {
 	subarray := []int32{1, 4, 1, 2}
 
 	// Open the array for writing.
-	array, err := tiledb.NewArray(ctx, denseGlobalExpansionName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -95,7 +91,7 @@ func writeDenseGlobalExpansionArray() {
 	checkError(err)
 }
 
-func writeRowMajorDenseGlobalExpansionArray() {
+func writeRowMajorDenseGlobalExpansionArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -103,7 +99,7 @@ func writeRowMajorDenseGlobalExpansionArray() {
 	subarray := []int32{1, 4, 3, 3}
 
 	// Open the array for writing.
-	array, err := tiledb.NewArray(ctx, denseGlobalExpansionName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -131,13 +127,13 @@ func writeRowMajorDenseGlobalExpansionArray() {
 	checkError(err)
 }
 
-func readDenseGlobalExpansionArray() {
+func readDenseGlobalExpansionArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, denseGlobalExpansionName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -172,14 +168,11 @@ func readDenseGlobalExpansionArray() {
 }
 
 func RunWritingDenseGlobalExpansion() {
-	createDenseGlobalExpansionArray()
-	writeDenseGlobalExpansionArray()
-	writeRowMajorDenseGlobalExpansionArray()
-	readDenseGlobalExpansionArray()
+	tmpDir := temp("writing_dense_global_expansion_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(denseGlobalExpansionName); err == nil {
-		err = os.RemoveAll(denseGlobalExpansionName)
-		checkError(err)
-	}
+	createDenseGlobalExpansionArray(tmpDir)
+	writeDenseGlobalExpansionArray(tmpDir)
+	writeRowMajorDenseGlobalExpansionArray(tmpDir)
+	readDenseGlobalExpansionArray(tmpDir)
 }

--- a/examples_lib/writing_dense_global_expansion.go
+++ b/examples_lib/writing_dense_global_expansion.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var denseGlobalExpansionName = "writing_dense_global_expansion_array"
+const denseGlobalExpansionName = "writing_dense_global_expansion_array"
 
 func createDenseGlobalExpansionArray() {
 	// Create a TileDB context.

--- a/examples_lib/writing_dense_multiple.go
+++ b/examples_lib/writing_dense_multiple.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var denseMultipleArrayName = "writing_dense_multiple_array"
+const denseMultipleArrayName = "writing_dense_multiple_array"
 
 func createDenseMultipleArray() {
 	// Create a TileDB context.

--- a/examples_lib/writing_dense_multiple.go
+++ b/examples_lib/writing_dense_multiple.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const denseMultipleArrayName = "writing_dense_multiple_array"
-
-func createDenseMultipleArray() {
+func createDenseMultipleArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -54,7 +50,7 @@ func createDenseMultipleArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, denseMultipleArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -62,7 +58,7 @@ func createDenseMultipleArray() {
 	checkError(err)
 }
 
-func writeDenseMultipleArray1() {
+func writeDenseMultipleArray1(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -70,7 +66,7 @@ func writeDenseMultipleArray1() {
 	subarray := []int32{1, 2, 1, 2}
 
 	// Open the array for writing.
-	array, err := tiledb.NewArray(ctx, denseMultipleArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -98,7 +94,7 @@ func writeDenseMultipleArray1() {
 	checkError(err)
 }
 
-func writeDenseMultipleArray2() {
+func writeDenseMultipleArray2(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -106,7 +102,7 @@ func writeDenseMultipleArray2() {
 	subarray := []int32{2, 3, 1, 4}
 
 	// Open the array for writing.
-	array, err := tiledb.NewArray(ctx, denseMultipleArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -135,13 +131,13 @@ func writeDenseMultipleArray2() {
 	checkError(err)
 }
 
-func readDenseMultipleArray() {
+func readDenseMultipleArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, denseMultipleArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -179,14 +175,11 @@ func readDenseMultipleArray() {
 }
 
 func RunWritingDenseMultiple() {
-	createDenseMultipleArray()
-	writeDenseMultipleArray1()
-	writeDenseMultipleArray2()
-	readDenseMultipleArray()
+	tmpDir := temp("writing_dense_multiple_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(denseMultipleArrayName); err == nil {
-		err = os.RemoveAll(denseMultipleArrayName)
-		checkError(err)
-	}
+	createDenseMultipleArray(tmpDir)
+	writeDenseMultipleArray1(tmpDir)
+	writeDenseMultipleArray2(tmpDir)
+	readDenseMultipleArray(tmpDir)
 }

--- a/examples_lib/writing_dense_padding.go
+++ b/examples_lib/writing_dense_padding.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var densePaddingArrayName = "writing_dense_padding_array"
+const densePaddingArrayName = "writing_dense_padding_array"
 
 func createDensePaddingArray() {
 	// Create a TileDB context.

--- a/examples_lib/writing_dense_padding.go
+++ b/examples_lib/writing_dense_padding.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const densePaddingArrayName = "writing_dense_padding_array"
-
-func createDensePaddingArray() {
+func createDensePaddingArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -54,7 +50,7 @@ func createDensePaddingArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, densePaddingArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -62,7 +58,7 @@ func createDensePaddingArray() {
 	checkError(err)
 }
 
-func writeDensePaddingArray() {
+func writeDensePaddingArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -70,7 +66,7 @@ func writeDensePaddingArray() {
 	subarray := []int32{2, 3, 1, 2}
 
 	// Open the array for writing.
-	array, err := tiledb.NewArray(ctx, densePaddingArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -99,13 +95,13 @@ func writeDensePaddingArray() {
 	checkError(err)
 }
 
-func readDensePaddingArray() {
+func readDensePaddingArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, densePaddingArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -143,13 +139,10 @@ func readDensePaddingArray() {
 }
 
 func RunWritingDensePadding() {
-	createDensePaddingArray()
-	writeDensePaddingArray()
-	readDensePaddingArray()
+	tmpDir := temp("writing_dense_padding_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(densePaddingArrayName); err == nil {
-		err = os.RemoveAll(densePaddingArrayName)
-		checkError(err)
-	}
+	createDensePaddingArray(tmpDir)
+	writeDensePaddingArray(tmpDir)
+	readDensePaddingArray(tmpDir)
 }

--- a/examples_lib/writing_dense_sparse.go
+++ b/examples_lib/writing_dense_sparse.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const denseSparseArrayName = "writing_dense_sparse_array"
-
-func createDenseSparseArray() {
+func createDenseSparseArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -54,7 +50,7 @@ func createDenseSparseArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, denseSparseArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -62,13 +58,13 @@ func createDenseSparseArray() {
 	checkError(err)
 }
 
-func writeDenseSparseArray() {
+func writeDenseSparseArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Open the array for writing, create the query
-	array, err := tiledb.NewArray(ctx, denseSparseArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -101,13 +97,13 @@ func writeDenseSparseArray() {
 	checkError(err)
 }
 
-func readDenseSparseArray() {
+func readDenseSparseArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, denseSparseArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -159,13 +155,10 @@ func readDenseSparseArray() {
 }
 
 func RunWritingDenseSparse() {
-	createDenseSparseArray()
-	writeDenseSparseArray()
-	readDenseSparseArray()
+	tmpDir := temp("writing_dense_sparse_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(denseSparseArrayName); err == nil {
-		err = os.RemoveAll(denseSparseArrayName)
-		checkError(err)
-	}
+	createDenseSparseArray(tmpDir)
+	writeDenseSparseArray(tmpDir)
+	readDenseSparseArray(tmpDir)
 }

--- a/examples_lib/writing_dense_sparse.go
+++ b/examples_lib/writing_dense_sparse.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var denseSparseArrayName = "writing_dense_sparse_array"
+const denseSparseArrayName = "writing_dense_sparse_array"
 
 func createDenseSparseArray() {
 	// Create a TileDB context.

--- a/examples_lib/writing_sparse_global.go
+++ b/examples_lib/writing_sparse_global.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const sparseGlobalArrayName = "writing_sparse_global_array"
-
-func createSparseGlobalArray() {
+func createSparseGlobalArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -54,7 +50,7 @@ func createSparseGlobalArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, sparseGlobalArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -87,13 +83,13 @@ func execQueryGlobalOrder(tdbCtx *tiledb.Context, array *tiledb.Array,
 	checkError(err)
 }
 
-func writeSparseGlobalArray() {
+func writeSparseGlobalArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Open the array for writing.
-	array, err := tiledb.NewArray(ctx, sparseGlobalArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -114,13 +110,13 @@ func writeSparseGlobalArray() {
 	execQueryGlobalOrder(ctx, array, data2, buffD1, buffD2)
 }
 
-func readSparseGlobalArray() {
+func readSparseGlobalArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, sparseGlobalArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -177,13 +173,10 @@ func readSparseGlobalArray() {
 }
 
 func RunWritingSparseGlobal() {
-	createSparseGlobalArray()
-	writeSparseGlobalArray()
-	readSparseGlobalArray()
+	tmpDir := temp("writing_sparse_global_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(sparseGlobalArrayName); err == nil {
-		err = os.RemoveAll(sparseGlobalArrayName)
-		checkError(err)
-	}
+	createSparseGlobalArray(tmpDir)
+	writeSparseGlobalArray(tmpDir)
+	readSparseGlobalArray(tmpDir)
 }

--- a/examples_lib/writing_sparse_global.go
+++ b/examples_lib/writing_sparse_global.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var sparseGlobalArrayName = "writing_sparse_global_array"
+const sparseGlobalArrayName = "writing_sparse_global_array"
 
 func createSparseGlobalArray() {
 	// Create a TileDB context.

--- a/examples_lib/writing_sparse_heter_dim.go
+++ b/examples_lib/writing_sparse_heter_dim.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var heterArrayName = "writing_sparse_heter_dim"
+const heterArrayName = "writing_sparse_heter_dim"
 
 func createSparseHeterDimArray() {
 	// Create a TileDB context.

--- a/examples_lib/writing_sparse_heter_dim.go
+++ b/examples_lib/writing_sparse_heter_dim.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const heterArrayName = "writing_sparse_heter_dim"
-
-func createSparseHeterDimArray() {
+func createSparseHeterDimArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -50,7 +46,7 @@ func createSparseHeterDimArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, heterArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -58,7 +54,7 @@ func createSparseHeterDimArray() {
 	checkError(err)
 }
 
-func writeSparseHeterDimArray() {
+func writeSparseHeterDimArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
@@ -69,7 +65,7 @@ func writeSparseHeterDimArray() {
 	buffA := []int32{1, 2, 3, 4}
 
 	// Open the array for writing and create the query.
-	array, err := tiledb.NewArray(ctx, heterArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -98,13 +94,13 @@ func writeSparseHeterDimArray() {
 	checkError(err)
 }
 
-func readSparseHeterDimArray() {
+func readSparseHeterDimArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, heterArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -159,13 +155,10 @@ func readSparseHeterDimArray() {
 // RunSparseHeterDimArray shows and example creation, writing and reading of
 // a sparse array using heterogeneus dimensions
 func RunSparseHeterDimArray() {
-	createSparseHeterDimArray()
-	writeSparseHeterDimArray()
-	readSparseHeterDimArray()
+	tmpDir := temp("sparse_heter_dim_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(heterArrayName); err == nil {
-		err = os.RemoveAll(heterArrayName)
-		checkError(err)
-	}
+	createSparseHeterDimArray(tmpDir)
+	writeSparseHeterDimArray(tmpDir)
+	readSparseHeterDimArray(tmpDir)
 }

--- a/examples_lib/writing_sparse_multiple.go
+++ b/examples_lib/writing_sparse_multiple.go
@@ -2,15 +2,11 @@ package examples_lib
 
 import (
 	"fmt"
-	"os"
 
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
-// Name of array.
-const multipleWritesSparseArrayName = "multiple_writes_sparse_array"
-
-func createMultipleWritesSparseArray() {
+func createMultipleWritesSparseArray(dir string) {
 	// Create a TileDB context.
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
@@ -54,7 +50,7 @@ func createMultipleWritesSparseArray() {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, multipleWritesSparseArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -88,13 +84,13 @@ func execQueryUnordered(tdbCtx *tiledb.Context, array *tiledb.Array,
 	checkError(err)
 }
 
-func writeMultipleWritesSparseArray() {
+func writeMultipleWritesSparseArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Open the array for writing.
-	array, err := tiledb.NewArray(ctx, multipleWritesSparseArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -124,13 +120,13 @@ func writeMultipleWritesSparseArray() {
 	checkError(err)
 }
 
-func readMultipleWritesSparseArray() {
+func readMultipleWritesSparseArray(dir string) {
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
 	defer ctx.Free()
 
 	// Prepare the array for reading
-	array, err := tiledb.NewArray(ctx, multipleWritesSparseArrayName)
+	array, err := tiledb.NewArray(ctx, dir)
 	checkError(err)
 	defer array.Free()
 
@@ -187,13 +183,10 @@ func readMultipleWritesSparseArray() {
 }
 
 func RunWritingSparseMultiple() {
-	createMultipleWritesSparseArray()
-	writeMultipleWritesSparseArray()
-	readMultipleWritesSparseArray()
+	tmpDir := temp("writing_sparse_multiple_array")
+	defer cleanup(tmpDir)
 
-	// Cleanup example so unit tests are clean
-	if _, err := os.Stat(multipleWritesSparseArrayName); err == nil {
-		err = os.RemoveAll(multipleWritesSparseArrayName)
-		checkError(err)
-	}
+	createMultipleWritesSparseArray(tmpDir)
+	writeMultipleWritesSparseArray(tmpDir)
+	readMultipleWritesSparseArray(tmpDir)
 }

--- a/examples_lib/writing_sparse_multiple.go
+++ b/examples_lib/writing_sparse_multiple.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Name of array.
-var multipleWritesSparseArrayName = "multiple_writes_sparse_array"
+const multipleWritesSparseArrayName = "multiple_writes_sparse_array"
 
 func createMultipleWritesSparseArray() {
 	// Create a TileDB context.


### PR DESCRIPTION
Inspired by a problem that @snagles ran into in change #174, this converts all the examples in examples_lib to write into a temporary directory where applicable. No behavior changes otherwise.