### PR TITLE
Add query and context stats

### DIFF
--- a/context.go
+++ b/context.go
@@ -150,3 +150,18 @@ func (c *Context) setDefaultTags() error {
 
 	return nil
 }
+
+// Stats gets stats for a context as a string
+func (c *Context) Stats() (string, error) {
+	var stats *C.char
+	if ret := C.tiledb_ctx_get_stats(c.tiledbContext, &stats); ret != C.TILEDB_OK {
+		return "", fmt.Errorf("Error getting stats from context: %s", c.LastError())
+	}
+
+	s := C.GoString(stats)
+	if ret := C.tiledb_stats_free_str(&stats); ret != C.TILEDB_OK {
+		return "", fmt.Errorf("Error freeing string from dumping stats to string")
+	}
+
+	return s, nil
+}

--- a/context_test.go
+++ b/context_test.go
@@ -40,6 +40,16 @@ func ExampleNewContext() {
 	}
 	// Output: true
 	fmt.Println(isS3Supported)
+
+	stats, err := context.Stats()
+	if err != nil {
+		// Handle error
+		return
+	}
+
+	if len(stats) > 0 {
+		// Do something with stats
+	}
 }
 
 // TestNewContext tests setting a new context

--- a/query.go
+++ b/query.go
@@ -3292,3 +3292,18 @@ func (q *Query) Config() (*Config, error) {
 
 	return &config, nil
 }
+
+// Stats gets query stats for a query as a string
+func (q *Query) Stats() (string, error) {
+	var stats *C.char
+	if ret := C.tiledb_query_get_stats(q.context.tiledbContext, q.tiledbQuery, &stats); ret != C.TILEDB_OK {
+		return "", fmt.Errorf("Error getting stats from query: %s", q.context.LastError())
+	}
+
+	s := C.GoString(stats)
+	if ret := C.tiledb_stats_free_str(&stats); ret != C.TILEDB_OK {
+		return "", fmt.Errorf("Error freeing string from dumping stats to string")
+	}
+
+	return s, nil
+}


### PR DESCRIPTION
Returns results as a string while the Stats API contract is TBD. I expect we should return a struct in the future. Current example:

```
{
  "timers": {
    "Context.StorageManager.Query.Reader.unfilter_coord_tiles.sum": 0.000418128,
    "Context.StorageManager.Query.Reader.unfilter_coord_tiles.avg": 0.000139376,
    "Context.StorageManager.Query.Reader.unfilter_attr_tiles.sum": 0.000282641,
    "Context.StorageManager.Query.Reader.unfilter_attr_tiles.avg": 0.000282641,
    "Context.StorageManager.Query.Reader.read.sum": 0.00506632,
    "Context.StorageManager.Query.Reader.read.avg": 0.00506632,
    "Context.StorageManager.Query.Reader.init_state.sum": 0.000134505,
    "Context.StorageManager.Query.Reader.init_state.avg": 0.000134505,
    "Context.StorageManager.Query.Reader.copy_var_attr_values.sum": 6.4168e-05,
    "Context.StorageManager.Query.Reader.copy_var_attr_values.avg": 6.4168e-05,
    "Context.StorageManager.Query.Reader.copy_fixed_coords.sum": 0.000101714,
    "Context.StorageManager.Query.Reader.copy_fixed_coords.avg": 5.0857e-05,
    "Context.StorageManager.Query.Reader.copy_coords.sum": 0.000139459,
    "Context.StorageManager.Query.Reader.copy_coords.avg": 0.000139459,
    "Context.StorageManager.Query.Reader.copy_attr_values.sum": 0.00135278,
    "Context.StorageManager.Query.Reader.copy_attr_values.avg": 0.00135278,
    "Context.StorageManager.Query.Reader.coord_tiles.sum": 0.0011391,
    "Context.StorageManager.Query.Reader.coord_tiles.avg": 0.000569549,
    "Context.StorageManager.Query.Reader.compute_sparse_result_tiles.sum": 6.8401e-05,
    "Context.StorageManager.Query.Reader.compute_sparse_result_tiles.avg": 6.8401e-05,
    "Context.StorageManager.Query.Reader.compute_sparse_result_cell_slabs_sparse.sum": 1.5961e-05,
    "Context.StorageManager.Query.Reader.compute_sparse_result_cell_slabs_sparse.avg": 1.5961e-05,
    "Context.StorageManager.Query.Reader.compute_result_coords.sum": 0.00182797,
    "Context.StorageManager.Query.Reader.compute_result_coords.avg": 0.00182797,
    "Context.StorageManager.Query.Reader.compute_range_result_coords.sum": 8.5271e-05,
    "Context.StorageManager.Query.Reader.compute_range_result_coords.avg": 8.5271e-05,
    "Context.StorageManager.Query.Reader.attr_tiles.sum": 0.000902534,
    "Context.StorageManager.Query.Reader.attr_tiles.avg": 0.000902534,
    "Context.StorageManager.Query.Reader.SubarrayPartitioner.read_next_partition.sum": 0.00164822,
    "Context.StorageManager.Query.Reader.SubarrayPartitioner.read_next_partition.avg": 0.00164822,
    "Context.StorageManager.Query.Reader.Subarray.read_load_relevant_rtrees.sum": 0.000427194,
    "Context.StorageManager.Query.Reader.Subarray.read_load_relevant_rtrees.avg": 0.000427194,
    "Context.StorageManager.Query.Reader.Subarray.read_compute_tile_overlap.sum": 0.00090967,
    "Context.StorageManager.Query.Reader.Subarray.read_compute_tile_overlap.avg": 0.00090967,
    "Context.StorageManager.Query.Reader.Subarray.read_compute_relevant_tile_overlap.sum": 0.000225574,
    "Context.StorageManager.Query.Reader.Subarray.read_compute_relevant_tile_overlap.avg": 0.000225574,
    "Context.StorageManager.Query.Reader.Subarray.read_compute_relevant_frags.sum": 0.00017724,
    "Context.StorageManager.Query.Reader.Subarray.read_compute_relevant_frags.avg": 0.00017724
  },
  "counters": {
    "Context.StorageManager.Query.Reader.result_num": 1,
    "Context.StorageManager.Query.Reader.read_unfiltered_byte_num": 54,
    "Context.StorageManager.Query.Reader.overlap_tile_num": 1,
    "Context.StorageManager.Query.Reader.loop_num": 1,
    "Context.StorageManager.Query.Reader.dim_fixed_num": 2,
    "Context.StorageManager.Query.Reader.cell_num": 3,
    "Context.StorageManager.Query.Reader.attr_var_num": 1,
    "Context.StorageManager.Query.Reader.SubarrayPartitioner.compute_current_start_end.ranges": 1,
    "Context.StorageManager.Query.Reader.SubarrayPartitioner.compute_current_start_end.found": 1,
    "Context.StorageManager.Query.Reader.SubarrayPartitioner.compute_current_start_end.adjusted_ranges": 1,
    "Context.StorageManager.Query.Reader.Subarray.precompute_tile_overlap.tile_overlap_byte_size": 64,
    "Context.StorageManager.Query.Reader.Subarray.precompute_tile_overlap.relevant_fragment_num": 1,
    "Context.StorageManager.Query.Reader.Subarray.precompute_tile_overlap.ranges_requested": 1,
    "Context.StorageManager.Query.Reader.Subarray.precompute_tile_overlap.ranges_computed": 1,
    "Context.StorageManager.Query.Reader.Subarray.precompute_tile_overlap.fragment_num": 1
  }
}
```