### PR TITLE
Add getters for internal tiledb ctx

### DIFF
--- a/array.go
+++ b/array.go
@@ -80,6 +80,11 @@ func (a *Array) Free() {
 	}
 }
 
+// Context exposes the internal TileDB context used to initialize the array
+func (a *Array) Context() *Context {
+	return a.context
+}
+
 // ArrayOpenOptions define the flexibile parameters in which arrays can be opened with.
 type ArrayOpenOption func(tdbArray *Array) error
 

--- a/array_schema.go
+++ b/array_schema.go
@@ -59,6 +59,11 @@ func (a *ArraySchema) MarshalJSON() ([]byte, error) {
 	return cpy, nil
 }
 
+// Context exposes the internal TileDB context used to initialize the array schema
+func (a *ArraySchema) Context() *Context {
+	return a.context
+}
+
 // UnmarshalJSON marshal arraySchema struct to json using tiledb
 func (a *ArraySchema) UnmarshalJSON(b []byte) error {
 	var err error

--- a/array_schema_evolution.go
+++ b/array_schema_evolution.go
@@ -58,6 +58,11 @@ func (ase *ArraySchemaEvolution) Free() {
 	}
 }
 
+// Context exposes the internal TileDB context used to initialize the array schema evolution
+func (ase *ArraySchemaEvolution) Context() *Context {
+	return ase.context
+}
+
 // AddAttribute adds an attribute to an array schema evolution.
 func (ase *ArraySchemaEvolution) AddAttribute(attribute *Attribute) error {
 	name, err := attribute.Name()

--- a/attribute.go
+++ b/attribute.go
@@ -61,6 +61,11 @@ func (a *Attribute) Free() {
 	}
 }
 
+// Context exposes the internal TileDB context used to initialize the attribute
+func (a *Attribute) Context() *Context {
+	return a.context
+}
+
 // SetFilterList sets the attribute filterList
 func (a *Attribute) SetFilterList(filterlist *FilterList) error {
 	ret := C.tiledb_attribute_set_filter_list(a.context.tiledbContext, a.tiledbAttribute, filterlist.tiledbFilterList)

--- a/buffer.go
+++ b/buffer.go
@@ -51,6 +51,11 @@ func (b *Buffer) Free() {
 	}
 }
 
+// Context exposes the internal TileDB context used to initialize the buffer
+func (b *Buffer) Context() *Context {
+	return b.context
+}
+
 // SetType sets buffer datatype
 func (b *Buffer) SetType(datatype Datatype) error {
 	ret := C.tiledb_buffer_set_type(b.context.tiledbContext, b.tiledbBuffer, C.tiledb_datatype_t(datatype))

--- a/buffer_list.go
+++ b/buffer_list.go
@@ -46,6 +46,11 @@ func (b *BufferList) Free() {
 	}
 }
 
+// Context exposes the internal TileDB context used to initialize the buffer list
+func (b *BufferList) Context() *Context {
+	return b.context
+}
+
 // NumBuffers returns number of buffers in the list
 func (b *BufferList) NumBuffers() (uint64, error) {
 	var numBuffers C.uint64_t

--- a/dimension.go
+++ b/dimension.go
@@ -244,6 +244,11 @@ func (d *Dimension) Free() {
 	}
 }
 
+// Context exposes the internal TileDB context used to initialize the dimension
+func (d *Dimension) Context() *Context {
+	return d.context
+}
+
 // SetFilterList sets the dimension filterList
 func (d *Dimension) SetFilterList(filterlist *FilterList) error {
 	ret := C.tiledb_dimension_set_filter_list(d.context.tiledbContext, d.tiledbDimension, filterlist.tiledbFilterList)

--- a/domain.go
+++ b/domain.go
@@ -51,6 +51,11 @@ func (d *Domain) Free() {
 	}
 }
 
+// Context exposes the internal TileDB context used to initialize the domain
+func (d *Domain) Context() *Context {
+	return d.context
+}
+
 // Type returns a domains type deduced from dimensions
 func (d *Domain) Type() (Datatype, error) {
 	var datatype C.tiledb_datatype_t

--- a/filter.go
+++ b/filter.go
@@ -48,6 +48,11 @@ func (f *Filter) Free() {
 	}
 }
 
+// Context exposes the internal TileDB context used to initialize the filter
+func (f *Filter) Context() *Context {
+	return f.context
+}
+
 // Type returns the filter type
 func (f *Filter) Type() (FilterType, error) {
 	var filterType C.tiledb_filter_type_t

--- a/filter_list.go
+++ b/filter_list.go
@@ -47,6 +47,11 @@ func (f *FilterList) Free() {
 	}
 }
 
+// Context exposes the internal TileDB context used to initialize the filter list
+func (f *FilterList) Context() *Context {
+	return f.context
+}
+
 // AddFilter appends a filter to a filter list. Data is processed through
 // each filter in the order the filters were added.
 func (f *FilterList) AddFilter(filter *Filter) error {

--- a/fragment_info.go
+++ b/fragment_info.go
@@ -58,6 +58,11 @@ func (fI *FragmentInfo) Free() {
 	}
 }
 
+// Context exposes the internal TileDB context used to initialize the fragment info
+func (fI *FragmentInfo) Context() *Context {
+	return fI.context
+}
+
 // Load loads the fragment info.
 func (fI *FragmentInfo) Load() error {
 	ret := C.tiledb_fragment_info_load(fI.context.tiledbContext, fI.tiledbFragmentInfo)

--- a/query.go
+++ b/query.go
@@ -97,6 +97,11 @@ func (q *Query) Free() {
 	}
 }
 
+// Context exposes the internal TileDB context used to initialize the query
+func (q *Query) Context() *Context {
+	return q.context
+}
+
 // SetSubArray Sets a subarray, defined in the order dimensions were added.
 // Coordinates are inclusive. For the case of writes, this is meaningful only
 // for dense arrays, and specifically dense writes.

--- a/query_condition.go
+++ b/query_condition.go
@@ -69,6 +69,11 @@ func (qc *QueryCondition) Free() {
 	}
 }
 
+// Context exposes the internal TileDB context used to initialize the query condition
+func (qc *QueryCondition) Context() *Context {
+	return qc.context
+}
+
 func (qc *QueryCondition) initQueryCondition(attributeName string, value interface{}, op QueryConditionOp) error {
 	cname := C.CString(attributeName)
 	defer C.free(unsafe.Pointer(cname))

--- a/vfs.go
+++ b/vfs.go
@@ -42,6 +42,11 @@ func (v *VFSfh) Free() {
 	}
 }
 
+// Context exposes the internal TileDB context used to initialize the vfsh
+func (v *VFSfh) Context() *Context {
+	return v.context
+}
+
 // IsClosed checks a vfs file handler to see if it is closed. Return true if
 // file handler is closed, false if its not closed and error is non-nil on error
 func (v *VFSfh) IsClosed() (bool, error) {
@@ -99,6 +104,11 @@ func (v *VFS) Free() {
 	if v.tiledbVFS != nil {
 		C.tiledb_vfs_free(&v.tiledbVFS)
 	}
+}
+
+// Context exposes the internal TileDB context used to initialize the vfs
+func (v *VFS) Context() *Context {
+	return v.context
 }
 
 // Config retrieves a copy of the config from vfs


### PR DESCRIPTION
Exposes the internal tiledb context used for initialization for a Getter. Guards against setting by keeping the field unexported. 