### PR TITLE
Associate array schema with domain in func ExampleNewArray(). Before …

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -64,6 +64,12 @@ func ExampleNewArray() {
 		return
 	}
 
+	err = arraySchema.SetDomain(domain)
+	if err != nil {
+		// Handle error
+		return
+	}
+
 	array, err := NewArray(context, "my_array")
 	if err != nil {
 		// Handle error


### PR DESCRIPTION
…fix, This function fails to create an array with 'Error creating tiledb array: [TileDB::ArraySchema] Error: Array schema check failed; Domain not set'