### PR TITLE
Add assertion/documentation that we rely on non-moving GC.

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -12,6 +12,11 @@ import (
 	"fmt"
 	"runtime"
 	"unsafe"
+
+	// Much of this package relies on the fact that the Go GC is non-moving.
+	// When we move to a new Go version, this dependency should be updated
+	// to ensure that the new version is still a non-moving GC.
+	_ "go4.org/unsafe/assume-no-moving-gc"
 )
 
 // Buffer A generic Buffer object used by some TileDB APIs

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/TileDB-Inc/TileDB-Go
 require (
 	github.com/mattn/go-pointer v0.0.1
 	github.com/stretchr/testify v1.6.1
+	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 h1:FyBZqvoA/jbNzuAWLQE2kG820zMAkcilx6BMjGbL/E4=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/vendor/go4.org/unsafe/assume-no-moving-gc/LICENSE
+++ b/vendor/go4.org/unsafe/assume-no-moving-gc/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2020, Brad Fitzpatrick
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/go4.org/unsafe/assume-no-moving-gc/README.md
+++ b/vendor/go4.org/unsafe/assume-no-moving-gc/README.md
@@ -1,0 +1,13 @@
+# go4.org/unsafe/assume-no-moving-gc
+
+If your Go package wants to declare that it plays `unsafe` games that only
+work if the Go runtime's garbage collector is not a moving collector, then add:
+
+```go
+import _ "go4.org/unsafe/assume-no-moving-gc"
+```
+
+Then your program will explode if that's no longer the case. (Users can override
+the explosion with a scary sounding environment variable.)
+
+This also gives us a way to find all the really gross unsafe packages.

--- a/vendor/go4.org/unsafe/assume-no-moving-gc/assume-no-moving-gc.go
+++ b/vendor/go4.org/unsafe/assume-no-moving-gc/assume-no-moving-gc.go
@@ -1,0 +1,22 @@
+// Copyright 2020 Brad Fitzpatrick. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package go4.org/unsafe/assume-no-moving-gc exists so you can depend
+// on it from unsafe code that wants to declare that it assumes that
+// the Go runtime does not using a moving garbage colllector.
+//
+// This package is then updated for new Go versions when that
+// is still the case and explodes at runtime with a failure
+// otherwise, unless an environment variable overrides it.
+//
+// To use:
+//
+//     import _ "go4.org/unsafe/assume-no-moving-gc"
+//
+// There is no API.
+//
+// The GitHub repo is at https://github.com/go4org/unsafe-assume-no-moving-gc
+package assume_no_moving_gc
+
+const env = "ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH"

--- a/vendor/go4.org/unsafe/assume-no-moving-gc/untested.go
+++ b/vendor/go4.org/unsafe/assume-no-moving-gc/untested.go
@@ -1,0 +1,26 @@
+// Copyright 2020 Brad Fitzpatrick. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build go1.20
+// +build go1.20
+
+package assume_no_moving_gc
+
+import (
+	"os"
+	"runtime"
+	"strings"
+)
+
+func init() {
+	dots := strings.SplitN(runtime.Version(), ".", 3)
+	v := runtime.Version()
+	if len(dots) >= 2 {
+		v = dots[0] + "." + dots[1]
+	}
+	if os.Getenv(env) == v {
+		return
+	}
+	panic("Something in this program imports go4.org/unsafe/assume-no-moving-gc to declare that it assumes a non-moving garbage collector, but your version of go4.org/unsafe/assume-no-moving-gc hasn't been updated to assert that it's safe against the " + v + " runtime. If you want to risk it, run with environment variable " + env + "=" + v + " set. Notably, if " + v + " adds a moving garbage collector, this program is unsafe to use.")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,6 +11,9 @@ github.com/pmezard/go-difflib/difflib
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
+# go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760
+## explicit; go 1.11
+go4.org/unsafe/assume-no-moving-gc
 # gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 ## explicit
 gopkg.in/yaml.v3


### PR DESCRIPTION
Large parts of this library rely on the fact that the Go GC does not
move objects when collecting them (compare to, e.g. the HotSpot JVM GC,
which does move objects extensively). This adds a combination of
documentation and assertion of this fact.