### PR TITLE
re-enable ASAN run and improve build/test workflow

### DIFF
--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -80,7 +80,7 @@ jobs:
 
     # Tests TileDB-Go
     - name: Test TileDB-Go
-      run: go test -v $(go list ./... | grep -v /cmd/)
+      run: go test -v ./...
 
   Macos_Test:
     runs-on: macos-10.15
@@ -119,7 +119,7 @@ jobs:
 
     # Tests TileDB-Go
     - name: Test TileDB-Go
-      run: go test -v $(go list ./... | grep -v /cmd/)
+      run: go test -v ./...
 
   Linux_Address_Sanitizer:
     runs-on: ubuntu-18.04
@@ -160,5 +160,4 @@ jobs:
     # Tests TileDB-Go
     - name: Running examples using address sanitizer flags
       continue-on-error: true
-      run: ./.github/scripts/build_with_sanitizer_and_run.sh
-      shell: bash
+      run: go run -tags asan ./cmd/tiledb-go-examples

--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -25,6 +25,8 @@ jobs:
     name: lint
     runs-on: ubuntu-18.04
     steps:
+
+    # Checks out repository
     - uses: actions/checkout@v2
 
     # Downloads TileDB-Core from release assets and install
@@ -47,6 +49,7 @@ jobs:
         # Will be checking following versions
         go: ["1.15", "1.16"]
     steps:
+
     # Checks out repository
     - uses: actions/checkout@v2
 
@@ -61,6 +64,19 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
+
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Install dependencies
+      run: go get -t .
 
     # Tests TileDB-Go
     - name: Test TileDB-Go
@@ -88,6 +104,19 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/Library/Caches/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Install dependencies
+      run: go get -t .
+
     # Tests TileDB-Go
     - name: Test TileDB-Go
       run: go test -v $(go list ./... | grep -v /cmd/)
@@ -113,6 +142,20 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
+
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-asan
+        restore-keys: |
+          ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          ${{ runner.os }}-go-
+
+    - name: Install dependencies
+      run: go get -t .
 
     # Tests TileDB-Go
     - name: Running examples using address sanitizer flags

--- a/cmd/tiledb-go-examples/asan_off.go
+++ b/cmd/tiledb-go-examples/asan_off.go
@@ -1,0 +1,7 @@
+// +build !asan
+//go:build !asan
+
+package main
+
+// maybeASAN runs ASAN if the ASAN build tag is enabled.
+func maybeASAN() { /* don't run ASAN. */ }

--- a/cmd/tiledb-go-examples/asan_on.go
+++ b/cmd/tiledb-go-examples/asan_on.go
@@ -1,0 +1,14 @@
+// +build asan
+//go:build asan
+
+package main
+
+// #cgo CFLAGS: -fsanitize=address
+// #cgo LDFLAGS: -fsanitize=address
+// void __lsan_do_leak_check(void);
+import "C"
+
+// maybeASAN runs ASAN if the ASAN build tag is enabled.
+func maybeASAN() {
+	C.__lsan_do_leak_check()
+}

--- a/cmd/tiledb-go-examples/main.go
+++ b/cmd/tiledb-go-examples/main.go
@@ -1,8 +1,10 @@
+// tiledb-go-examples runs all of TileDB's example code.
+//
+// If built with "-tags asan", it will also perform an ASAN check after running:
+//
+//     go run -tags asan ./cmd/tiledb-go-examples
 package main
 
-// void __lsan_do_leak_check(void);
-//
-// import "C"
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
 func main() {
@@ -38,5 +40,5 @@ func main() {
 	examples_lib.RunSparseHeterDimArray()
 	examples_lib.RunWritingSparseMultiple()
 
-	C.__lsan_do_leak_check()
+	maybeASAN()
 }


### PR DESCRIPTION
This re-enables running the ASAN build of the TileDB-Go examples using the `asan` build tag. It also adds a cache for the Go dependencies. (This pattern can later be followed to cache the built TileDB core library to avoid needing to build it from source every time.)