### PR TITLE
Set up caching to speed up build and test.

### DIFF
--- a/.github/scripts/build_with_sanitizer_and_run.sh
+++ b/.github/scripts/build_with_sanitizer_and_run.sh
@@ -1,3 +1,0 @@
-set -e -x
-CGO_ENABLED=1 CGO_LDFLAGS='-fsanitize=address' CGO_CFLAGS='-fsanitize=address' go build cmd/tiledb-go/main.go
-./main

--- a/.github/scripts/env.sh
+++ b/.github/scripts/env.sh
@@ -1,0 +1,16 @@
+# Subroutine to set up environment variables.
+
+CORE_ROOT="$HOME/tiledb-core"
+
+case "$(uname -s)" in
+  Linux)
+    OS="linux"
+  ;;
+  Darwin)
+    OS="macos"
+  ;;
+  *)
+    echo 'Unknown OS!'
+    exit 1
+  ;;
+esac

--- a/.github/scripts/install_tiledb_binary.sh
+++ b/.github/scripts/install_tiledb_binary.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -exo pipefail
+. "${BASH_SOURCE%/*}/env.sh"
+mkdir "$CORE_ROOT"
+cd "$CORE_ROOT"
+mkdir install
+curl --location -o tiledb.tar.gz "https://github.com/TileDB-Inc/TileDB/releases/download/${CORE_VERSION}/tiledb-${OS}-x86_64-${CORE_VERSION}-${CORE_HASH}.tar.gz"
+tar -C ./install -xf tiledb.tar.gz

--- a/.github/scripts/install_tiledb_linux.sh
+++ b/.github/scripts/install_tiledb_linux.sh
@@ -1,4 +1,0 @@
-set -e -x
-curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.10.2/tiledb-linux-x86_64-2.10.2-9ab84f9.tar.gz \
-&& sudo tar -C /usr/local -xf tiledb.tar.gz
-sudo ldconfig /usr/local/lib

--- a/.github/scripts/install_tiledb_linux_debug.sh
+++ b/.github/scripts/install_tiledb_linux_debug.sh
@@ -1,8 +1,0 @@
-set -e -x
-git clone https://github.com/TileDB-Inc/TileDB.git -b 2.10.2
-cd TileDB
-mkdir build && cd build
-cmake -DSANITIZER=leak -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr/local ..
-make -j4
-sudo make -C tiledb install
-sudo ldconfig /usr/local/lib

--- a/.github/scripts/install_tiledb_macos.sh
+++ b/.github/scripts/install_tiledb_macos.sh
@@ -1,3 +1,0 @@
-set -e -x
-curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.10.2/tiledb-macos-x86_64-2.10.2-9ab84f9.tar.gz \
-&& sudo tar -C /usr/local -xf tiledb.tar.gz

--- a/.github/scripts/install_tiledb_source.sh
+++ b/.github/scripts/install_tiledb_source.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -exo pipefail
+. "${BASH_SOURCE%/*}/env.sh"
+mkdir "$CORE_ROOT"
+cd "$CORE_ROOT"
+case "$OS" in
+  linux)
+    NPROC="$(nproc)"
+  ;;
+  macos)
+    NPROC="$(sysctl -n hw.ncpu)"
+  ;;
+esac
+git clone --depth 1 -b "$CORE_VERSION" https://github.com/TileDB-Inc/TileDB.git
+cd TileDB
+mkdir build
+cd build
+# BUILD_FLAGS is unquoted because it needs to expand into multiple strings.
+cmake $BUILD_FLAGS -DCMAKE_INSTALL_PREFIX="${CORE_ROOT}/install" ..
+make -j"$NPROC"
+
+mkdir "${CORE_ROOT}/install"
+make -C tiledb install

--- a/.github/scripts/install_tiledb_source_linux.sh
+++ b/.github/scripts/install_tiledb_source_linux.sh
@@ -1,8 +1,0 @@
-set -e -x
-git clone https://github.com/TileDB-Inc/TileDB.git -b 2.10.2
-cd TileDB
-mkdir build && cd build
-cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
-make -j$(nproc)
-sudo make -C tiledb install
-sudo ldconfig

--- a/.github/scripts/install_tiledb_source_macos.sh
+++ b/.github/scripts/install_tiledb_source_macos.sh
@@ -1,7 +1,0 @@
-set -e -x
-git clone https://github.com/TileDB-Inc/TileDB.git -b 2.10.2
-cd TileDB
-mkdir build && cd build
-cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
-make -j$(sysctl -n hw.ncpu)
-sudo make -C tiledb install

