### PR TITLE
Pulls `runtime.SetFinalizer` calls into a `freeOnGC` function.

### DIFF
--- a/array.go
+++ b/array.go
@@ -11,7 +11,6 @@ import "C"
 import (
 	"encoding/json"
 	"fmt"
-	"runtime"
 	"unsafe"
 )
 
@@ -62,11 +61,7 @@ func NewArray(tdbCtx *Context, uri string) (*Array, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb array: %s", array.context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&array, func(array *Array) {
-		array.Free()
-	})
+	freeOnGC(&array)
 
 	return &array, nil
 }
@@ -229,10 +224,7 @@ func (a *Array) Schema() (*ArraySchema, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error getting schema for tiledb array: %s", a.context.LastError())
 	}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&arraySchema, func(arraySchema *ArraySchema) {
-		arraySchema.Free()
-	})
+	freeOnGC(&arraySchema)
 	return &arraySchema, nil
 }
 

--- a/array_schema.go
+++ b/array_schema.go
@@ -12,7 +12,6 @@ import "C"
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"unsafe"
 )
 
@@ -101,12 +100,7 @@ func NewArraySchema(tdbCtx *Context, arrayType ArrayType) (*ArraySchema, error) 
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb arraySchema: %s", arraySchema.context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&arraySchema, func(arraySchema *ArraySchema) {
-		arraySchema.Free()
-	})
-
+	freeOnGC(&arraySchema)
 	return &arraySchema, nil
 }
 
@@ -153,10 +147,7 @@ func (a *ArraySchema) AttributeFromIndex(index uint) (*Attribute, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error getting attribute %d for tiledb arraySchema: %s", index, a.context.LastError())
 	}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&attr, func(attr *Attribute) {
-		attr.Free()
-	})
+	freeOnGC(&attr)
 	return &attr, nil
 }
 
@@ -171,10 +162,7 @@ func (a *ArraySchema) AttributeFromName(attrName string) (*Attribute, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error getting attribute %s for tiledb arraySchema: %s", attrName, a.context.LastError())
 	}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&attr, func(attr *Attribute) {
-		attr.Free()
-	})
+	freeOnGC(&attr)
 	return &attr, nil
 }
 
@@ -266,10 +254,7 @@ func (a *ArraySchema) Domain() (*Domain, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error setting domain for tiledb arraySchema: %s", a.context.LastError())
 	}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&domain, func(domain *Domain) {
-		domain.Free()
-	})
+	freeOnGC(&domain)
 	return &domain, nil
 }
 
@@ -346,10 +331,7 @@ func (a *ArraySchema) CoordsFilterList() (*FilterList, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error getting coordinates filter list for tiledb arraySchema: %s", a.context.LastError())
 	}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&filterList, func(filterList *FilterList) {
-		filterList.Free()
-	})
+	freeOnGC(&filterList)
 	return &filterList, nil
 }
 
@@ -371,10 +353,7 @@ func (a *ArraySchema) OffsetsFilterList() (*FilterList, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error getting offsets filter list for tiledb arraySchema: %s", a.context.LastError())
 	}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&filterList, func(filterList *FilterList) {
-		filterList.Free()
-	})
+	freeOnGC(&filterList)
 	return &filterList, nil
 }
 
@@ -396,10 +375,7 @@ func LoadArraySchema(context *Context, path string) (*ArraySchema, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error in loading arraySchema from %s: %s", path, a.context.LastError())
 	}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&a, func(arraySchema *ArraySchema) {
-		arraySchema.Free()
-	})
+	freeOnGC(&a)
 	return &a, nil
 }
 

--- a/array_schema_evolution.go
+++ b/array_schema_evolution.go
@@ -18,7 +18,6 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"runtime"
 	"unsafe"
 )
 
@@ -37,12 +36,7 @@ func NewArraySchemaEvolution(tdbCtx *Context) (*ArraySchemaEvolution, error) {
 		return nil, fmt.Errorf("error creating tiledb arraySchemaEvolution: %s",
 			arraySchemaEvolution.context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&arraySchemaEvolution,
-		func(arraySchemaEvolution *ArraySchemaEvolution) {
-			arraySchemaEvolution.Free()
-		})
+	freeOnGC(&arraySchemaEvolution)
 
 	return &arraySchemaEvolution, nil
 }

--- a/attribute.go
+++ b/attribute.go
@@ -11,7 +11,6 @@ import "C"
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"unsafe"
 )
 
