### PR TITLE
Replace C.GoString with C.GoStringN where applicable

### DIFF
--- a/array.go
+++ b/array.go
@@ -1004,7 +1004,7 @@ func (a *Array) GetMetadataFromIndexWithValueLimit(index uint64, limit *uint) (*
 	}
 
 	arrayMetadata := ArrayMetadata{
-		Key:      C.GoString(cKey),
+		Key:      C.GoStringN(cKey, C.int(cKeyLen)),
 		KeyLen:   uint32(cKeyLen),
 		Datatype: datatype,
 		ValueNum: valueNum,

--- a/enums.go
+++ b/enums.go
@@ -402,19 +402,22 @@ func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, e
 			return "", nil
 		}
 		tmpslice := (*[1 << 46]C.char)(cvalue)[:valueNum:valueNum]
-		return C.GoString(&tmpslice[0])[0:valueNum], nil
+		// TODO: Handle overflow from unsigned conversion
+		return C.GoStringN(&tmpslice[0], C.int(valueNum))[0:valueNum], nil
 	case TILEDB_STRING_ASCII:
 		if cvalue == nil || valueNum == 0 {
 			return "", nil
 		}
 		tmpslice := (*[1 << 46]C.char)(cvalue)[:valueNum:valueNum]
-		return C.GoString(&tmpslice[0])[0:valueNum], nil
+		// TODO: Handle overflow from unsigned conversion
+		return C.GoStringN(&tmpslice[0], C.int(valueNum))[0:valueNum], nil
 	case TILEDB_STRING_UTF8:
 		if cvalue == nil || valueNum == 0 {
 			return "", nil
 		}
 		tmpslice := (*[1 << 46]C.char)(cvalue)[:valueNum:valueNum]
-		return C.GoString(&tmpslice[0])[0:valueNum], nil
+		// TODO: Handle overflow from unsigned conversion
+		return C.GoStringN(&tmpslice[0], C.int(valueNum))[0:valueNum], nil
 	case TILEDB_DATETIME_YEAR, TILEDB_DATETIME_MONTH, TILEDB_DATETIME_WEEK,
 		TILEDB_DATETIME_DAY, TILEDB_DATETIME_HR, TILEDB_DATETIME_MIN,
 		TILEDB_DATETIME_SEC, TILEDB_DATETIME_MS, TILEDB_DATETIME_US,

--- a/group.go
+++ b/group.go
@@ -411,7 +411,7 @@ func (g *Group) GetMetadataFromIndexWithValueLimit(index uint64, limit *uint) (*
 	}
 
 	groupMetadata := GroupMetadata{
-		Key:      C.GoString(cKey),
+		Key:      C.GoStringN(cKey, C.int(cKeyLen)),
 		KeyLen:   uint32(cKeyLen),
 		Datatype: datatype,
 		ValueNum: valueNum,


### PR DESCRIPTION
This allows us to support nulls in the strings. TileDB does not use null delimiters for any data, but the conversion from "C" to "Go" was treating nulls as delimiters. This solves this by using the size give by the core.