--- a/.github/scripts/post_install.sh
+++ b/.github/scripts/post_install.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -exo pipefail
+. "${BASH_SOURCE%/*}/env.sh"
+
+# Sets up the environment after installing or extracting TileDB.
+
+if [ "$OS" = "linux" ]; then
+  /sbin/ldconfig -n "${CORE_ROOT}/install/lib"
+fi
+
+go env -w "CGO_CFLAGS=-I${CORE_ROOT}/install/include"
+go env -w "CGO_LDFLAGS=-L${CORE_ROOT}/install/lib/ -Wl,-rpath,${CORE_ROOT}/install/lib/"

--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -7,157 +7,121 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  # The version of TileDB to test against.
+  CORE_VERSION: "2.10.2"
+  # The first seven characters of that version's commit hash
+  # (the same ones that GitHub displays on a release page).
+  CORE_HASH: "9ab84f9"
+
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-20.04
     steps:
 
-    # Checks out repository
-    - uses: actions/checkout@v2
+      # Checks out repository
+      - uses: actions/checkout@v2
 
-    # Downloads TileDB-Core from release assets and install
-    - name: Run TileDB install script
-      run: ./.github/scripts/install_tiledb_linux.sh
-      shell: bash
+      - name: Cache build
+        id: build-cache
+        uses: actions/cache@v2
+        with:
+          path: ~/tiledb-core/install
+          key: golangci-${{ runner.os }}-${{ env.CORE_VERSION }}-${{ env.CORE_HASH }}-${{ hashFiles('./.github/scripts/install_tiledb_binary.sh') }}
 
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
-      continue-on-error: true
-      with:
-        # Required: the version of golangci-lint is required and must be
-        # specified without patch version: we always use the latest patch version.
-        version: v1.35.2
+      - name: Install TileDB Core
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: './.github/scripts/install_tiledb_binary.sh'
 
-  Linux_Test:
-    runs-on: ubuntu-20.04
+      - name: Post-install
+        run: ./.github/scripts/post_install.sh
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        continue-on-error: true
+        with:
+          # Required: the version of golangci-lint is required and must be
+          # specified without patch version: we always use the latest patch version.
+          version: v1.35.2
+
+  binary-test:
+    name: binary-${{ matrix.runner }}-go${{ matrix.go }}
+    runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
-        # Will be checking following versions
         go: ["1.18"]
+        runner: ["macos-11", "ubuntu-20.04"]
+
     steps:
 
-    # Checks out repository
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    # Downloads TileDB-Core from release assets and install
-    - name: Run TileDB install script
-      run: ./.github/scripts/install_tiledb_linux.sh
-      shell: bash
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
 
-    # Following action sets up Go and uses the strategy matrix to test on
-    # specific versions
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
+      - name: Cache build
+        id: build-cache
+        uses: actions/cache@v2
+        with:
+          path: ~/tiledb-core/install
+          key: golangci-${{ runner.os }}-${{ env.CORE_VERSION }}-${{ env.CORE_HASH }}-${{ hashFiles('./.github/scripts/install_tiledb_binary.sh') }}
 
-    # Tests TileDB-Go
-    - name: Test TileDB-Go
-      run: go test -v ./...
+      - name: Install TileDB Core
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: './.github/scripts/install_tiledb_binary.sh'
 
-  Macos_Test:
-    runs-on: macos-11
+      - name: Post-install
+        run: ./.github/scripts/post_install.sh
+
+      - name: Run tests
+        run: go test -v ./...
+
+  source-test:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
-        # Will be checking following versions
-        go: ["1.18"]
+        include:
+          - name: macos-experimental
+            runner: macos-11
+            flags: "-DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release"
+            test-command: go test -tags=experimental -v ./...
+          - name: linux-experimental
+            runner: ubuntu-20.04
+            flags: "-DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release"
+            test-command: go test -tags=experimental -v ./...
+          - name: linux-asan
+            runner: ubuntu-20.04
+            flags: "-DSANITIZER=leak -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Debug"
+            test-command: go run -asan ./cmd/tiledb-go-examples
+
     steps:
-    # Checks out repository
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    # Downloads TileDB-Core from release assets and install
-    - name: Run TileDB install script
-      run: ./.github/scripts/install_tiledb_macos.sh
-      shell: bash
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.18"
 
-    # Following action sets up Go and uses the strategy matrix to test on
-    # specific versions
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
+      - name: Cache build
+        id: build-cache
+        uses: actions/cache@v2
+        with:
+          path: ~/tiledb-core/install
+          key: tiledb-binary-${{ runner.os }}-${{ env.CORE_VERSION }}-${{ env.CORE_HASH }}-${{ hashFiles('./.github/scripts/install_tiledb_source.sh') }}-${{ matrix.flags }}
 
