### PR TITLE
Ensure `bool`s are in every switch-case I can find.

### DIFF
--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.17", "1.18"]
+        go: ["1.18"]
     steps:
 
     # Checks out repository
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.17", "1.18"]
+        go: ["1.18"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v2
@@ -113,7 +113,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.17", "1.18"]
+        go: ["1.18"]
     steps:
 
     # Checks out repository
@@ -153,7 +153,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.17", "1.18"]
+        go: ["1.18"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v2

--- a/array.go
+++ b/array.go
@@ -11,9 +11,7 @@ import "C"
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"runtime"
-	"strconv"
 	"unsafe"
 )
 
@@ -269,7 +267,7 @@ func (a *Array) OpenEndTimestamp() (uint64, error) {
 }
 
 // getNonEmptyDomainForDim creates a NonEmptyDomain from a generic dimension-typed slice
-func getNonEmptyDomainForDim(dimension *Dimension, dimensionSlice interface{}) (*NonEmptyDomain, error) {
+func getNonEmptyDomainForDim(dimension *Dimension, bounds interface{}) (*NonEmptyDomain, error) {
 	dimensionType, err := dimension.Type()
 	if err != nil {
 		return nil, err
@@ -279,51 +277,47 @@ func getNonEmptyDomainForDim(dimension *Dimension, dimensionSlice interface{}) (
 	if err != nil {
 		return nil, err
 	}
-
-	var nonEmptyDomain NonEmptyDomain
-	switch dimensionType {
-	case TILEDB_INT8:
-		tmpDimension := dimensionSlice.([]int8)
-		nonEmptyDomain = NonEmptyDomain{DimensionName: name, Bounds: []int8{tmpDimension[0], tmpDimension[1]}}
-	case TILEDB_INT16:
-		tmpDimension := dimensionSlice.([]int16)
-		nonEmptyDomain = NonEmptyDomain{DimensionName: name, Bounds: []int16{tmpDimension[0], tmpDimension[1]}}
-	case TILEDB_INT32:
-		tmpDimension := dimensionSlice.([]int32)
-		nonEmptyDomain = NonEmptyDomain{DimensionName: name, Bounds: []int32{tmpDimension[0], tmpDimension[1]}}
-	case TILEDB_INT64, TILEDB_DATETIME_YEAR, TILEDB_DATETIME_MONTH, TILEDB_DATETIME_WEEK, TILEDB_DATETIME_DAY,
-		TILEDB_DATETIME_HR, TILEDB_DATETIME_MIN, TILEDB_DATETIME_SEC, TILEDB_DATETIME_MS, TILEDB_DATETIME_US,
-		TILEDB_DATETIME_NS, TILEDB_DATETIME_AS, TILEDB_DATETIME_FS, TILEDB_DATETIME_PS, TILEDB_TIME_HR, TILEDB_TIME_MIN, TILEDB_TIME_SEC, TILEDB_TIME_MS, TILEDB_TIME_US, TILEDB_TIME_NS, TILEDB_TIME_PS, TILEDB_TIME_FS, TILEDB_TIME_AS:
-		tmpDimension := dimensionSlice.([]int64)
-		nonEmptyDomain = NonEmptyDomain{DimensionName: name, Bounds: []int64{tmpDimension[0], tmpDimension[1]}}
-	case TILEDB_UINT8:
-		tmpDimension := dimensionSlice.([]uint8)
-		nonEmptyDomain = NonEmptyDomain{DimensionName: name, Bounds: []uint8{tmpDimension[0], tmpDimension[1]}}
-	case TILEDB_UINT16:
-		tmpDimension := dimensionSlice.([]uint16)
-		nonEmptyDomain = NonEmptyDomain{DimensionName: name, Bounds: []uint16{tmpDimension[0], tmpDimension[1]}}
-	case TILEDB_UINT32:
-		tmpDimension := dimensionSlice.([]uint32)
-		nonEmptyDomain = NonEmptyDomain{DimensionName: name, Bounds: []uint32{tmpDimension[0], tmpDimension[1]}}
-	case TILEDB_UINT64:
-		tmpDimension := dimensionSlice.([]uint64)
-		nonEmptyDomain = NonEmptyDomain{DimensionName: name, Bounds: []uint64{tmpDimension[0], tmpDimension[1]}}
-	case TILEDB_FLOAT32:
-		tmpDimension := dimensionSlice.([]float32)
-		nonEmptyDomain = NonEmptyDomain{DimensionName: name, Bounds: []float32{tmpDimension[0], tmpDimension[1]}}
-	case TILEDB_FLOAT64:
-		tmpDimension := dimensionSlice.([]float64)
-		nonEmptyDomain = NonEmptyDomain{DimensionName: name, Bounds: []float64{tmpDimension[0], tmpDimension[1]}}
-	case TILEDB_STRING_ASCII:
-		tmpDimension := dimensionSlice.([]interface{})
-		lowBound := tmpDimension[0].([]uint8)
-		highBound := tmpDimension[1].([]uint8)
-		nonEmptyDomain = NonEmptyDomain{DimensionName: name, Bounds: []string{string(lowBound), string(highBound)}}
-	default:
-		return nil, fmt.Errorf("error creating non empty domain: unknown dimension type")
+	switch ds := bounds.(type) {
+	case []int8:
+		return makeNonEmptyDomain(name, ds)
+	case []int16:
+		return makeNonEmptyDomain(name, ds)
+	case []int32:
+		return makeNonEmptyDomain(name, ds)
+	case []int64:
+		return makeNonEmptyDomain(name, ds)
+	case []uint8:
+		return makeNonEmptyDomain(name, ds)
+	case []uint16:
+		return makeNonEmptyDomain(name, ds)
+	case []uint32:
+		return makeNonEmptyDomain(name, ds)
+	case []uint64:
+		return makeNonEmptyDomain(name, ds)
+	case []float32:
+		return makeNonEmptyDomain(name, ds)
+	case []float64:
+		return makeNonEmptyDomain(name, ds)
+	case []bool:
+		return makeNonEmptyDomain(name, ds)
+	case []any:
+		if dimensionType != TILEDB_STRING_ASCII {
+			return nil, fmt.Errorf(
+				"type mismatch between non-empty domain type (%T) and dimension type (%v); expected %v",
+				ds[0], dimensionType, TILEDB_STRING_ASCII,
+			)
+		}
+		lo, hi := ds[0].([]byte), ds[1].([]byte)
+		return &NonEmptyDomain{DimensionName: name, Bounds: []string{string(lo), string(hi)}}, nil
 	}
+	return nil, fmt.Errorf(
+		"error creating nonempty domain: unknown data type (slice %T; type %v)",
+		bounds, dimensionType,
+	)
+}
 
-	return &nonEmptyDomain, nil
+func makeNonEmptyDomain[T any](name string, bounds []T) (*NonEmptyDomain, error) {
+	return &NonEmptyDomain{DimensionName: name, Bounds: []T{bounds[0], bounds[1]}}, nil
 }
 
 // NonEmptyDomain retrieves the non-empty domain from an array
@@ -830,182 +824,94 @@ func (a *Array) PutCharMetadata(key string, charData string) error {
 // PutMetadata puts a metadata key-value item to an open array. The array must
 // be opened in WRITE mode, otherwise the function will error out.
 func (a *Array) PutMetadata(key string, value interface{}) error {
-	ckey := C.CString(key)
-	defer C.free(unsafe.Pointer(ckey))
-
-	var isSliceValue bool = false
-	if reflect.TypeOf(value).Kind() == reflect.Slice {
-		isSliceValue = true
+	switch value := value.(type) {
+	case int:
+		return arrayPutScalarMetadata(a, tileDBInt, key, value)
+	case []int:
+		return arrayPutSliceMetadata(a, tileDBInt, key, value)
+	case int8:
+		return arrayPutScalarMetadata(a, TILEDB_INT8, key, value)
+	case []int8:
+		return arrayPutSliceMetadata(a, TILEDB_INT8, key, value)
+	case int16:
+		return arrayPutScalarMetadata(a, TILEDB_INT16, key, value)
+	case []int16:
+		return arrayPutSliceMetadata(a, TILEDB_INT16, key, value)
+	case int32:
+		return arrayPutScalarMetadata(a, TILEDB_INT32, key, value)
+	case []int32:
+		return arrayPutSliceMetadata(a, TILEDB_INT32, key, value)
+	case uint:
+		return arrayPutScalarMetadata(a, tileDBUint, key, value)
+	case []uint:
+		return arrayPutSliceMetadata(a, tileDBUint, key, value)
+	case int64:
+		return arrayPutScalarMetadata(a, TILEDB_INT64, key, value)
+	case []int64:
+		return arrayPutSliceMetadata(a, TILEDB_INT64, key, value)
+	case uint8:
+		return arrayPutScalarMetadata(a, TILEDB_UINT8, key, value)
+	case []uint8:
+		return arrayPutSliceMetadata(a, TILEDB_UINT8, key, value)
+	case uint16:
+		return arrayPutScalarMetadata(a, TILEDB_UINT16, key, value)
+	case []uint16:
+		return arrayPutSliceMetadata(a, TILEDB_UINT16, key, value)
+	case uint32:
+		return arrayPutScalarMetadata(a, TILEDB_UINT32, key, value)
+	case []uint32:
+		return arrayPutSliceMetadata(a, TILEDB_UINT32, key, value)
+	case uint64:
+		return arrayPutScalarMetadata(a, TILEDB_UINT64, key, value)
+	case []uint64:
+		return arrayPutSliceMetadata(a, TILEDB_UINT64, key, value)
+	case float32:
+		return arrayPutScalarMetadata(a, TILEDB_FLOAT32, key, value)
+	case []float32:
+		return arrayPutSliceMetadata(a, TILEDB_FLOAT32, key, value)
+	case float64:
+		return arrayPutScalarMetadata(a, TILEDB_FLOAT64, key, value)
+	case []float64:
+		return arrayPutSliceMetadata(a, TILEDB_FLOAT64, key, value)
+	case bool:
+		return arrayPutScalarMetadata(a, TILEDB_BOOL, key, value)
+	case []bool:
+		return arrayPutSliceMetadata(a, TILEDB_BOOL, key, value)
+	case string:
+		if len(value) == 0 {
+			return fmt.Errorf("length of metadata %T must be nonzero", value)
+		}
+		valPtr := unsafe.Pointer(C.CString(value))
+		defer C.free(valPtr)
+		return arrayPutMetadata(a, TILEDB_STRING_UTF8, key, valPtr, len(value))
 	}
+	return fmt.Errorf("can't add value of unrecognized type %T to metadata", value)
+}
 
-	var datatype Datatype
-	var valueNum C.uint
-	var valueType reflect.Kind
-
-	valueInterfaceVal := reflect.ValueOf(value)
-	if isSliceValue {
-		if valueInterfaceVal.Len() == 0 {
-			return fmt.Errorf("Value passed must be a non-empty slice, size of slice is: %d", valueInterfaceVal.Len())
-		}
-		valueType = reflect.TypeOf(value).Elem().Kind()
-		valueNum = C.uint(valueInterfaceVal.Len())
-	} else {
-		valueType = reflect.TypeOf(value).Kind()
-		valueNum = 1
+func arrayPutSliceMetadata[T scalarType](a *Array, dt Datatype, key string, value []T) error {
+	if len(value) == 0 {
+		return fmt.Errorf("length of metadata %T must be nonzero", value)
 	}
+	return arrayPutMetadata(a, dt, key, slicePtr(value), len(value))
+}
 
-	var ret C.int32_t
-	switch valueType {
-	case reflect.Int:
-		// Check size of int on platform
-		if strconv.IntSize == 32 {
-			datatype = TILEDB_INT32
-			if isSliceValue {
-				tmpValue := value.([]int32)
-				ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-			} else {
-				tmpValue := value.(int32)
-				ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-			}
-		} else {
-			datatype = TILEDB_INT64
-			if isSliceValue {
-				tmpValue := value.([]int64)
-				ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-			} else {
-				tmpValue := value.(int64)
-				ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-			}
-		}
-	case reflect.Int8:
-		datatype = TILEDB_INT8
-		if isSliceValue {
-			tmpValue := value.([]int8)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(int8)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Int16:
-		datatype = TILEDB_INT16
-		if isSliceValue {
-			tmpValue := value.([]int16)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(int16)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Int32:
-		datatype = TILEDB_INT32
-		if isSliceValue {
-			tmpValue := value.([]int32)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(int32)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Int64:
-		datatype = TILEDB_INT64
-		if isSliceValue {
-			tmpValue := value.([]int64)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(int64)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Uint:
-		// Check size of uint on platform
-		if strconv.IntSize == 32 {
-			datatype = TILEDB_UINT32
-			if isSliceValue {
-				tmpValue := value.([]uint32)
-				ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-			} else {
-				tmpValue := value.(uint32)
-				ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-			}
-		} else {
-			datatype = TILEDB_UINT64
-			if isSliceValue {
-				tmpValue := value.([]uint64)
-				ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-			} else {
-				tmpValue := value.(uint64)
-				ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-			}
-		}
-	case reflect.Uint8:
-		datatype = TILEDB_UINT8
-		if isSliceValue {
-			tmpValue := value.([]uint8)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(uint8)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Uint16:
-		datatype = TILEDB_UINT16
-		if isSliceValue {
-			tmpValue := value.([]uint16)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(uint16)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Uint32:
-		datatype = TILEDB_UINT32
-		if isSliceValue {
-			tmpValue := value.([]uint32)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(uint32)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Uint64:
-		datatype = TILEDB_UINT64
-		if isSliceValue {
-			tmpValue := value.([]uint64)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(uint64)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Float32:
-		datatype = TILEDB_FLOAT32
-		if isSliceValue {
-			tmpValue := value.([]float32)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(float32)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Float64:
-		datatype = TILEDB_FLOAT64
-		if isSliceValue {
-			tmpValue := value.([]float64)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(float64)
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.String:
-		datatype = TILEDB_STRING_UTF8
-		stringValue := value.(string)
-		valueNum = C.uint(len(stringValue))
-		cTmpValue := C.CString(stringValue)
-		defer C.free(unsafe.Pointer(cTmpValue))
-		if valueNum > 0 {
-			ret = C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(cTmpValue))
-		}
-	default:
-		if isSliceValue {
-			return fmt.Errorf("Unrecognized value type passed: %s", valueInterfaceVal.Index(0).Kind().String())
-		}
-		return fmt.Errorf("Unrecognized value type passed: %s", valueInterfaceVal.Kind().String())
-	}
+func arrayPutScalarMetadata[T scalarType](a *Array, dt Datatype, key string, value T) error {
+	return arrayPutMetadata(a, dt, key, unsafe.Pointer(&value), 1)
+}
 
+func arrayPutMetadata(a *Array, dt Datatype, key string, valuePtr unsafe.Pointer, count int) error {
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+	ret := C.tiledb_array_put_metadata(
+		a.context.tiledbContext,
+		a.tiledbArray,
+		cKey,
+		C.tiledb_datatype_t(dt),
+		C.uint(count),
+		valuePtr,
+	)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error adding metadata to array: %s", a.context.LastError())
+		return fmt.Errorf("could not add metadata to array: %w", a.context.LastError())
 	}
 	return nil
 }

--- a/attribute.go
+++ b/attribute.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"reflect"
 	"runtime"
 	"unsafe"
 )
@@ -139,89 +138,76 @@ func (a *Attribute) CellSize() (uint64, error) {
 // @note For fixed-sized attributes, the input `size` should be equal
 //      to the cell size.
 func (a *Attribute) SetFillValue(value interface{}) error {
-
 	if value == nil {
 		return errors.New("Unrecognized value type passed: Cannot be a nil")
 	}
 
-	if reflect.TypeOf(value).Kind() == reflect.Slice {
-		return errors.New("Unrecognized value type passed: Cannot be a slice")
-	}
-
-	valueType := reflect.TypeOf(value).Kind()
-
-	cellValNum, err := a.CellValNum()
-	if err != nil {
-		return err
-	}
-
-	attrDataType, err := a.Type()
-	if err != nil {
-		return err
-	}
-
-	var valueSize C.uint64_t
-	if cellValNum == TILEDB_VAR_NUM {
-		valueSize = C.uint64_t(reflect.TypeOf(value).Size())
-	} else {
-		valueSize = C.uint64_t(attrDataType.Size() * uint64(cellValNum))
-	}
-
-	var ret C.int32_t
-	switch valueType {
-	case reflect.Int:
-		tmpValue := value.(int)
-		ret = C.tiledb_attribute_set_fill_value(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize)
-	case reflect.Int8:
-		tmpValue := value.(int8)
-		ret = C.tiledb_attribute_set_fill_value(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize)
-	case reflect.Int16:
-		tmpValue := value.(int16)
-		ret = C.tiledb_attribute_set_fill_value(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize)
-	case reflect.Int32:
-		tmpValue := value.(int32)
-		ret = C.tiledb_attribute_set_fill_value(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize)
-	case reflect.Int64:
-		tmpValue := value.(int64)
-		ret = C.tiledb_attribute_set_fill_value(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize)
-	case reflect.Uint:
-		tmpValue := value.(uint)
-		ret = C.tiledb_attribute_set_fill_value(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize)
-	case reflect.Uint8:
-		tmpValue := value.(uint8)
-		ret = C.tiledb_attribute_set_fill_value(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize)
-	case reflect.Uint16:
-		tmpValue := value.(uint16)
-		ret = C.tiledb_attribute_set_fill_value(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize)
-	case reflect.Uint32:
-		tmpValue := value.(uint32)
-		ret = C.tiledb_attribute_set_fill_value(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize)
-	case reflect.Uint64:
-		tmpValue := value.(uint64)
-		ret = C.tiledb_attribute_set_fill_value(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize)
-	case reflect.Float32:
-		tmpValue := value.(float32)
-		ret = C.tiledb_attribute_set_fill_value(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize)
-	case reflect.Float64:
-		tmpValue := value.(float64)
-		ret = C.tiledb_attribute_set_fill_value(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize)
-	case reflect.String:
-		stringValue := value.(string)
-		valueSize = C.uint64_t(len(stringValue))
-		cTmpValue := C.CString(stringValue)
-		defer C.free(unsafe.Pointer(cTmpValue))
-		if valueSize > 0 {
-			ret = C.tiledb_attribute_set_fill_value(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(cTmpValue), valueSize)
+	switch value := value.(type) {
+	case int:
+		return attributeSetFillValue(a, value)
+	case int8:
+		return attributeSetFillValue(a, value)
+	case int16:
+		return attributeSetFillValue(a, value)
+	case int32:
+		return attributeSetFillValue(a, value)
+	case int64:
+		return attributeSetFillValue(a, value)
+	case uint:
+		return attributeSetFillValue(a, value)
+	case uint8:
+		return attributeSetFillValue(a, value)
+	case uint16:
+		return attributeSetFillValue(a, value)
+	case uint32:
+		return attributeSetFillValue(a, value)
+	case uint64:
+		return attributeSetFillValue(a, value)
+	case float32:
+		return attributeSetFillValue(a, value)
+	case float64:
+		return attributeSetFillValue(a, value)
+	case bool:
+		return attributeSetFillValue(a, value)
+	case string:
+		if len(value) == 0 {
+			// TODO: This behavior is from the previous code that was here.
+			// Is it correct?
+			return nil
 		}
-	default:
-		valueInterfaceVal := reflect.ValueOf(value)
-		return fmt.Errorf("Unrecognized value type passed: %s", valueInterfaceVal.Kind().String())
+		cValue := unsafe.Pointer(C.CString(value))
+		defer C.free(cValue)
+		return attributeSetFillValueInternal(a, cValue, uint64(len(value)))
 	}
+	return fmt.Errorf("unrecognized fill value type %T", value)
+}
 
+func attributeSetFillValue[T scalarType](a *Attribute, value T) error {
+	valNum, err := a.CellValNum()
+	if err != nil {
+		return err
+	}
+	dataType, err := a.Type()
+	if err != nil {
+		return err
+	}
+	valueSize := uint64(unsafe.Sizeof(value))
+	if valNum != TILEDB_VAR_NUM {
+		valueSize = dataType.Size() * uint64(valNum)
+	}
+	return attributeSetFillValueInternal(a, unsafe.Pointer(&value), valueSize)
+}
+
+func attributeSetFillValueInternal(a *Attribute, value unsafe.Pointer, valueSize uint64) error {
+	ret := C.tiledb_attribute_set_fill_value(
+		a.context.tiledbContext,
+		a.tiledbAttribute,
+		value,
+		C.uint64_t(valueSize),
+	)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error filling attribute value: %s", a.context.LastError())
+		return fmt.Errorf("could not set attribute fill value: %w", a.context.LastError())
 	}
-
 	return nil
 }
 
@@ -238,93 +224,81 @@ func (a *Attribute) SetFillValue(value interface{}) error {
 // @note For fixed-sized attributes, the input `size` should be equal
 //      to the cell size.
 func (a *Attribute) SetFillValueNullable(value interface{}, valid bool) error {
-
 	if value == nil {
 		return errors.New("Unrecognized value type passed: Cannot be a nil")
 	}
 
-	if reflect.TypeOf(value).Kind() == reflect.Slice {
-		return errors.New("Unrecognized value type passed: Cannot be a slice")
-	}
-
-	valueType := reflect.TypeOf(value).Kind()
-
-	cellValNum, err := a.CellValNum()
-	if err != nil {
-		return err
-	}
-
-	attrDataType, err := a.Type()
-	if err != nil {
-		return err
-	}
-
-	var valueSize C.uint64_t
-	if cellValNum == TILEDB_VAR_NUM {
-		valueSize = C.uint64_t(reflect.TypeOf(value).Size())
-	} else {
-		valueSize = C.uint64_t(attrDataType.Size() * uint64(cellValNum))
-	}
-
-	var ret C.int32_t
-	var cvalid C.uint8_t
-	if valid {
-		cvalid = 1
-	}
-	switch valueType {
-	case reflect.Int:
-		tmpValue := value.(int)
-		ret = C.tiledb_attribute_set_fill_value_nullable(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize, cvalid)
-	case reflect.Int8:
-		tmpValue := value.(int8)
-		ret = C.tiledb_attribute_set_fill_value_nullable(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize, cvalid)
-	case reflect.Int16:
-		tmpValue := value.(int16)
-		ret = C.tiledb_attribute_set_fill_value_nullable(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize, cvalid)
-	case reflect.Int32:
-		tmpValue := value.(int32)
-		ret = C.tiledb_attribute_set_fill_value_nullable(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize, cvalid)
-	case reflect.Int64:
-		tmpValue := value.(int64)
-		ret = C.tiledb_attribute_set_fill_value_nullable(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize, cvalid)
-	case reflect.Uint:
-		tmpValue := value.(uint)
-		ret = C.tiledb_attribute_set_fill_value_nullable(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize, cvalid)
-	case reflect.Uint8:
-		tmpValue := value.(uint8)
-		ret = C.tiledb_attribute_set_fill_value_nullable(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize, cvalid)
-	case reflect.Uint16:
-		tmpValue := value.(uint16)
-		ret = C.tiledb_attribute_set_fill_value_nullable(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize, cvalid)
-	case reflect.Uint32:
-		tmpValue := value.(uint32)
-		ret = C.tiledb_attribute_set_fill_value_nullable(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize, cvalid)
-	case reflect.Uint64:
-		tmpValue := value.(uint64)
-		ret = C.tiledb_attribute_set_fill_value_nullable(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize, cvalid)
-	case reflect.Float32:
-		tmpValue := value.(float32)
-		ret = C.tiledb_attribute_set_fill_value_nullable(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize, cvalid)
-	case reflect.Float64:
-		tmpValue := value.(float64)
-		ret = C.tiledb_attribute_set_fill_value_nullable(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(&tmpValue), valueSize, cvalid)
-	case reflect.String:
-		stringValue := value.(string)
-		valueSize = C.uint64_t(len(stringValue))
-		cTmpValue := C.CString(stringValue)
-		defer C.free(unsafe.Pointer(cTmpValue))
-		if valueSize > 0 {
-			ret = C.tiledb_attribute_set_fill_value_nullable(a.context.tiledbContext, a.tiledbAttribute, unsafe.Pointer(cTmpValue), valueSize, cvalid)
+	switch value := value.(type) {
+	case int:
+		return attributeSetFillValueNullable(a, value, valid)
+	case int8:
+		return attributeSetFillValueNullable(a, value, valid)
+	case int16:
+		return attributeSetFillValueNullable(a, value, valid)
+	case int32:
+		return attributeSetFillValueNullable(a, value, valid)
+	case int64:
+		return attributeSetFillValueNullable(a, value, valid)
+	case uint:
+		return attributeSetFillValueNullable(a, value, valid)
+	case uint8:
+		return attributeSetFillValueNullable(a, value, valid)
+	case uint16:
+		return attributeSetFillValueNullable(a, value, valid)
+	case uint32:
+		return attributeSetFillValueNullable(a, value, valid)
+	case uint64:
+		return attributeSetFillValueNullable(a, value, valid)
+	case float32:
+		return attributeSetFillValueNullable(a, value, valid)
+	case float64:
+		return attributeSetFillValueNullable(a, value, valid)
+	case bool:
+		return attributeSetFillValueNullable(a, value, valid)
+	case string:
+		if len(value) == 0 {
+			// TODO: This behavior is from the previous code that was here.
+			// Is it correct?
+			return nil
 		}
-	default:
-		valueInterfaceVal := reflect.ValueOf(value)
-		return fmt.Errorf("Unrecognized value type passed: %s", valueInterfaceVal.Kind().String())
+		cValue := unsafe.Pointer(C.CString(value))
+		defer C.free(cValue)
+		return attributeSetFillValueNullableInternal(a, cValue, uint64(len(value)), valid)
 	}
+	return fmt.Errorf("unrecognized fill value type %T", value)
+}
 
+func attributeSetFillValueNullable[T scalarType](a *Attribute, value T, valid bool) error {
+	valNum, err := a.CellValNum()
+	if err != nil {
+		return err
+	}
+	dataType, err := a.Type()
+	if err != nil {
+		return err
+	}
+	valueSize := uint64(unsafe.Sizeof(value))
+	if valNum != TILEDB_VAR_NUM {
+		valueSize = dataType.Size() * uint64(valNum)
+	}
+	return attributeSetFillValueNullableInternal(a, unsafe.Pointer(&value), valueSize, valid)
+}
+
+func attributeSetFillValueNullableInternal(a *Attribute, value unsafe.Pointer, valueSize uint64, valid bool) error {
+	cValid := C.uint8_t(0)
+	if valid {
+		cValid = 1
+	}
+	ret := C.tiledb_attribute_set_fill_value_nullable(
+		a.context.tiledbContext,
+		a.tiledbAttribute,
+		value,
+		C.uint64_t(valueSize),
+		cValid,
+	)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error filling attribute value: %s", a.context.LastError())
+		return fmt.Errorf("could not set attribute fill value: %w", a.context.LastError())
 	}
-
 	return nil
 }
 

--- a/common.go
+++ b/common.go
@@ -1,0 +1,18 @@
+package tiledb
+
+import "unsafe"
+
+// scalarType includes the basic types that can be stored in a TileDB array.
+// It does not include variable-sized types like strings or blobs.
+// For consistency, we should arrange switch blocks in this order.
+type scalarType interface {
+	int | int8 | int16 | int32 | int64 |
+		uint | uint8 | uint16 | uint32 | uint64 |
+		float32 | float64 |
+		bool
+}
+
+// slicePtr gives you an unsafe pointer to the start of a slice.
+func slicePtr[T any](slc []T) unsafe.Pointer {
+	return unsafe.Pointer(&slc[0])
+}

--- a/enums.go
+++ b/enums.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 	"unsafe"
 )
 
@@ -444,6 +445,18 @@ func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, e
 	default:
 		return nil, fmt.Errorf("Unrecognized value type: %d", d)
 	}
+}
+
+var tileDBInt, tileDBUint = intUintTypes() // The Datatypes of Go `int` and `uint`.
+
+func intUintTypes() (Datatype, Datatype) {
+	switch strconv.IntSize {
+	case 32:
+		return TILEDB_INT32, TILEDB_UINT32
+	case 64:
+		return TILEDB_INT64, TILEDB_UINT64
+	}
+	panic(fmt.Sprintf("can't run on systems with %v-bit integers", strconv.IntSize))
 }
 
 // EncryptionType represents different encryption algorithms

--- a/group.go
+++ b/group.go
@@ -11,9 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"runtime"
-	"strconv"
 	"unsafe"
 )
 
@@ -182,191 +180,94 @@ func (g GroupMetadata) MarshalJSON() ([]byte, error) {
 // PutMetadata puts a metadata key-value item to an open group. The group must
 // be opened in WRITE mode, otherwise the function will error out.
 func (g *Group) PutMetadata(key string, value interface{}) error {
-	ckey := C.CString(key)
-	defer C.free(unsafe.Pointer(ckey))
-
-	var isSliceValue bool = false
-	if reflect.TypeOf(value).Kind() == reflect.Slice {
-		isSliceValue = true
+	switch value := value.(type) {
+	case int:
+		return groupPutScalarMetadata(g, tileDBInt, key, value)
+	case []int:
+		return groupPutSliceMetadata(g, tileDBInt, key, value)
+	case int8:
+		return groupPutScalarMetadata(g, TILEDB_INT8, key, value)
+	case []int8:
+		return groupPutSliceMetadata(g, TILEDB_INT8, key, value)
+	case int16:
+		return groupPutScalarMetadata(g, TILEDB_INT16, key, value)
+	case []int16:
+		return groupPutSliceMetadata(g, TILEDB_INT16, key, value)
+	case int32:
+		return groupPutScalarMetadata(g, TILEDB_INT32, key, value)
+	case []int32:
+		return groupPutSliceMetadata(g, TILEDB_INT32, key, value)
+	case uint:
+		return groupPutScalarMetadata(g, tileDBUint, key, value)
+	case []uint:
+		return groupPutSliceMetadata(g, tileDBUint, key, value)
+	case int64:
+		return groupPutScalarMetadata(g, TILEDB_INT64, key, value)
+	case []int64:
+		return groupPutSliceMetadata(g, TILEDB_INT64, key, value)
+	case uint8:
+		return groupPutScalarMetadata(g, TILEDB_UINT8, key, value)
+	case []uint8:
+		return groupPutSliceMetadata(g, TILEDB_UINT8, key, value)
+	case uint16:
+		return groupPutScalarMetadata(g, TILEDB_UINT16, key, value)
+	case []uint16:
+		return groupPutSliceMetadata(g, TILEDB_UINT16, key, value)
+	case uint32:
+		return groupPutScalarMetadata(g, TILEDB_UINT32, key, value)
+	case []uint32:
+		return groupPutSliceMetadata(g, TILEDB_UINT32, key, value)
+	case uint64:
+		return groupPutScalarMetadata(g, TILEDB_UINT64, key, value)
+	case []uint64:
+		return groupPutSliceMetadata(g, TILEDB_UINT64, key, value)
+	case float32:
+		return groupPutScalarMetadata(g, TILEDB_FLOAT32, key, value)
+	case []float32:
+		return groupPutSliceMetadata(g, TILEDB_FLOAT32, key, value)
+	case float64:
+		return groupPutScalarMetadata(g, TILEDB_FLOAT64, key, value)
+	case []float64:
+		return groupPutSliceMetadata(g, TILEDB_FLOAT64, key, value)
+	case bool:
+		return groupPutScalarMetadata(g, TILEDB_BOOL, key, value)
+	case []bool:
+		return groupPutSliceMetadata(g, TILEDB_BOOL, key, value)
+	case string:
+		if len(value) == 0 {
+			return fmt.Errorf("length of metadata %T must be nonzero", value)
+		}
+		valPtr := unsafe.Pointer(C.CString(value))
+		defer C.free(valPtr)
+		return groupPutMetadata(g, TILEDB_STRING_UTF8, key, valPtr, len(value))
 	}
+	return fmt.Errorf("can't add value of unrecognized type %T to metadata", value)
+}
 
-	var datatype Datatype
-	var valueNum C.uint
-	var valueType reflect.Kind
-
-	valueInterfaceVal := reflect.ValueOf(value)
-	if isSliceValue {
-		if valueInterfaceVal.Len() == 0 {
-			return fmt.Errorf("Value passed must be a non-empty slice, size of slice is: %d", valueInterfaceVal.Len())
-		}
-		valueType = reflect.TypeOf(value).Elem().Kind()
-		valueNum = C.uint(valueInterfaceVal.Len())
-	} else {
-		valueType = reflect.TypeOf(value).Kind()
-		valueNum = 1
+func groupPutSliceMetadata[T scalarType](g *Group, dt Datatype, key string, value []T) error {
+	if len(value) == 0 {
+		return fmt.Errorf("length of metadata %T must be nonzero", value)
 	}
+	return groupPutMetadata(g, dt, key, slicePtr(value), len(value))
+}
 
-	var ret C.int32_t
-	switch valueType {
-	case reflect.Int:
-		// Check size of int on platform
-		if strconv.IntSize == 32 {
-			datatype = TILEDB_INT32
-			if isSliceValue {
-				tmpValue := value.([]int32)
-				ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-			} else {
-				tmpValue := value.(int32)
-				ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-			}
-		} else {
-			datatype = TILEDB_INT64
-			if isSliceValue {
-				tmpValue := value.([]int64)
-				ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-			} else {
-				tmpValue := value.(int64)
-				ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-			}
-		}
-	case reflect.Int8:
-		datatype = TILEDB_INT8
-		if isSliceValue {
-			tmpValue := value.([]int8)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(int8)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Int16:
-		datatype = TILEDB_INT16
-		if isSliceValue {
-			tmpValue := value.([]int16)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(int16)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Int32:
-		datatype = TILEDB_INT32
-		if isSliceValue {
-			tmpValue := value.([]int32)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(int32)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Int64:
-		datatype = TILEDB_INT64
-		if isSliceValue {
-			tmpValue := value.([]int64)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(int64)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Uint:
-		// Check size of uint on platform
-		if strconv.IntSize == 32 {
-			datatype = TILEDB_UINT32
-			if isSliceValue {
-				tmpValue := value.([]uint32)
-				ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-			} else {
-				tmpValue := value.(uint32)
-				ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-			}
-		} else {
-			datatype = TILEDB_UINT64
-			if isSliceValue {
-				tmpValue := value.([]uint64)
-				ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-			} else {
-				tmpValue := value.(uint64)
-				ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-			}
-		}
-	case reflect.Uint8:
-		datatype = TILEDB_UINT8
-		if isSliceValue {
-			tmpValue := value.([]uint8)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(uint8)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Uint16:
-		datatype = TILEDB_UINT16
-		if isSliceValue {
-			tmpValue := value.([]uint16)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(uint16)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Uint32:
-		datatype = TILEDB_UINT32
-		if isSliceValue {
-			tmpValue := value.([]uint32)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(uint32)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Uint64:
-		datatype = TILEDB_UINT64
-		if isSliceValue {
-			tmpValue := value.([]uint64)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(uint64)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Float32:
-		datatype = TILEDB_FLOAT32
-		if isSliceValue {
-			tmpValue := value.([]float32)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(float32)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.Float64:
-		datatype = TILEDB_FLOAT64
-		if isSliceValue {
-			tmpValue := value.([]float64)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(float64)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	case reflect.String:
-		datatype = TILEDB_STRING_UTF8
-		stringValue := value.(string)
-		valueNum = C.uint(len(stringValue))
-		cTmpValue := C.CString(stringValue)
-		defer C.free(unsafe.Pointer(cTmpValue))
-		if valueNum > 0 {
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(cTmpValue))
-		}
-	case reflect.Bool:
-		datatype = TILEDB_BOOL
-		if isSliceValue {
-			tmpValue := value.([]bool)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue[0]))
-		} else {
-			tmpValue := value.(bool)
-			ret = C.tiledb_group_put_metadata(g.context.tiledbContext, g.group, ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&tmpValue))
-		}
-	default:
-		if isSliceValue {
-			return fmt.Errorf("Unrecognized value type passed: %s", valueInterfaceVal.Index(0).Kind().String())
-		}
-		return fmt.Errorf("Unrecognized value type passed: %s", valueInterfaceVal.Kind().String())
-	}
+func groupPutScalarMetadata[T scalarType](g *Group, dt Datatype, key string, value T) error {
+	return groupPutMetadata(g, dt, key, unsafe.Pointer(&value), 1)
+}
 
+func groupPutMetadata(g *Group, dt Datatype, key string, valuePtr unsafe.Pointer, count int) error {
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+	ret := C.tiledb_group_put_metadata(
+		g.context.tiledbContext,
+		g.group,
+		cKey,
+		C.tiledb_datatype_t(dt),
+		C.uint(count),
+		valuePtr,
+	)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error adding metadata to group: %s", g.context.LastError())
+		return fmt.Errorf("could not add metadata to group: %w", g.context.LastError())
 	}
 	return nil
 }

--- a/query.go
+++ b/query.go
@@ -904,6 +904,9 @@ func (q *Query) AddRangeVar(dimIdx uint32, start interface{}, end interface{}) e
 	case reflect.Float64:
 		return fmt.Errorf("Unsupported type of range component passed: %s",
 			startType.String())
+	case reflect.Bool:
+		return fmt.Errorf("Unsupported type of range component passed: %s",
+			startType.String())
 	default:
 		return fmt.Errorf("Unrecognized type of range component passed: %s",
 			startType.String())
@@ -986,6 +989,9 @@ func (q *Query) AddRangeVarByName(dimName string, start interface{}, end interfa
 		return fmt.Errorf("Unsupported type of range component passed: %s",
 			startType.String())
 	case reflect.Float64:
+		return fmt.Errorf("Unsupported type of range component passed: %s",
+			startType.String())
+	case reflect.Bool:
 		return fmt.Errorf("Unsupported type of range component passed: %s",
 			startType.String())
 	default:
@@ -1111,6 +1117,9 @@ func (q *Query) GetRange(dimIdx uint32, rangeNum uint64) (interface{}, interface
 		case TILEDB_FLOAT64:
 			start = *(*float64)(unsafe.Pointer(pStart))
 			end = *(*float64)(unsafe.Pointer(pEnd))
+		case TILEDB_BOOL:
+			start = *(*bool)(unsafe.Pointer(pStart))
+			end = *(*bool)(unsafe.Pointer(pEnd))
 		case TILEDB_STRING_ASCII:
 			start = *(*uint8)(unsafe.Pointer(pStart))
 			end = *(*uint8)(unsafe.Pointer(pEnd))
@@ -1243,6 +1252,9 @@ func (q *Query) GetRangeFromName(dimName string, rangeNum uint64) (interface{}, 
 		case TILEDB_FLOAT64:
 			start = *(*float64)(unsafe.Pointer(pStart))
 			end = *(*float64)(unsafe.Pointer(pEnd))
+		case TILEDB_BOOL:
+			start = *(*bool)(unsafe.Pointer(pStart))
+			end = *(*bool)(unsafe.Pointer(pEnd))
 		case TILEDB_STRING_ASCII:
 			start = *(*uint8)(unsafe.Pointer(pStart))
 			end = *(*uint8)(unsafe.Pointer(pEnd))
@@ -2437,6 +2449,13 @@ func (q *Query) BufferVar(attributeOrDimension string) ([]uint64, interface{}, e
 		offsetsLength := *coffsetsSize / C.sizeof_uint64_t
 		offsets = (*[1 << 46]uint64)(unsafe.Pointer(coffsets))[:offsetsLength:offsetsLength]
 
+	case TILEDB_BOOL:
+		ret = C.tiledb_query_get_buffer_var(q.context.tiledbContext, q.tiledbQuery, cattributeNameOrDimension, &coffsets, &coffsetsSize, &cbuffer, &cbufferSize)
+		length := (*cbufferSize) / C.sizeof_char
+		buffer = (*[1 << 46]bool)(cbuffer)[:length:length]
+		offsetsLength := *coffsetsSize / C.sizeof_uint64_t
+		offsets = (*[1 << 46]uint64)(unsafe.Pointer(coffsets))[:offsetsLength:offsetsLength]
+
 	case TILEDB_CHAR:
 		ret = C.tiledb_query_get_buffer_var(q.context.tiledbContext, q.tiledbQuery, cattributeNameOrDimension, &coffsets, &coffsetsSize, &cbuffer, &cbufferSize)
 		length := (*cbufferSize) / C.sizeof_char
@@ -2614,6 +2633,10 @@ func (q *Query) BufferVarNullable(attributeOrDimension string) ([]uint64, interf
 	case TILEDB_FLOAT64:
 		length := (*cbufferSize) / C.sizeof_double
 		buffer = (*[1 << 46]float64)(cbuffer)[:length:length]
+
+	case TILEDB_BOOL:
+		length := (*cbufferSize) / C.sizeof_double
+		buffer = (*[1 << 46]bool)(cbuffer)[:length:length]
 
 	case TILEDB_CHAR:
 		length := (*cbufferSize) / C.sizeof_char

--- a/serialize.go
+++ b/serialize.go
@@ -144,73 +144,48 @@ func DeserializeArrayNonEmptyDomain(a *Array, buffer *Buffer, serializationType 
 		return nil, true, nil
 	}
 
-	tmpDomainType := reflect.TypeOf(tmpDomain).Elem().Kind()
-	nonEmptyDomains := make([]NonEmptyDomain, 0)
-	for i := uint(0); i < ndims; i++ {
-		dimension, err := domain.DimensionFromIndex(i)
+	nonEmptyDomains := make([]NonEmptyDomain, ndims)
+	for i := range nonEmptyDomains {
+		dimension, err := domain.DimensionFromIndex(uint(i))
 		if err != nil {
 			return nil, false, err
 		}
 
 		var nonEmptyDomain *NonEmptyDomain
 
-		switch tmpDomainType {
-		case reflect.Int:
-			tmpSubArray := tmpDomain.([]int)
-			tmpDimension := []int{tmpSubArray[(2 * i)], tmpSubArray[(2*i)+1]}
-			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDimension)
-		case reflect.Int8:
-			tmpSubArray := tmpDomain.([]int8)
-			tmpDimension := []int8{tmpSubArray[(2 * i)], tmpSubArray[(2*i)+1]}
-			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDimension)
-		case reflect.Int16:
-			tmpSubArray := tmpDomain.([]int16)
-			tmpDimension := []int16{tmpSubArray[(2 * i)], tmpSubArray[(2*i)+1]}
-			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDimension)
-		case reflect.Int32:
-			tmpSubArray := tmpDomain.([]int32)
-			tmpDimension := []int32{tmpSubArray[(2 * i)], tmpSubArray[(2*i)+1]}
-			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDimension)
-		case reflect.Int64:
-			tmpSubArray := tmpDomain.([]int64)
-			tmpDimension := []int64{tmpSubArray[(2 * i)], tmpSubArray[(2*i)+1]}
-			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDimension)
-		case reflect.Uint:
-			tmpSubArray := tmpDomain.([]uint)
-			tmpDimension := []uint{tmpSubArray[(2 * i)], tmpSubArray[(2*i)+1]}
-			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDimension)
-		case reflect.Uint8:
-			tmpSubArray := tmpDomain.([]uint8)
-			tmpDimension := []uint8{tmpSubArray[(2 * i)], tmpSubArray[(2*i)+1]}
-			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDimension)
-		case reflect.Uint16:
-			tmpSubArray := tmpDomain.([]uint16)
-			tmpDimension := []uint16{tmpSubArray[(2 * i)], tmpSubArray[(2*i)+1]}
-			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDimension)
-		case reflect.Uint32:
-			tmpSubArray := tmpDomain.([]uint32)
-			tmpDimension := []uint32{tmpSubArray[(2 * i)], tmpSubArray[(2*i)+1]}
-			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDimension)
-		case reflect.Uint64:
-			tmpSubArray := tmpDomain.([]uint64)
-			tmpDimension := []uint64{tmpSubArray[(2 * i)], tmpSubArray[(2*i)+1]}
-			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDimension)
-		case reflect.Float32:
-			tmpSubArray := tmpDomain.([]float32)
-			tmpDimension := []float32{tmpSubArray[(2 * i)], tmpSubArray[(2*i)+1]}
-			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDimension)
-		case reflect.Float64:
-			tmpSubArray := tmpDomain.([]float64)
-			tmpDimension := []float64{tmpSubArray[(2 * i)], tmpSubArray[(2*i)+1]}
-			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDimension)
-		default:
-			return nil, false, fmt.Errorf("unhandled domain datatype: %s", tmpDomainType.String())
+		switch tmpDomain := tmpDomain.(type) {
+		case []int:
+			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDomain[2*i:2*i+2])
+		case []int8:
+			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDomain[2*i:2*i+2])
+		case []int16:
+			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDomain[2*i:2*i+2])
+		case []int32:
+			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDomain[2*i:2*i+2])
+		case []int64:
+			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDomain[2*i:2*i+2])
+		case []uint:
+			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDomain[2*i:2*i+2])
+		case []uint8:
+			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDomain[2*i:2*i+2])
+		case []uint16:
+			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDomain[2*i:2*i+2])
+		case []uint32:
+			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDomain[2*i:2*i+2])
+		case []uint64:
+			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDomain[2*i:2*i+2])
+		case []float32:
+			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDomain[2*i:2*i+2])
+		case []float64:
+			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDomain[2*i:2*i+2])
+		case []bool:
+			nonEmptyDomain, err = getNonEmptyDomainForDim(dimension, tmpDomain[2*i:2*i+2])
 		}
 
 		if err != nil {
 			return nil, false, err
 		}
-		nonEmptyDomains = append(nonEmptyDomains, *nonEmptyDomain)
+		nonEmptyDomains[i] = *nonEmptyDomain
 	}
 
 	return nonEmptyDomains, false, nil
@@ -253,46 +228,35 @@ func SerializeArrayMaxBufferSizes(a *Array, subarray interface{}, serializationT
 	if reflect.TypeOf(subarray).Kind() != reflect.Slice {
 		return nil, fmt.Errorf("subarray passed must be a slice, type passed was: %s", reflect.TypeOf(subarray).Kind().String())
 	}
-	subarrayType := reflect.TypeOf(subarray).Elem().Kind()
-	switch subarrayType {
-	case reflect.Int:
-		tmpSubArray := subarray.([]int)
-		cSubarray = unsafe.Pointer(&tmpSubArray[0])
-	case reflect.Int8:
-		tmpSubArray := subarray.([]int8)
-		cSubarray = unsafe.Pointer(&tmpSubArray[0])
-	case reflect.Int16:
-		tmpSubArray := subarray.([]int16)
-		cSubarray = unsafe.Pointer(&tmpSubArray[0])
-	case reflect.Int32:
-		tmpSubArray := subarray.([]int32)
-		cSubarray = unsafe.Pointer(&tmpSubArray[0])
-	case reflect.Int64:
-		tmpSubArray := subarray.([]int64)
-		cSubarray = unsafe.Pointer(&tmpSubArray[0])
-	case reflect.Uint:
-		tmpSubArray := subarray.([]uint)
-		cSubarray = unsafe.Pointer(&tmpSubArray[0])
-	case reflect.Uint8:
-		tmpSubArray := subarray.([]uint8)
-		cSubarray = unsafe.Pointer(&tmpSubArray[0])
-	case reflect.Uint16:
-		tmpSubArray := subarray.([]uint16)
-		cSubarray = unsafe.Pointer(&tmpSubArray[0])
-	case reflect.Uint32:
-		tmpSubArray := subarray.([]uint32)
-		cSubarray = unsafe.Pointer(&tmpSubArray[0])
-	case reflect.Uint64:
-		tmpSubArray := subarray.([]uint64)
-		cSubarray = unsafe.Pointer(&tmpSubArray[0])
-	case reflect.Float32:
-		tmpSubArray := subarray.([]float32)
-		cSubarray = unsafe.Pointer(&tmpSubArray[0])
-	case reflect.Float64:
-		tmpSubArray := subarray.([]float64)
-		cSubarray = unsafe.Pointer(&tmpSubArray[0])
+	switch subarray := subarray.(type) {
+	case []int:
+		cSubarray = slicePtr(subarray)
+	case []int8:
+		cSubarray = slicePtr(subarray)
+	case []int16:
+		cSubarray = slicePtr(subarray)
+	case []int32:
+		cSubarray = slicePtr(subarray)
+	case []int64:
+		cSubarray = slicePtr(subarray)
+	case []uint:
+		cSubarray = slicePtr(subarray)
+	case []uint8:
+		cSubarray = slicePtr(subarray)
+	case []uint16:
+		cSubarray = slicePtr(subarray)
+	case []uint32:
+		cSubarray = slicePtr(subarray)
+	case []uint64:
+		cSubarray = slicePtr(subarray)
+	case []float32:
+		cSubarray = slicePtr(subarray)
+	case []float64:
+		cSubarray = slicePtr(subarray)
+	case []bool:
+		cSubarray = slicePtr(subarray)
 	default:
-		return nil, fmt.Errorf("unhandled subarray datatype: %s", subarrayType.String())
+		return nil, fmt.Errorf("subarray must be a slice of scalars, not a %T", subarray)
 	}
 
 	buffer := Buffer{context: a.context}


### PR DESCRIPTION
I went through every (?) switch I could find in the whole library and
ensured that they supported `bool`s. In cases where it made sense,
I converted the switches to a shorter form and used generics to
dramatically reduce the amount of duplicated logic but with different
types.

Because we now use generics, we can't build on TileDB 1.17 (which is
fine, because our go.mod already specified that we need 1.18).