### PR TITLE
Update CI workflows to only cover supported versions of Go.

### DIFF
--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: [1.13, 1.14, 1.15]
+        go: ["1.15", "1.16"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v2
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: [1.13, 1.14, 1.15]
+        go: ["1.15", "1.16"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v2


### PR DESCRIPTION
Our go.mod file says we require Go 1.15, and now that Go 1.16 is out,
v1.14 is no longer supported.