### PR TITLE
Add serialization helper func, create copy of bytes to prevent gc

### DIFF
--- a/array_schema.go
+++ b/array_schema.go
@@ -33,30 +33,11 @@ type ArraySchema struct {
 
 // MarshalJSON marshal arraySchema struct to json using tiledb
 func (a *ArraySchema) MarshalJSON() ([]byte, error) {
-	clientSide := false // Currently this parameter is unused in libtiledb
-	buffer, err := SerializeArraySchema(a, TILEDB_JSON, clientSide)
+	bs, err := SerializeArraySchema(a, TILEDB_JSON, false)
 	if err != nil {
 		return nil, fmt.Errorf("Error marshaling json for array schema: %s", a.context.LastError())
 	}
-
-	bytes, err := buffer.Data()
-	if err != nil {
-		return nil, fmt.Errorf("Error marshaling json for array schema: %s", buffer.context.LastError())
-	}
-
-	// Create a full copy of the byte slice, as the Buffer object owns the memory.
-	size := len(bytes)
-	cpy := make([]byte, size)
-
-	copy(cpy, bytes)
-
-	// Check if the last character is a null byte, if so remove it from the slice
-	if cpy[size-1] == 0 {
-		cpy = cpy[:size-1]
-	}
-
-	runtime.KeepAlive(buffer)
-	return cpy, nil
+	return bs, nil
 }
 
 // Context exposes the internal TileDB context used to initialize the array schema

--- a/array_schema_evolution_test.go
+++ b/array_schema_evolution_test.go
@@ -80,11 +80,16 @@ func TestArraySchemaEvolution(t *testing.T) {
 	// Remove atrribute a1
 	require.NoError(t, arraySchemaEvolution.DropAttribute("a1"))
 
-	buffer, err := SerializeArraySchemaEvolution(arraySchemaEvolution,
+	bs, err := SerializeArraySchemaEvolution(arraySchemaEvolution,
 		TILEDB_CAPNP, true)
 	require.NoError(t, err)
 
-	newArraySchemaEvolution, err := DeserializeArraySchemaEvolution(buffer,
+	buff, err := NewBuffer(context)
+
+	err = buff.SetBuffer(bs)
+	require.NoError(t, err)
+
+	newArraySchemaEvolution, err := DeserializeArraySchemaEvolution(buff,
 		TILEDB_CAPNP, true)
 	require.NoError(t, err)
 

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -24,7 +24,7 @@ func ExampleNewBuffer() {
 	}
 
 	// Get data slice
-	bytes, err := buffer.Data()
+	bytes, err := buffer.bytes()
 	if err != nil {
 		// Handle error
 		return
@@ -42,7 +42,7 @@ func TestNewBuffer(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, buffer)
 
-	bytes, err := buffer.Data()
+	bytes, err := buffer.bytes()
 	require.NoError(t, err)
 	assert.Nil(t, bytes)
 

--- a/query_test.go
+++ b/query_test.go
@@ -1359,7 +1359,7 @@ func TestDenseQueryWrite(t *testing.T) {
 	bufferA5 := "hello" + "world"
 	offsetBufferA5 := []uint64{0, 5}
 	// Second string array so we can compare reads
-	bufferA5Comparison := make([]byte, len(bufferA5)) //new(string, len(bufferA5))
+	bufferA5Comparison := make([]byte, len(bufferA5)) // new(string, len(bufferA5))
 	elementsCopied = copy(bufferA5Comparison, bufferA5)
 	assert.Equal(t, len(bufferA5), elementsCopied)
 	assert.EqualValues(t, bufferA5, bufferA5Comparison)
@@ -1469,7 +1469,7 @@ func TestDenseQueryWrite(t *testing.T) {
 	_, _, err = query.SetBufferVar("a4", readOffsetBufferA4, readBufferA4)
 	require.NoError(t, err)
 
-	readBufferA5 := make([]byte, 10) //make(string, 10)
+	readBufferA5 := make([]byte, 10) // make(string, 10)
 	readOffsetBufferA5 := make([]uint64, 2)
 	_, _, err = query.SetBufferVar("a5", readOffsetBufferA5, readBufferA5)
 	require.NoError(t, err)
@@ -1651,8 +1651,8 @@ func TestSparseQueryWrite(t *testing.T) {
 	assert.NotNil(t, query)
 
 	// Set read subarray to only data that was written
-	//err = query.SetSubArray(subArray)
-	//require.NoError(t, err)
+	// err = query.SetSubArray(subArray)
+	// require.NoError(t, err)
 
 	// Set coordinates, since test is 1d, this is subarray
 	_, err = query.SetBuffer("dim1", subArray)

--- a/serialize.go
+++ b/serialize.go
@@ -18,7 +18,7 @@ import (
 )
 
 // SerializeArraySchema serializes an array schema
-func SerializeArraySchema(schema *ArraySchema, serializationType SerializationType, clientSide bool) (*Buffer, error) {
+func SerializeArraySchema(schema *ArraySchema, serializationType SerializationType, clientSide bool) ([]byte, error) {
 	var cClientSide C.int32_t
 	if clientSide {
 		cClientSide = 1
@@ -37,7 +37,7 @@ func SerializeArraySchema(schema *ArraySchema, serializationType SerializationTy
 		return nil, fmt.Errorf("Error serializing array schema: %s", schema.context.LastError())
 	}
 
-	return &buffer, nil
+	return buffer.Serialize(serializationType)
 }
 
 // DeserializeArraySchema deserializes a new array schema from the given buffer
@@ -68,7 +68,7 @@ func DeserializeArraySchema(buffer *Buffer, serializationType SerializationType,
 }
 
 // SerializeArrayNonEmptyDomain gets and serializes the array nonempty domain
-func SerializeArrayNonEmptyDomain(a *Array, serializationType SerializationType) (*Buffer, error) {
+func SerializeArrayNonEmptyDomain(a *Array, serializationType SerializationType) ([]byte, error) {
 	schema, err := a.Schema()
 	if err != nil {
 		return nil, err
@@ -106,7 +106,7 @@ func SerializeArrayNonEmptyDomain(a *Array, serializationType SerializationType)
 		return nil, fmt.Errorf("Error serializing array nonempty domain: %s", a.context.LastError())
 	}
 
-	return &buffer, nil
+	return buffer.Serialize(serializationType)
 }
 
 // DeserializeArrayNonEmptyDomain deserializes an array nonempty domain
@@ -217,7 +217,7 @@ func DeserializeArrayNonEmptyDomain(a *Array, buffer *Buffer, serializationType 
 }
 
 // SerializeArrayNonEmptyDomainAllDimensions gets and serializes the array nonempty domain
-func SerializeArrayNonEmptyDomainAllDimensions(a *Array, serializationType SerializationType) (*Buffer, error) {
+func SerializeArrayNonEmptyDomainAllDimensions(a *Array, serializationType SerializationType) ([]byte, error) {
 
 	buffer := Buffer{context: a.context}
 	// Set finalizer for free C pointer on gc
@@ -231,7 +231,7 @@ func SerializeArrayNonEmptyDomainAllDimensions(a *Array, serializationType Seria
 		return nil, fmt.Errorf("Error serializing array nonempty domain: %s", a.context.LastError())
 	}
 
-	return &buffer, nil
+	return buffer.Serialize(serializationType)
 }
 
 // DeserializeArrayNonEmptyDomainAllDimensions deserializes an array nonempty domain
@@ -247,7 +247,7 @@ func DeserializeArrayNonEmptyDomainAllDimensions(a *Array, buffer *Buffer, seria
 }
 
 // SerializeArrayMaxBufferSizes gets and serializes the array max buffer sizes for the given subarray
-func SerializeArrayMaxBufferSizes(a *Array, subarray interface{}, serializationType SerializationType) (*Buffer, error) {
+func SerializeArrayMaxBufferSizes(a *Array, subarray interface{}, serializationType SerializationType) ([]byte, error) {
 	// Create subarray void*
 	var cSubarray unsafe.Pointer
 	if reflect.TypeOf(subarray).Kind() != reflect.Slice {
@@ -306,7 +306,7 @@ func SerializeArrayMaxBufferSizes(a *Array, subarray interface{}, serializationT
 		return nil, fmt.Errorf("error serializing array max buffer sizes: %s", a.context.LastError())
 	}
 
-	return &buffer, nil
+	return buffer.Serialize(serializationType)
 }
 
 // SerializeQuery serializes a query
@@ -350,7 +350,7 @@ func DeserializeQuery(query *Query, buffer *Buffer, serializationType Serializat
 }
 
 // SerializeArrayMetadata gets and serializes the array metadata
-func SerializeArrayMetadata(a *Array, serializationType SerializationType) (*Buffer, error) {
+func SerializeArrayMetadata(a *Array, serializationType SerializationType) ([]byte, error) {
 	buffer := Buffer{context: a.context}
 	// Set finalizer for free C pointer on gc
 	runtime.SetFinalizer(&buffer, func(buffer *Buffer) {
@@ -362,7 +362,7 @@ func SerializeArrayMetadata(a *Array, serializationType SerializationType) (*Buf
 		return nil, fmt.Errorf("Error serializing array metadata: %s", a.context.LastError())
 	}
 
-	return &buffer, nil
+	return buffer.Serialize(serializationType)
 }
 
 // DeserializeArrayMetadata deserializes array metadata
@@ -375,7 +375,7 @@ func DeserializeArrayMetadata(a *Array, buffer *Buffer, serializationType Serial
 }
 
 // SerializeQueryEstResultSizes gets and serializes the query estimated result sizes
-func SerializeQueryEstResultSizes(q *Query, serializationType SerializationType, clientSide bool) (*Buffer, error) {
+func SerializeQueryEstResultSizes(q *Query, serializationType SerializationType, clientSide bool) ([]byte, error) {
 	var cClientSide C.int32_t
 	if clientSide {
 		cClientSide = 1
@@ -394,7 +394,7 @@ func SerializeQueryEstResultSizes(q *Query, serializationType SerializationType,
 		return nil, fmt.Errorf("Error serializing query est buffer sizes: %s", q.context.LastError())
 	}
 
-	return &buffer, nil
+	return buffer.Serialize(serializationType)
 }
 
 // DeserializeQueryEstResultSizes deserializes query estimated result sizes

--- a/serialize_array_schema_evolution.go
+++ b/serialize_array_schema_evolution.go
@@ -22,7 +22,7 @@ import (
 )
 
 // SerializeArraySchemaEvolution serializes the given array schema evolution
-func SerializeArraySchemaEvolution(arraySchemaEvolution *ArraySchemaEvolution, serializationType SerializationType, clientSide bool) (*Buffer, error) {
+func SerializeArraySchemaEvolution(arraySchemaEvolution *ArraySchemaEvolution, serializationType SerializationType, clientSide bool) ([]byte, error) {
 	var cClientSide C.int32_t
 	if clientSide {
 		cClientSide = 1
@@ -46,7 +46,7 @@ func SerializeArraySchemaEvolution(arraySchemaEvolution *ArraySchemaEvolution, s
 			arraySchemaEvolution.context.LastError())
 	}
 
-	return &buffer, nil
+	return buffer.Serialize(serializationType)
 }
 
 // DeserializeArraySchemaEvolution deserializes a new array schema evolution object from the given buffer


### PR DESCRIPTION
Adds serialization helper funcs on a buffer. 

Handles:
- Trim of null terminated core buffers for JSON
- Maintains null terminator for capnp
- Creates copy of buffers to limit issues with Go GC and buffer collection