### PR TITLE
Add cancel tasks on context func

### DIFF
--- a/context.go
+++ b/context.go
@@ -9,6 +9,7 @@ package tiledb
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"unsafe"
@@ -80,6 +81,15 @@ func (c *Context) Free() {
 	if c.tiledbContext != nil {
 		C.tiledb_ctx_free(&c.tiledbContext)
 	}
+}
+
+// CancelAllTasks cancels all currently executing tasks on the context
+func (c *Context) CancelAllTasks() error {
+	ret := C.tiledb_ctx_cancel_tasks(c.tiledbContext)
+	if ret != C.TILEDB_OK {
+		return errors.New("failed to cancel tasks")
+	}
+	return nil
 }
 
 // Config retrieves a copy of the config from context

--- a/context_test.go
+++ b/context_test.go
@@ -77,6 +77,19 @@ func TestNewContext(t *testing.T) {
 	assert.NotNil(t, context)
 }
 
+// TestNewContext tests setting a new context
+func TestCancelAllTasks(t *testing.T) {
+	config, err := NewConfig()
+	assert.Nil(t, err)
+
+	context, err := NewContext(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, context)
+
+	// just call cancel with no tasks
+	assert.NoError(t, context.CancelAllTasks())
+}
+
 // TestGetContextConfig tests creating a new Context with config vars.
 func TestGetContextConfig(t *testing.T) {
 	// Create a context with a non-default value:


### PR DESCRIPTION
Adds the ctx_cancel_tasks Go wrapper func. This can be used to cancel any long running tasks associated with the context. Common use case would likely include long running queries that have exceeded a configured timeout.