@@ -39,11 +38,7 @@ func NewAttribute(context *Context, name string, datatype Datatype) (*Attribute,
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb attribute: %s", context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&attribute, func(attribute *Attribute) {
-		attribute.Free()
-	})
+	freeOnGC(&attribute)
 
 	return &attribute, nil
 }
@@ -80,11 +75,7 @@ func (a *Attribute) FilterList() (*FilterList, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error getting tiledb attribute filter list: %s", a.context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&filterList, func(filterList *FilterList) {
-		filterList.Free()
-	})
+	freeOnGC(&filterList)
 
 	return &filterList, nil
 }

--- a/buffer.go
+++ b/buffer.go
@@ -54,11 +54,7 @@ func NewBuffer(context *Context) (*Buffer, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb buffer: %s", buffer.context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&buffer, func(buffer *Buffer) {
-		buffer.Free()
-	})
+	freeOnGC(&buffer)
 
 	return &buffer, nil
 }

--- a/buffer_list.go
+++ b/buffer_list.go
@@ -9,7 +9,6 @@ package tiledb
 import "C"
 import (
 	"fmt"
-	"runtime"
 )
 
 // BufferList A list of TileDB BufferList objects
@@ -26,11 +25,7 @@ func NewBufferList(context *Context) (*BufferList, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb buffer list: %s", bufferList.context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&bufferList, func(bufferList *BufferList) {
-		bufferList.Free()
-	})
+	freeOnGC(&bufferList)
 
 	return &bufferList, nil
 }
@@ -66,10 +61,7 @@ func (b *BufferList) NumBuffers() (uint64, error) {
 // GetBuffer returns a Buffer at the given index in the list
 func (b *BufferList) GetBuffer(bufferIndex uint) (*Buffer, error) {
 	buffer := Buffer{context: b.context}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&buffer, func(buffer *Buffer) {
-		buffer.Free()
-	})
+	freeOnGC(&buffer)
 
 	ret := C.tiledb_buffer_list_get_buffer(b.context.tiledbContext, b.tiledbBufferList, C.uint64_t(bufferIndex), &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
@@ -94,10 +86,7 @@ func (b *BufferList) TotalSize() (uint64, error) {
 // Flatten copies and concatenates all buffers in the list into a new buffer
 func (b *BufferList) Flatten() (*Buffer, error) {
 	buffer := Buffer{context: b.context}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&buffer, func(buffer *Buffer) {
-		buffer.Free()
-	})
+	freeOnGC(&buffer)
 
 	ret := C.tiledb_buffer_list_flatten(b.context.tiledbContext, b.tiledbBufferList, &buffer.tiledbBuffer)
 

--- a/config.go
+++ b/config.go
@@ -10,7 +10,6 @@ import "C"
 
 import (
 	"fmt"
-	"runtime"
 	"unsafe"
 )
 
@@ -30,10 +29,7 @@ func NewConfig() (*Config, error) {
 		defer C.tiledb_error_free(&err)
 		return nil, fmt.Errorf("error creating tiledb config: %s", C.GoString(msg))
 	}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&config, func(config *Config) {
-		config.Free()
-	})
+	freeOnGC(&config)
 
 	return &config, nil
 }
@@ -137,11 +133,7 @@ func LoadConfig(uri string) (*Config, error) {
 		defer C.tiledb_error_free(&err)
 		return nil, fmt.Errorf("error loading config from file %s: %s", uri, C.GoString(msg))
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&config, func(config *Config) {
-		config.Free()
-	})
+	freeOnGC(&config)
 
 	return &config, nil
 }

--- a/config_iter.go
+++ b/config_iter.go
@@ -10,7 +10,6 @@ import "C"
 
 import (
 	"fmt"
-	"runtime"
 	"unsafe"
 )
 
@@ -34,11 +33,7 @@ func NewConfigIter(config *Config, prefix string) (*ConfigIter, error) {
 		defer C.tiledb_error_free(&err)
 		return nil, fmt.Errorf("error creating tiledb config iter: %s", C.GoString(msg))
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&ci, func(ci *ConfigIter) {
-		ci.Free()
-	})
+	freeOnGC(&ci)
 
 	return &ci, nil
 }

