### PR TITLE
Updates to TileDB 2.7.0

### DIFF
--- a/.github/scripts/install_tiledb_linux.sh
+++ b/.github/scripts/install_tiledb_linux.sh
@@ -1,4 +1,4 @@
 set -e -x
-curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.6.1/tiledb-linux-x86_64-2.6.1-2f6b7f6.tar.gz \
+curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.7.0-rc0/tiledb-linux-x86_64-2.7.0-rc0-c7053ca.tar.gz \
 && sudo tar -C /usr/local -xf tiledb.tar.gz
 sudo ldconfig /usr/local/lib

--- a/.github/scripts/install_tiledb_linux_debug.sh
+++ b/.github/scripts/install_tiledb_linux_debug.sh
@@ -1,5 +1,5 @@
 set -e -x
-git clone https://github.com/TileDB-Inc/TileDB.git -b 2.6.1
+git clone https://github.com/TileDB-Inc/TileDB.git -b 2.7.0-rc0
 cd TileDB
 mkdir build && cd build
 cmake -DSANITIZER=leak -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr/local ..

--- a/.github/scripts/install_tiledb_macos.sh
+++ b/.github/scripts/install_tiledb_macos.sh
@@ -1,3 +1,3 @@
 set -e -x
-curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.6.1/tiledb-macos-x86_64-2.6.1-2f6b7f6.tar.gz \
+curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.7.0-rc0/tiledb-macos-x86_64-2.7.0-rc0-c7053ca.tar.gz \
 && sudo tar -C /usr/local -xf tiledb.tar.gz

--- a/.github/scripts/install_tiledb_source_linux.sh
+++ b/.github/scripts/install_tiledb_source_linux.sh
@@ -1,5 +1,5 @@
 set -e -x
-git clone https://github.com/TileDB-Inc/TileDB.git -b 2.6.1
+git clone https://github.com/TileDB-Inc/TileDB.git -b 2.7.0-rc0
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..

--- a/.github/scripts/install_tiledb_source_macos.sh
+++ b/.github/scripts/install_tiledb_source_macos.sh
@@ -1,5 +1,5 @@
 set -e -x
-git clone https://github.com/TileDB-Inc/TileDB.git -b 2.6.1
+git clone https://github.com/TileDB-Inc/TileDB.git -b 2.7.0-rc0
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..

--- a/array_test.go
+++ b/array_test.go
@@ -149,11 +149,23 @@ func TestArray(t *testing.T) {
 	// Open array for reading
 	require.NoError(t, array.Open(TILEDB_READ))
 
+	isOpen, err := array.Isopen()
+	require.NoError(t, err)
+	assert.Equal(t, true, isOpen)
+
 	// Test re-opening
 	require.NoError(t, array.Reopen())
 
+	isOpen, err = array.Isopen()
+	require.NoError(t, err)
+	assert.Equal(t, true, isOpen)
+
 	// Close Array
 	require.NoError(t, array.Close())
+
+	isOpen, err = array.Isopen()
+	require.NoError(t, err)
+	assert.Equal(t, false, isOpen)
 
 	// Open array for reading At
 	require.NoError(t, array.OpenWithOptions(TILEDB_READ, WithEndTimestamp(uint64(time.Now().UnixNano()/1000000))))


### PR DESCRIPTION
- Adds support for `tiledb_array_is_open`
- Before `array.Close` we check if array is open using `tiledb_array_is_open`
- Adds tests for `tiledb_array_is_open`
- [sc-14603]