-    # Tests TileDB-Go
-    - name: Test TileDB-Go
-      run: go test -v ./...
+      - name: Compile TileDB Core
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: './.github/scripts/install_tiledb_source.sh'
+        env:
+          BUILD_FLAGS: ${{ matrix.flags }}
 
-  Linux_Experimental_Test:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        # Will be checking following versions
-        go: ["1.18"]
-    steps:
+      - name: Post-install
+        run: ./.github/scripts/post_install.sh
 
-    # Checks out repository
-    - uses: actions/checkout@v2
-
-    # Downloads TileDB-Core from release assets and install
-    - name: Run TileDB install script
-      run: ./.github/scripts/install_tiledb_source_linux.sh
-      shell: bash
-
-    # Following action sets up Go and uses the strategy matrix to test on
-    # specific versions
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
-
-    # Tests TileDB-Go
-    - name: Test TileDB-Go
-      run: go test -tags=experimental -v ./...
-
-  Macos_Experimental_Test:
-    runs-on: macos-11
-    strategy:
-      matrix:
-        # Will be checking following versions
-        go: ["1.18"]
-    steps:
-    # Checks out repository
-    - uses: actions/checkout@v2
-
-    # Downloads TileDB-Core from release assets and install
-    - name: Run TileDB install script
-      run: ./.github/scripts/install_tiledb_source_macos.sh
-      shell: bash
-
-    # Following action sets up Go and uses the strategy matrix to test on
-    # specific versions
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
-
-    # Tests experimental bindings of TileDB-Go
-    - name: Test TileDB-Go
-      run: go test -tags=experimental -v ./...
-
-  Linux_Address_Sanitizer:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        # Will be checking following versions
-        go: [1.18]
-    steps:
-    # Checks out repository
-    - uses: actions/checkout@v2
-
-    # Downloads TileDB-Core from release assets and install
-    - name: Run TileDB install script
-      run: ./.github/scripts/install_tiledb_linux_debug.sh
-      shell: bash
-
-    # Following action sets up Go and uses the strategy matrix to test on
-    # specific versions
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
-
-    # Tests TileDB-Go
-    - name: Running examples using address sanitizer flags
-      continue-on-error: true
-      run: go run -tags asan ./cmd/tiledb-go-examples
+      - name: Run test
+        run: ${{ matrix.test-command }}

--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -52,19 +52,6 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
-    - name: Install dependencies
-      run: go get -t .
-
     # Tests TileDB-Go
     - name: Test TileDB-Go
       run: go test -v ./...
@@ -90,19 +77,6 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
-
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/Library/Caches/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
-    - name: Install dependencies
-      run: go get -t .
 
     # Tests TileDB-Go
     - name: Test TileDB-Go
@@ -131,19 +105,6 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-experimental
-        restore-keys: |
-          ${{ runner.os }}-go-
-
-    - name: Install dependencies
-      run: go get -t .
-
     # Tests TileDB-Go
     - name: Test TileDB-Go
       run: go test -tags=experimental -v ./...
@@ -170,19 +131,6 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/Library/Caches/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-experimental
-        restore-keys: |
-          ${{ runner.os }}-go-
-
-    - name: Install dependencies
-      run: go get -t .
-
     # Tests experimental bindings of TileDB-Go
     - name: Test TileDB-Go
       run: go test -tags=experimental -v ./...
@@ -208,20 +156,6 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
-
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-asan
-        restore-keys: |
-          ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          ${{ runner.os }}-go-
-
-    - name: Install dependencies
-      run: go get -t .
 
     # Tests TileDB-Go
     - name: Running examples using address sanitizer flags

--- a/cmd/tiledb-go-examples/asan_on.go
+++ b/cmd/tiledb-go-examples/asan_on.go
@@ -8,7 +8,14 @@ package main
 // void __lsan_do_leak_check(void);
 import "C"
 
+import (
+	"runtime"
+)
+
 // maybeASAN runs ASAN if the ASAN build tag is enabled.
 func maybeASAN() {
+	// Aggressively GC so that we can minimize false positives.
+	runtime.GC()
+	runtime.GC()
 	C.__lsan_do_leak_check()
 }


### PR DESCRIPTION
This change unifies the build scripts between Mac OS and Linux,
and caches build outputs. This means that future builds of the same
version don’t need to rerun the entire build process; they can use the
previously-built version.

We do a few things to accomplish this:

- Move compilation/installation into the `~/tiledb-core/install`
  directory. This allows us to cache it.
- Set appropriate `CGO_*FLAGS` variables to point to that directory.
  This includes the `rpath` directive, which embeds the full path
  to the dynamic library in the binary, so it knows it needs to look in
  `~/tiledb-core/install/lib` for `libtiledb.so`.
- Matrixes things out to reduce repetition.

This also fixes the ASAN step, which was never actually compiling.