### PR TITLE
Add explicit link to GoDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ free'ing of C heap allocated structures.
 
 ## Quick Links
 
+- GoDoc API documentation: https://pkg.go.dev/github.com/TileDB-Inc/TileDB-Go
 - Full Installation Docs: [https://docs.tiledb.com/main/how-to/installation](https://docs.tiledb.com/main/how-to/installation)
 - Quickstart: [https://docs.tiledb.com/quickstart](https://docs.tiledb.com/main/solutions/tiledb-embedded/installation/quick-install)
 - Full developer documentation for all APIs and integrations: [https://docs.tiledb.com](https://docs.tiledb.com)


### PR DESCRIPTION
(I know it's linked from the status, but that's too subtle for me)