--- a/context.go
+++ b/context.go
@@ -36,11 +36,7 @@ func NewContext(config *Config) (*Context, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb context: %w", context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&context, func(context *Context) {
-		context.Free()
-	})
+	freeOnGC(&context)
 
 	err := context.setDefaultTags()
 	if err != nil {
@@ -102,11 +98,7 @@ func (c *Context) Config() (*Config, error) {
 	} else if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Unknown error in GetConfig")
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&config, func(config *Config) {
-		config.Free()
-	})
+	freeOnGC(&config)
 
 	return &config, nil
 }

--- a/dimension.go
+++ b/dimension.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"runtime"
 	"strconv"
 	"unsafe"
 )
@@ -211,11 +210,7 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb dimension: %s", context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&dimension, func(dimension *Dimension) {
-		dimension.Free()
-	})
+	freeOnGC(&dimension)
 
 	return &dimension, nil
 }
@@ -235,11 +230,7 @@ func NewStringDimension(context *Context, name string) (*Dimension, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb dimension: %s", context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&dimension, func(dimension *Dimension) {
-		dimension.Free()
-	})
+	freeOnGC(&dimension)
 
 	return &dimension, nil
 }
@@ -276,11 +267,7 @@ func (d *Dimension) FilterList() (*FilterList, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error getting tiledb dimension filter list: %s", d.context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&filterList, func(filterList *FilterList) {
-		filterList.Free()
-	})
+	freeOnGC(&filterList)
 
 	return &filterList, nil
 }

--- a/domain.go
+++ b/domain.go
@@ -11,7 +11,6 @@ import "C"
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"unsafe"
 )
 
@@ -31,11 +30,7 @@ func NewDomain(tdbCtx *Context) (*Domain, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb domain: %s", domain.context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&domain, func(domain *Domain) {
-		domain.Free()
-	})
+	freeOnGC(&domain)
 
 	return &domain, nil
 }
@@ -86,10 +81,7 @@ func (d *Domain) DimensionFromIndex(index uint) (*Dimension, error) {
 	}
 
 	dimension := Dimension{tiledbDimension: dim, context: d.context}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&dimension, func(dimension *Dimension) {
-		dimension.Free()
-	})
+	freeOnGC(&dimension)
 
 	return &dimension, nil
 }
@@ -104,10 +96,7 @@ func (d *Domain) DimensionFromName(name string) (*Dimension, error) {
 		return nil, fmt.Errorf("Error getting tiledb dimension by name for domain: %s", d.context.LastError())
 	}
 	dimension := Dimension{tiledbDimension: dim, context: d.context}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&dimension, func(dimension *Dimension) {
-		dimension.Free()
-	})
+	freeOnGC(&dimension)
 	return &dimension, nil
 }
 

--- a/filestore.go
+++ b/filestore.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"runtime"
 	"unsafe"
 )
 
@@ -175,9 +174,7 @@ func NewArraySchemaForFile(tdbCtx *Context, filePath string) (*ArraySchema, erro
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating schema: %s", tdbCtx.LastError())
 	}
-	runtime.SetFinalizer(&arraySchema, func(arraySchema *ArraySchema) {
-		arraySchema.Free()
-	})
+	freeOnGC(&arraySchema)
 
 	return &arraySchema, nil
 }

--- a/filter.go
+++ b/filter.go
@@ -10,7 +10,6 @@ import "C"
 
 import (
 	"fmt"
-	"runtime"
 	"unsafe"
 )
 
@@ -28,11 +27,7 @@ func NewFilter(context *Context, filterType FilterType) (*Filter, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb filter: %s", filter.context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&filter, func(filter *Filter) {
-		filter.Free()
-	})
+	freeOnGC(&filter)
 
 	return &filter, nil
 }

--- a/filter_list.go
+++ b/filter_list.go
@@ -10,7 +10,6 @@ import "C"
 
 import (
 	"fmt"
-	"runtime"
 )
 
 // FilterList represents
@@ -27,11 +26,7 @@ func NewFilterList(context *Context) (*FilterList, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb FilterList: %s", filterList.context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&filterList, func(filterList *FilterList) {
-		filterList.Free()
-	})
+	freeOnGC(&filterList)
 
 	return &filterList, nil
 }
@@ -98,10 +93,7 @@ func (f *FilterList) FilterFromIndex(index uint32) (*Filter, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error fetching filter for index %d from tiledb FilterList: %s", index, f.context.LastError())
 	}
-
-	runtime.SetFinalizer(&filter, func(filter *Filter) {
-		filter.Free()
-	})
+	freeOnGC(&filter)
 	return &filter, nil
 }
 

