### PR TITLE
Do not error for empty metadata value

### DIFF
--- a/array.go
+++ b/array.go
@@ -1038,10 +1038,6 @@ func (a *Array) GetMetadata(key string) (Datatype, uint, interface{}, error) {
 		return 0, 0, nil, fmt.Errorf("Error getting metadata from array, key: %s does not exist", key)
 	}
 
-	if cvalue == nil {
-		return 0, 0, nil, fmt.Errorf("Error getting metadata from array, value is empty")
-	}
-
 	datatype := Datatype(cType)
 	value, err := datatype.GetValue(valueNum, cvalue)
 	if err != nil {
@@ -1095,10 +1091,6 @@ func (a *Array) GetMetadataFromIndexWithValueLimit(index uint64, limit *uint) (*
 	valueNum := uint(cValueNum)
 	if valueNum == 0 {
 		return nil, fmt.Errorf("Error getting metadata from array, Index: %d does not exist", index)
-	}
-
-	if cvalue == nil {
-		return nil, fmt.Errorf("Error getting metadata from array, value is empty")
 	}
 
 	datatype := Datatype(cType)

--- a/enums.go
+++ b/enums.go
@@ -255,127 +255,116 @@ func (d Datatype) MakeSlice(numElements uint64) (interface{}, unsafe.Pointer, er
 
 // GetValue gets value stored in a void pointer for this data type
 func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, error) {
-	var value interface{}
 	switch d {
 	case TILEDB_INT8:
 		if valueNum > 1 {
 			tmpValue := make([]int8, valueNum)
-			tmpslice := (*[1 << 46]C.int8_t)(unsafe.Pointer(cvalue))[:valueNum:valueNum]
+			tmpslice := (*[1 << 46]C.int8_t)(cvalue)[:valueNum:valueNum]
 			for i, s := range tmpslice {
 				tmpValue[i] = int8(s)
 			}
-			value = tmpValue
-		} else {
-			value = *(*int8)(unsafe.Pointer(cvalue))
+			return tmpValue, nil
 		}
+		return *(*int8)(cvalue), nil
 	case TILEDB_INT16:
 		if valueNum > 1 {
 			tmpValue := make([]int16, valueNum)
-			tmpslice := (*[1 << 46]C.int16_t)(unsafe.Pointer(cvalue))[:valueNum:valueNum]
+			tmpslice := (*[1 << 46]C.int16_t)(cvalue)[:valueNum:valueNum]
 			for i, s := range tmpslice {
 				tmpValue[i] = int16(s)
 			}
-			value = tmpValue
-		} else {
-			value = *(*int16)(unsafe.Pointer(cvalue))
+			return tmpValue, nil
 		}
+		return *(*int16)(cvalue), nil
 	case TILEDB_INT32:
 		if valueNum > 1 {
 			tmpValue := make([]int32, valueNum)
-			tmpslice := (*[1 << 46]C.int32_t)(unsafe.Pointer(cvalue))[:valueNum:valueNum]
+			tmpslice := (*[1 << 46]C.int32_t)(cvalue)[:valueNum:valueNum]
 			for i, s := range tmpslice {
 				tmpValue[i] = int32(s)
 			}
-			value = tmpValue
-		} else {
-			value = *(*int32)(unsafe.Pointer(cvalue))
+			return tmpValue, nil
 		}
+		return *(*int32)(cvalue), nil
 	case TILEDB_INT64:
 		if valueNum > 1 {
 			tmpValue := make([]int64, valueNum)
-			tmpslice := (*[1 << 46]C.int64_t)(unsafe.Pointer(cvalue))[:valueNum:valueNum]
+			tmpslice := (*[1 << 46]C.int64_t)(cvalue)[:valueNum:valueNum]
 			for i, s := range tmpslice {
 				tmpValue[i] = int64(s)
 			}
-			value = tmpValue
-		} else {
-			value = *(*int64)(unsafe.Pointer(cvalue))
+			return tmpValue, nil
 		}
+		return *(*int64)(cvalue), nil
 	case TILEDB_UINT8:
 		if valueNum > 1 {
 			tmpValue := make([]uint8, valueNum)
-			tmpslice := (*[1 << 46]C.uint8_t)(unsafe.Pointer(cvalue))[:valueNum:valueNum]
+			tmpslice := (*[1 << 46]C.uint8_t)(cvalue)[:valueNum:valueNum]
 			for i, s := range tmpslice {
 				tmpValue[i] = uint8(s)
 			}
-			value = tmpValue
-		} else {
-			value = *(*uint8)(unsafe.Pointer(cvalue))
+			return tmpValue, nil
 		}
+		return *(*uint8)(cvalue), nil
 	case TILEDB_UINT16:
 		if valueNum > 1 {
 			tmpValue := make([]uint16, valueNum)
-			tmpslice := (*[1 << 46]C.uint16_t)(unsafe.Pointer(cvalue))[:valueNum:valueNum]
+			tmpslice := (*[1 << 46]C.uint16_t)(cvalue)[:valueNum:valueNum]
 			for i, s := range tmpslice {
 				tmpValue[i] = uint16(s)
 			}
-			value = tmpValue
-		} else {
-			value = *(*uint16)(unsafe.Pointer(cvalue))
+			return tmpValue, nil
 		}
+		return *(*uint16)(cvalue), nil
 	case TILEDB_UINT32:
 		if valueNum > 1 {
 			tmpValue := make([]uint32, valueNum)
-			tmpslice := (*[1 << 46]C.uint32_t)(unsafe.Pointer(cvalue))[:valueNum:valueNum]
+			tmpslice := (*[1 << 46]C.uint32_t)(cvalue)[:valueNum:valueNum]
 			for i, s := range tmpslice {
 				tmpValue[i] = uint32(s)
 			}
-			value = tmpValue
-		} else {
-			value = *(*uint32)(unsafe.Pointer(cvalue))
+			return tmpValue, nil
 		}
+		return *(*uint32)(cvalue), nil
 	case TILEDB_UINT64:
 		if valueNum > 1 {
 			tmpValue := make([]uint64, valueNum)
-			tmpslice := (*[1 << 46]C.uint64_t)(unsafe.Pointer(cvalue))[:valueNum:valueNum]
+			tmpslice := (*[1 << 46]C.uint64_t)(cvalue)[:valueNum:valueNum]
 			for i, s := range tmpslice {
 				tmpValue[i] = uint64(s)
 			}
-			value = tmpValue
-		} else {
-			value = *(*uint64)(unsafe.Pointer(cvalue))
+			return tmpValue, nil
 		}
+		return *(*uint64)(cvalue), nil
 	case TILEDB_FLOAT32:
 		if valueNum > 1 {
 			tmpValue := make([]float32, valueNum)
-			tmpslice := (*[1 << 46]C.float)(unsafe.Pointer(cvalue))[:valueNum:valueNum]
+			tmpslice := (*[1 << 46]C.float)(cvalue)[:valueNum:valueNum]
 			for i, s := range tmpslice {
 				tmpValue[i] = float32(s)
 			}
-			value = tmpValue
-		} else {
-			value = *(*float32)(unsafe.Pointer(cvalue))
+			return tmpValue, nil
 		}
+		return *(*float32)(cvalue), nil
 	case TILEDB_FLOAT64:
 		if valueNum > 1 {
 			tmpValue := make([]float64, valueNum)
-			tmpslice := (*[1 << 46]C.double)(unsafe.Pointer(cvalue))[:valueNum:valueNum]
+			tmpslice := (*[1 << 46]C.double)(cvalue)[:valueNum:valueNum]
 			for i, s := range tmpslice {
 				tmpValue[i] = float64(s)
 			}
-			value = tmpValue
-		} else {
-			value = *(*float64)(unsafe.Pointer(cvalue))
+			return tmpValue, nil
 		}
+		return *(*float64)(cvalue), nil
 	case TILEDB_CHAR:
-		tmpslice := (*[1 << 46]C.char)(unsafe.Pointer(cvalue))[:valueNum:valueNum]
-		value = C.GoString(&tmpslice[0])[0:valueNum]
+		tmpslice := (*[1 << 46]C.char)(cvalue)[:valueNum:valueNum]
+		return C.GoString(&tmpslice[0])[0:valueNum], nil
 	case TILEDB_STRING_ASCII:
-		tmpslice := (*[1 << 46]C.char)(unsafe.Pointer(cvalue))[:valueNum:valueNum]
-		value = C.GoString(&tmpslice[0])[0:valueNum]
+		tmpslice := (*[1 << 46]C.char)(cvalue)[:valueNum:valueNum]
+		return C.GoString(&tmpslice[0])[0:valueNum], nil
 	case TILEDB_STRING_UTF8:
-		tmpslice := (*[1 << 46]C.char)(unsafe.Pointer(cvalue))[:valueNum:valueNum]
-		value = C.GoString(&tmpslice[0])[0:valueNum]
+		tmpslice := (*[1 << 46]C.char)(cvalue)[:valueNum:valueNum]
+		return C.GoString(&tmpslice[0])[0:valueNum], nil
 	case TILEDB_DATETIME_YEAR, TILEDB_DATETIME_MONTH, TILEDB_DATETIME_WEEK,
 		TILEDB_DATETIME_DAY, TILEDB_DATETIME_HR, TILEDB_DATETIME_MIN,
 		TILEDB_DATETIME_SEC, TILEDB_DATETIME_MS, TILEDB_DATETIME_US,
@@ -384,14 +373,12 @@ func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, e
 		if valueNum > 1 {
 			return nil, fmt.Errorf("Unrecognized value type: %d", d)
 		} else {
-			var timestamp interface{} = *(*int16)(unsafe.Pointer(cvalue))
-			value = GetTimeFromTimestamp(d, timestamp.(int64))
+			var timestamp interface{} = *(*int16)(cvalue)
+			return GetTimeFromTimestamp(d, timestamp.(int64)), nil
 		}
 	default:
 		return nil, fmt.Errorf("Unrecognized value type: %d", d)
 	}
-
-	return value, nil
 }
 
 // EncryptionType represents different encryption algorithms
@@ -488,7 +475,7 @@ const (
 	TILEDB_COMPLETED QueryStatus = C.TILEDB_COMPLETED
 	// TILEDB_INPROGRESS Query is in progress
 	TILEDB_INPROGRESS QueryStatus = C.TILEDB_INPROGRESS
-	//TILEDB_INCOMPLETE Query completed (but not all data has been read)
+	// TILEDB_INCOMPLETE Query completed (but not all data has been read)
 	TILEDB_INCOMPLETE QueryStatus = C.TILEDB_INCOMPLETE
 	// TILEDB_UNINITIALIZED Query not initialized.
 	TILEDB_UNINITIALIZED QueryStatus = C.TILEDB_UNINITIALIZED

--- a/enums.go
+++ b/enums.go
@@ -257,6 +257,9 @@ func (d Datatype) MakeSlice(numElements uint64) (interface{}, unsafe.Pointer, er
 func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, error) {
 	switch d {
 	case TILEDB_INT8:
+		if cvalue == nil {
+			return int8(0), nil
+		}
 		if valueNum > 1 {
 			tmpValue := make([]int8, valueNum)
 			tmpslice := (*[1 << 46]C.int8_t)(cvalue)[:valueNum:valueNum]
@@ -267,6 +270,9 @@ func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, e
 		}
 		return *(*int8)(cvalue), nil
 	case TILEDB_INT16:
+		if cvalue == nil {
+			return int16(0), nil
+		}
 		if valueNum > 1 {
 			tmpValue := make([]int16, valueNum)
 			tmpslice := (*[1 << 46]C.int16_t)(cvalue)[:valueNum:valueNum]
@@ -277,6 +283,9 @@ func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, e
 		}
 		return *(*int16)(cvalue), nil
 	case TILEDB_INT32:
+		if cvalue == nil {
+			return int32(0), nil
+		}
 		if valueNum > 1 {
 			tmpValue := make([]int32, valueNum)
 			tmpslice := (*[1 << 46]C.int32_t)(cvalue)[:valueNum:valueNum]
@@ -287,6 +296,9 @@ func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, e
 		}
 		return *(*int32)(cvalue), nil
 	case TILEDB_INT64:
+		if cvalue == nil {
+			return int64(0), nil
+		}
 		if valueNum > 1 {
 			tmpValue := make([]int64, valueNum)
 			tmpslice := (*[1 << 46]C.int64_t)(cvalue)[:valueNum:valueNum]
@@ -297,6 +309,9 @@ func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, e
 		}
 		return *(*int64)(cvalue), nil
 	case TILEDB_UINT8:
+		if cvalue == nil {
+			return uint8(0), nil
+		}
 		if valueNum > 1 {
 			tmpValue := make([]uint8, valueNum)
 			tmpslice := (*[1 << 46]C.uint8_t)(cvalue)[:valueNum:valueNum]
@@ -307,6 +322,9 @@ func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, e
 		}
 		return *(*uint8)(cvalue), nil
 	case TILEDB_UINT16:
+		if cvalue == nil {
+			return uint16(0), nil
+		}
 		if valueNum > 1 {
 			tmpValue := make([]uint16, valueNum)
 			tmpslice := (*[1 << 46]C.uint16_t)(cvalue)[:valueNum:valueNum]
@@ -317,6 +335,9 @@ func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, e
 		}
 		return *(*uint16)(cvalue), nil
 	case TILEDB_UINT32:
+		if cvalue == nil {
+			return uint32(0), nil
+		}
 		if valueNum > 1 {
 			tmpValue := make([]uint32, valueNum)
 			tmpslice := (*[1 << 46]C.uint32_t)(cvalue)[:valueNum:valueNum]
@@ -327,6 +348,9 @@ func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, e
 		}
 		return *(*uint32)(cvalue), nil
 	case TILEDB_UINT64:
+		if cvalue == nil {
+			return uint64(0), nil
+		}
 		if valueNum > 1 {
 			tmpValue := make([]uint64, valueNum)
 			tmpslice := (*[1 << 46]C.uint64_t)(cvalue)[:valueNum:valueNum]
@@ -337,6 +361,9 @@ func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, e
 		}
 		return *(*uint64)(cvalue), nil
 	case TILEDB_FLOAT32:
+		if cvalue == nil {
+			return float32(0), nil
+		}
 		if valueNum > 1 {
 			tmpValue := make([]float32, valueNum)
 			tmpslice := (*[1 << 46]C.float)(cvalue)[:valueNum:valueNum]
@@ -347,6 +374,9 @@ func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, e
 		}
 		return *(*float32)(cvalue), nil
 	case TILEDB_FLOAT64:
+		if cvalue == nil {
+			return float64(0), nil
+		}
 		if valueNum > 1 {
 			tmpValue := make([]float64, valueNum)
 			tmpslice := (*[1 << 46]C.double)(cvalue)[:valueNum:valueNum]
@@ -357,12 +387,21 @@ func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, e
 		}
 		return *(*float64)(cvalue), nil
 	case TILEDB_CHAR:
+		if cvalue == nil || valueNum == 0 {
+			return "", nil
+		}
 		tmpslice := (*[1 << 46]C.char)(cvalue)[:valueNum:valueNum]
 		return C.GoString(&tmpslice[0])[0:valueNum], nil
 	case TILEDB_STRING_ASCII:
+		if cvalue == nil || valueNum == 0 {
+			return "", nil
+		}
 		tmpslice := (*[1 << 46]C.char)(cvalue)[:valueNum:valueNum]
 		return C.GoString(&tmpslice[0])[0:valueNum], nil
 	case TILEDB_STRING_UTF8:
+		if cvalue == nil || valueNum == 0 {
+			return "", nil
+		}
 		tmpslice := (*[1 << 46]C.char)(cvalue)[:valueNum:valueNum]
 		return C.GoString(&tmpslice[0])[0:valueNum], nil
 	case TILEDB_DATETIME_YEAR, TILEDB_DATETIME_MONTH, TILEDB_DATETIME_WEEK,
@@ -373,6 +412,9 @@ func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, e
 		if valueNum > 1 {
 			return nil, fmt.Errorf("Unrecognized value type: %d", d)
 		} else {
+			if cvalue == nil {
+				return int64(0), nil
+			}
 			var timestamp interface{} = *(*int16)(cvalue)
 			return GetTimeFromTimestamp(d, timestamp.(int64)), nil
 		}


### PR DESCRIPTION
Removes error case for when a nil pointer is returned for a given metadata value because it is empty. Removal of the check necessitated getting back a zero value from GetValue. Empty values occur even though they're abnormal. 