### PR TITLE
Add support for tiledb_query_get_relevant_fragment_num

### DIFF
--- a/.github/scripts/install_tiledb_linux.sh
+++ b/.github/scripts/install_tiledb_linux.sh
@@ -1,4 +1,4 @@
 set -e -x
-curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.10.2/tiledb-linux-x86_64-2.10.2-9ab84f9.tar.gz \
+curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.10.4/tiledb-linux-x86_64-2.10.4-f2b5d11.tar.gz \
 && sudo tar -C /usr/local -xf tiledb.tar.gz
 sudo ldconfig /usr/local/lib

--- a/.github/scripts/install_tiledb_linux_debug.sh
+++ b/.github/scripts/install_tiledb_linux_debug.sh
@@ -1,5 +1,5 @@
 set -e -x
-git clone https://github.com/TileDB-Inc/TileDB.git -b 2.10.2
+git clone https://github.com/TileDB-Inc/TileDB.git -b 2.10.4
 cd TileDB
 mkdir build && cd build
 cmake -DSANITIZER=leak -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr/local ..

--- a/.github/scripts/install_tiledb_macos.sh
+++ b/.github/scripts/install_tiledb_macos.sh
@@ -1,3 +1,3 @@
 set -e -x
-curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.10.2/tiledb-macos-x86_64-2.10.2-9ab84f9.tar.gz \
+curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.10.4/tiledb-macos-x86_64-2.10.4-f2b5d11.tar.gz \
 && sudo tar -C /usr/local -xf tiledb.tar.gz

--- a/.github/scripts/install_tiledb_source_linux.sh
+++ b/.github/scripts/install_tiledb_source_linux.sh
@@ -1,5 +1,5 @@
 set -e -x
-git clone https://github.com/TileDB-Inc/TileDB.git -b 2.10.2
+git clone https://github.com/TileDB-Inc/TileDB.git -b 2.10.4
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..

--- a/.github/scripts/install_tiledb_source_macos.sh
+++ b/.github/scripts/install_tiledb_source_macos.sh
@@ -1,5 +1,5 @@
 set -e -x
-git clone https://github.com/TileDB-Inc/TileDB.git -b 2.10.2
+git clone https://github.com/TileDB-Inc/TileDB.git -b 2.10.4
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..

--- a/query_experimental.go
+++ b/query_experimental.go
@@ -1,0 +1,30 @@
+//go:build experimental
+// +build experimental
+
+// This file declares Go bindings for experimental features in TileDB.
+// Experimental APIs to do not fall under the API compatibility guarantees and
+// might change between TileDB versions
+
+package tiledb
+
+/*
+#cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
+#include <tiledb/tiledb.h>
+#include <tiledb/tiledb_experimental.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"fmt"
+)
+
+func (q *Query) RelevantFragmentNum() (uint64, error) {
+	var num C.uint64_t
+	if ret := C.tiledb_query_get_relevant_fragment_num(q.context.tiledbContext, q.tiledbQuery, &num); ret != C.TILEDB_OK {
+		return 0, fmt.Errorf("Error getting relevant fragment num from query: %s", q.context.LastError())
+	}
+
+	return uint64(num), nil
+}


### PR DESCRIPTION
Add support for `tiledb_query_get_relevant_fragment_num` via `Query.RelevantFragmentCount` in a new experimental file.

This requires TileDB 2.10.4 that is pending release.