--- a/fragment_info.go
+++ b/fragment_info.go
@@ -10,7 +10,6 @@ import "C"
 
 import (
 	"fmt"
-	"runtime"
 	"unsafe"
 )
 
@@ -38,11 +37,7 @@ func NewFragmentInfo(tdbCtx *Context, uri string) (*FragmentInfo, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb fragment info: %s", fI.context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&fI, func(fragmentInfo *FragmentInfo) {
-		fragmentInfo.Free()
-	})
+	freeOnGC(&fI)
 
 	return &fI, nil
 }

--- a/memory.go
+++ b/memory.go
@@ -1,0 +1,31 @@
+package tiledb
+
+import "runtime"
+
+// Freeable represents an object that can be Free'd at the end of its lifetime
+// to release its resources.
+type Freeable interface {
+	Free() // Releases non–garbage-collected resources held by this object.
+}
+
+// freeOnGC sets a finalizer on the provided object that will cause it to
+// automatically be Free'd when it is collected by the garbage collecter.
+// It should be included immediately after the err-check of the code which
+// creates it:
+//
+//     func NewThingy() (*Thingy, error) {
+//       thingy := Thingy{}
+//       ret := C.tiledb_make_thingy(&thingy)
+//       if ret != C.TILEDB_OK {
+//         return nil, errors.New("whatever")
+//       }
+//       freeOnGC(&thingy)  // <-- put this here
+//       return &thingy, nil
+//     }
+func freeOnGC(obj Freeable) {
+	runtime.SetFinalizer(obj, freeFreeable)
+}
+
+// freeFreeable frees the Freeable. It's free-floating to avoid capturing
+// anything in a closure.
+func freeFreeable(obj Freeable) { obj.Free() }

--- a/query.go
+++ b/query.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"runtime"
 	"sync"
 	"unsafe"
 
@@ -71,11 +70,7 @@ func NewQuery(tdbCtx *Context, array *Array) (*Query, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error creating tiledb query: %s", query.context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&query, func(query *Query) {
-		query.Free()
-	})
+	freeOnGC(&query)
 
 	query.resultBufferElements = make(map[string][3]*uint64)
 
@@ -3343,10 +3338,7 @@ func (q *Query) Array() (*Array, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error getting array from query: %s", q.context.LastError())
 	}
-
-	runtime.SetFinalizer(&array, func(array *Array) {
-		array.Free()
-	})
+	freeOnGC(&array)
 	return &array, nil
 }
 
@@ -3369,10 +3361,7 @@ func (q *Query) Config() (*Config, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error getting config from query: %s", q.context.LastError())
 	}
-
-	runtime.SetFinalizer(&config, func(config *Config) {
-		config.Free()
-	})
+	freeOnGC(&config)
 
 	if q.config == nil {
 		q.config = &config

--- a/query_condition.go
+++ b/query_condition.go
@@ -10,7 +10,6 @@ import "C"
 
 import (
 	"fmt"
-	"runtime"
 	"unsafe"
 )
 
@@ -26,11 +25,7 @@ func NewQueryCondition(tdbCtx *Context, attributeName string, op QueryConditionO
 	if ret := C.tiledb_query_condition_alloc(qc.context.tiledbContext, &qc.cond); ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error allocating tiledb query condition: %s", qc.context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&qc, func(qc *QueryCondition) {
-		qc.Free()
-	})
+	freeOnGC(&qc)
 
 	if err := qc.init(attributeName, value, op); err != nil {
 		return nil, err
@@ -46,11 +41,7 @@ func NewQueryConditionCombination(tdbCtx *Context, left *QueryCondition, op Quer
 	if ret := C.tiledb_query_condition_combine(qc.context.tiledbContext, left.cond, right.cond, C.tiledb_query_condition_combination_op_t(op), &qc.cond); ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error allocating tiledb query condition: %s", qc.context.LastError())
 	}
-
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&qc, func(qc *QueryCondition) {
-		qc.Free()
-	})
+	freeOnGC(&qc)
 
 	return &qc, nil
 }

--- a/serialize.go
+++ b/serialize.go
@@ -13,7 +13,6 @@ import "C"
 import (
 	"fmt"
 	"reflect"
-	"runtime"
 	"unsafe"
 )
 
