### PR TITLE
Expand documentation of all x.Free() functions.

### DIFF
--- a/array.go
+++ b/array.go
@@ -68,7 +68,11 @@ func NewArray(tdbCtx *Context, uri string) (*Array, error) {
 	return &array, nil
 }
 
-// Free tiledb_array_t that was allocated on heap in c
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (a *Array) Free() {
 	if a.tiledbArray != nil {
 		a.Close()

--- a/array_schema.go
+++ b/array_schema.go
@@ -124,7 +124,11 @@ func NewArraySchema(tdbCtx *Context, arrayType ArrayType) (*ArraySchema, error) 
 	return &arraySchema, nil
 }
 
-// Free tiledb_array_schema_t that was allocated on heap in c
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (a *ArraySchema) Free() {
 	if a.tiledbArraySchema != nil {
 		C.tiledb_array_schema_free(&a.tiledbArraySchema)

--- a/attribute.go
+++ b/attribute.go
@@ -50,7 +50,11 @@ func NewAttribute(context *Context, name string, datatype Datatype) (*Attribute,
 	return &attribute, nil
 }
 
-// Free tiledb_attribute_t that was allocated on heap in c
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (a *Attribute) Free() {
 	if a.tiledbAttribute != nil {
 		C.tiledb_attribute_free(&a.tiledbAttribute)

--- a/buffer.go
+++ b/buffer.go
@@ -40,7 +40,11 @@ func NewBuffer(context *Context) (*Buffer, error) {
 	return &buffer, nil
 }
 
-// Free c-alloc'ed data types
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (b *Buffer) Free() {
 	if b.tiledbBuffer != nil {
 		C.tiledb_buffer_free(&b.tiledbBuffer)

--- a/buffer_list.go
+++ b/buffer_list.go
@@ -35,7 +35,11 @@ func NewBufferList(context *Context) (*BufferList, error) {
 	return &bufferList, nil
 }
 
-// Free c-alloc'ed data types
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (b *BufferList) Free() {
 	if b.tiledbBufferList != nil {
 		C.tiledb_buffer_list_free(&b.tiledbBufferList)

--- a/config.go
+++ b/config.go
@@ -146,7 +146,11 @@ func LoadConfig(uri string) (*Config, error) {
 	return &config, nil
 }
 
-// Free tiledb_config_t that was allocated on heap in c
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (c *Config) Free() {
 	if c.tiledbConfig != nil {
 		C.tiledb_config_free(&c.tiledbConfig)

--- a/config_iter.go
+++ b/config_iter.go
@@ -43,7 +43,11 @@ func NewConfigIter(config *Config, prefix string) (*ConfigIter, error) {
 	return &ci, nil
 }
 
-// Free tiledb_config_iter_t that was allocated on heap in c
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (ci *ConfigIter) Free() {
 	if ci.tiledbConfigIter != nil {
 		C.tiledb_config_iter_free(&ci.tiledbConfigIter)

--- a/context.go
+++ b/context.go
@@ -71,7 +71,11 @@ func NewContextFromMap(cfgMap map[string]string) (*Context, error) {
 	return NewContext(config)
 }
 
-// Free tiledb_ctx_t that was allocated on heap in c
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (c *Context) Free() {
 	if c.tiledbContext != nil {
 		C.tiledb_ctx_free(&c.tiledbContext)

--- a/dimension.go
+++ b/dimension.go
@@ -233,7 +233,11 @@ func NewStringDimension(context *Context, name string) (*Dimension, error) {
 	return &dimension, nil
 }
 
-// Free tiledb_dimension_t that was allocated on heap in c
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (d *Dimension) Free() {
 	if d.tiledbDimension != nil {
 		C.tiledb_dimension_free(&d.tiledbDimension)

--- a/domain.go
+++ b/domain.go
@@ -40,7 +40,11 @@ func NewDomain(tdbCtx *Context) (*Domain, error) {
 	return &domain, nil
 }
 
-// Free tiledb_domain_t that was allocated on heap in c
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (d *Domain) Free() {
 	if d.tiledbDomain != nil {
 		C.tiledb_domain_free(&d.tiledbDomain)

--- a/filter.go
+++ b/filter.go
@@ -37,7 +37,11 @@ func NewFilter(context *Context, filterType FilterType) (*Filter, error) {
 	return &filter, nil
 }
 
-// Free c-alloc'ed data types
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (f *Filter) Free() {
 	if f.tiledbFilter != nil {
 		C.tiledb_filter_free(&f.tiledbFilter)

--- a/filter_list.go
+++ b/filter_list.go
@@ -36,7 +36,11 @@ func NewFilterList(context *Context) (*FilterList, error) {
 	return &filterList, nil
 }
 
-// Free c-alloc'ed data types
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (f *FilterList) Free() {
 	if f.tiledbFilterList != nil {
 		C.tiledb_filter_list_free(&f.tiledbFilterList)

--- a/fragment_info.go
+++ b/fragment_info.go
@@ -49,7 +49,11 @@ func NewFragmentInfo(tdbCtx *Context, uri string) (*FragmentInfo, error) {
 	return &fI, nil
 }
 
-// Free frees tiledb_fragment_info_t that was allocated on heap in c
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (fI *FragmentInfo) Free() {
 	if fI.tiledbFragmentInfo != nil {
 		C.tiledb_fragment_info_free(&fI.tiledbFragmentInfo)

--- a/query.go
+++ b/query.go
@@ -82,7 +82,11 @@ func NewQuery(tdbCtx *Context, array *Array) (*Query, error) {
 	return &query, nil
 }
 
-// Free tiledb_query_t that was allocated on heap in c
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (q *Query) Free() {
 	q.bufferMutex.Lock()
 	defer q.bufferMutex.Unlock()

--- a/query_condition.go
+++ b/query_condition.go
@@ -58,7 +58,11 @@ func NewQueryConditionCombination(tdbCtx *Context, left *QueryCondition, op Quer
 	return &qc, nil
 }
 
-// Free tiledb_query_condition_t that was allocated on heap in c
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (qc *QueryCondition) Free() {
 	if qc.cond != nil {
 		C.tiledb_query_condition_free(&qc.cond)

--- a/vfs.go
+++ b/vfs.go
@@ -31,7 +31,11 @@ type VFSfh struct {
 	uri         string
 }
 
-// Free a tiledb c vfs file handler
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (v *VFSfh) Free() {
 	if v.tiledbVFSfh != nil {
 		C.tiledb_vfs_fh_free(&v.tiledbVFSfh)
@@ -86,7 +90,11 @@ func NewVFS(context *Context, config *Config) (*VFS, error) {
 	return &vfs, nil
 }
 
-// Free tiledb_vfs_t c structure that was allocated on the heap
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be
+// called earlier to manually release memory if needed. Free is idempotent and
+// can safely be called many times on the same object; if it has already
+// been freed, it will not be freed again.
 func (v *VFS) Free() {
 	if v.tiledbVFS != nil {
 		C.tiledb_vfs_free(&v.tiledbVFS)


### PR DESCRIPTION
This change replaces the doc comments for all the Free functions with
a more descriptive one that addresses that (a) it is idempotent and
(b) it is called automatically.