### PR TITLE
Removes not experimental tag from vacuum test

### DIFF
--- a/.github/scripts/install_tiledb_source_linux.sh
+++ b/.github/scripts/install_tiledb_source_linux.sh
@@ -1,5 +1,5 @@
 set -e -x
-git clone -b bd/ch9808-schema-evolution-serialization https://github.com/TileDB-Inc/TileDB.git
+git clone https://github.com/TileDB-Inc/TileDB.git
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..

--- a/.github/scripts/install_tiledb_source_macos.sh
+++ b/.github/scripts/install_tiledb_source_macos.sh
@@ -1,5 +1,5 @@
 set -e -x
-git clone -b bd/ch9808-schema-evolution-serialization https://github.com/TileDB-Inc/TileDB.git
+git clone https://github.com/TileDB-Inc/TileDB.git
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..

--- a/examples/vacuum_test.go
+++ b/examples/vacuum_test.go
@@ -1,6 +1,3 @@
-//go:build !experimental
-// +build !experimental
-
 /**
  * @file   vacuum_test.go
  *


### PR DESCRIPTION
Issue with fragments is resolved in TileDB Core 2.4, test passes