@@ -27,10 +26,7 @@ func SerializeArraySchema(schema *ArraySchema, serializationType SerializationTy
 	}
 
 	buffer := Buffer{context: schema.context}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&buffer, func(buffer *Buffer) {
-		buffer.Free()
-	})
+	freeOnGC(&buffer)
 
 	ret := C.tiledb_serialize_array_schema(schema.context.tiledbContext, schema.tiledbArraySchema, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
@@ -56,13 +52,10 @@ func DeserializeArraySchema(buffer *Buffer, serializationType SerializationType,
 		return nil, fmt.Errorf("Error deserializing array schema: %s", schema.context.LastError())
 	}
 
-	// Set finalizer for free C pointer on gc
 	// This needs to happen *after* the tiledb_deserialize_array_schema call
 	// because that may leave the arraySchema with a non-nil pointer
 	// to already-freed memory.
-	runtime.SetFinalizer(&schema, func(arraySchema *ArraySchema) {
-		arraySchema.Free()
-	})
+	freeOnGC(&schema)
 
 	return &schema, nil
 }
@@ -95,10 +88,7 @@ func SerializeArrayNonEmptyDomain(a *Array, serializationType SerializationType)
 	}
 
 	buffer := Buffer{context: schema.context}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&buffer, func(buffer *Buffer) {
-		buffer.Free()
-	})
+	freeOnGC(&buffer)
 
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
 	ret = C.tiledb_serialize_array_nonempty_domain(a.context.tiledbContext, a.tiledbArray, unsafe.Pointer(&tmpDomain[0]), isEmpty, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
@@ -195,10 +185,7 @@ func DeserializeArrayNonEmptyDomain(a *Array, buffer *Buffer, serializationType 
 func SerializeArrayNonEmptyDomainAllDimensions(a *Array, serializationType SerializationType) ([]byte, error) {
 
 	buffer := Buffer{context: a.context}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&buffer, func(buffer *Buffer) {
-		buffer.Free()
-	})
+	freeOnGC(&buffer)
 
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
 	ret := C.tiledb_serialize_array_non_empty_domain_all_dimensions(a.context.tiledbContext, a.tiledbArray, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
@@ -260,10 +247,7 @@ func SerializeArrayMaxBufferSizes(a *Array, subarray interface{}, serializationT
 	}
 
 	buffer := Buffer{context: a.context}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&buffer, func(buffer *Buffer) {
-		buffer.Free()
-	})
+	freeOnGC(&buffer)
 
 	ret := C.tiledb_serialize_array_max_buffer_sizes(a.context.tiledbContext, a.tiledbArray, cSubarray, C.tiledb_serialization_type_t(serializationType), &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
@@ -276,10 +260,7 @@ func SerializeArrayMaxBufferSizes(a *Array, subarray interface{}, serializationT
 // SerializeQuery serializes a query
 func SerializeQuery(query *Query, serializationType SerializationType, clientSide bool) (*BufferList, error) {
 	bufferList := BufferList{context: query.context}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&bufferList, func(bufferList *BufferList) {
-		bufferList.Free()
-	})
+	freeOnGC(&bufferList)
 
 	var cClientSide C.int32_t
 	if clientSide {
@@ -316,10 +297,7 @@ func DeserializeQuery(query *Query, buffer *Buffer, serializationType Serializat
 // SerializeArrayMetadata gets and serializes the array metadata
 func SerializeArrayMetadata(a *Array, serializationType SerializationType) ([]byte, error) {
 	buffer := Buffer{context: a.context}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&buffer, func(buffer *Buffer) {
-		buffer.Free()
-	})
+	freeOnGC(&buffer)
 
 	ret := C.tiledb_serialize_array_metadata(a.context.tiledbContext, a.tiledbArray, C.tiledb_serialization_type_t(serializationType), &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
@@ -348,10 +326,7 @@ func SerializeQueryEstResultSizes(q *Query, serializationType SerializationType,
 	}
 
 	buffer := Buffer{context: q.context}
-	// Set finalizer for free C pointer on gc
-	runtime.SetFinalizer(&buffer, func(buffer *Buffer) {
-		buffer.Free()
-	})
+	freeOnGC(&buffer)
 
 	ret := C.tiledb_serialize_query_est_result_sizes(q.context.tiledbContext, q.tiledbQuery, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {


### PR DESCRIPTION
This centralizes all the calls to `runtime.SetFinalizer` into one place,
and documents exactly where that function should be called. This reduces
repetition and hopefully makes things less error-prone.