### PR TITLE
Fix segfault when attempting to DeserializeArraySchema invalid data.

### DIFF
--- a/serialize_test.go
+++ b/serialize_test.go
@@ -1,0 +1,32 @@
+package tiledb
+
+import (
+	"runtime"
+	"runtime/debug"
+	"testing"
+)
+
+func TestDeserializeArraySchemaGC(t *testing.T) {
+	// Disable garbage collection for this test.
+	// TODO: Pull this out into a "disableGC" helper using t.Cleanup
+	// when we stop supporting Go 1.13.
+	was := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(was)
+
+	ctx, err := NewContext(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buffer, err := NewBuffer(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := buffer.SetBuffer([]byte(`invalid`)); err != nil {
+		t.Fatal(err)
+	}
+	if schema, err := DeserializeArraySchema(buffer, TILEDB_CAPNP, true); err == nil {
+		t.Fatalf("DeserializeArraySchema(bogus JSON) -> %v; want err", schema)
+	}
+	runtime.GC()
+	runtime.GC()
+}


### PR DESCRIPTION
https://github.com/TileDB-Inc/TileDB/blob/ecfb3c629a8f3cf9377661afa94bedd0f26ec26f/tiledb/sm/c_api/tiledb.cc#L5275-L5290

In tiledb_deserialize_array_schema, `*array_schema` will be
unconditionally set to a newly-allocated address. If an error later
occurs, `*array_schema` remains at that value, but the memory that it
points to *has already been freed*. That means that, on the Go side,
it sees the `ArraySchema.tiledbArraySchema` as a non-nil pointer,
so when it goes to free it in `ArraySchema.Free`, the memory will be
freed again.

This change works around that by only adding the finalizer *after*
it is verified that there was no error.

---

Editor’s notes:

- It would be good to add tests on the other functions but I don’t know of a reliable way to get them to error out unlike trying to deserialize an invalid schema.
- We should probably set returned-but-freed out-param pointers to nullptr in the C API.
- It is well after midnight, do not be like me, go to sleep at a reasonable time.