### PR TITLE
Add test demonstrating Buffer's unsafety.

### DIFF
--- a/buffer_test.go
+++ b/buffer_test.go
@@ -2,6 +2,7 @@ package tiledb
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,4 +50,48 @@ func TestNewBuffer(t *testing.T) {
 	datatype, err := buffer.Type()
 	require.NoError(t, err)
 	assert.Equal(t, datatype, TILEDB_UINT8)
+}
+
+func TestBufferSafety(t *testing.T) {
+	context, err := NewContext(nil)
+	require.NoError(t, err)
+	buffer, err := NewBuffer(context)
+	require.NoError(t, err)
+
+	require.NoError(t, buffer.SetBuffer([]byte{8, 6, 7, 5, 3, 0, 9}))
+
+	churn := func() {
+		churners := make([][]byte, 1024*128)
+		for i := range churners {
+			churners[i] = make([]byte, 7)
+			for j := range churners[i] {
+				churners[i][j] = ^byte(j)
+			}
+		}
+		for i := range churners {
+			churners[i] = nil
+		}
+	}
+	verify := func() {
+		got, err := buffer.Serialize(TILEDB_CAPNP)
+		require.NoError(t, err)
+		assert.Equal(t, []byte{8, 6, 7, 5, 3, 0, 9}, got)
+	}
+
+	t.Log("pre churn")
+	churn()
+	t.Log("post churn")
+	verify()
+	t.Log("pre gc")
+	runtime.GC()
+	t.Log("post gc")
+	verify()
+	t.Log("pre churn 2")
+	churn()
+	t.Log("post churn 2")
+	verify()
+	t.Log("pre gc 2")
+	runtime.GC()
+	t.Log("post gc 2")
+	verify()
 }


### PR DESCRIPTION
Buffer violates the CGo contract in two ways:

 1. It passes Go-managed memory into C, and C holds a pointer to that
    memory for longer than the duration of the call.
 2. When that memory *is* passed in, Buffer does not ensure that
    that memory remains alive. This means that it may be GC'd or
    overwritten before its next use.

Part 1 of the contract is currently not a huge concern: Go's GC does not
(yet?) actually relocate objects. In this case, so long as we hold up
Part 2, we should be fine. The problem is: we're not holding up Part 2,
and this test demonstrates that.