### PR TITLE
Use a safe(r) internal byte-storage type in Buffer.

### DIFF
--- a/common.go
+++ b/common.go
@@ -1,6 +1,9 @@
 package tiledb
 
-import "unsafe"
+import (
+	"reflect"
+	"unsafe"
+)
 
 // scalarType includes the basic types that can be stored in a TileDB array.
 // It does not include variable-sized types like strings or blobs.
@@ -14,5 +17,6 @@ type scalarType interface {
 
 // slicePtr gives you an unsafe pointer to the start of a slice.
 func slicePtr[T any](slc []T) unsafe.Pointer {
-	return unsafe.Pointer(&slc[0])
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&slc))
+	return unsafe.Pointer(hdr.Data)
 }

--- a/memory.go
+++ b/memory.go
@@ -1,7 +1,6 @@
 package tiledb
 
 import (
-	"reflect"
 	"runtime"
 	"unsafe"
 
@@ -47,8 +46,7 @@ func freeFreeable(obj Freeable) { obj.Free() }
 type byteBuffer []byte
 
 func (bb byteBuffer) start() unsafe.Pointer {
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&bb))
-	return unsafe.Pointer(hdr.Data)
+	return slicePtr(bb)
 }
 
 func (bb byteBuffer) lenBytes() uintptr { return uintptr(len(bb)) }

--- a/memory.go
+++ b/memory.go
@@ -1,6 +1,15 @@
 package tiledb
 
-import "runtime"
+import (
+	"reflect"
+	"runtime"
+	"unsafe"
+
+	// Much of this package relies on the fact that the Go GC is non-moving.
+	// When we move to a new Go version, this dependency should be updated
+	// to ensure that the new version is still a non-moving GC.
+	_ "go4.org/unsafe/assume-no-moving-gc"
+)
 
 // Freeable represents an object that can be Free'd at the end of its lifetime
 // to release its resources.
@@ -13,15 +22,15 @@ type Freeable interface {
 // It should be included immediately after the err-check of the code which
 // creates it:
 //
-//     func NewThingy() (*Thingy, error) {
-//       thingy := Thingy{}
-//       ret := C.tiledb_make_thingy(&thingy)
-//       if ret != C.TILEDB_OK {
-//         return nil, errors.New("whatever")
-//       }
-//       freeOnGC(&thingy)  // <-- put this here
-//       return &thingy, nil
-//     }
+//	func NewThingy() (*Thingy, error) {
+//	  thingy := Thingy{}
+//	  ret := C.tiledb_make_thingy(&thingy)
+//	  if ret != C.TILEDB_OK {
+//	    return nil, errors.New("whatever")
+//	  }
+//	  freeOnGC(&thingy)  // <-- put this here
+//	  return &thingy, nil
+//	}
 func freeOnGC(obj Freeable) {
 	runtime.SetFinalizer(obj, freeFreeable)
 }
@@ -29,3 +38,22 @@ func freeOnGC(obj Freeable) {
 // freeFreeable frees the Freeable. It's free-floating to avoid capturing
 // anything in a closure.
 func freeFreeable(obj Freeable) { obj.Free() }
+
+//
+// Memory buffers and related stuff
+//
+
+// byteBuffer provides methods useful for treating byte slices as memory.
+type byteBuffer []byte
+
+func (bb byteBuffer) start() unsafe.Pointer {
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&bb))
+	return unsafe.Pointer(hdr.Data)
+}
+
+func (bb byteBuffer) lenBytes() uintptr { return uintptr(len(bb)) }
+
+func (bb byteBuffer) subSlice(sliceStart unsafe.Pointer, sliceBytes uintptr) []byte {
+	startIdx := uintptr(sliceStart) - uintptr(bb.start())
+	return bb[startIdx:sliceBytes]
+}


### PR DESCRIPTION
This creates byteBuffer, a safer way to handle buffers that are passed to and from C. It keeps track of its own address and uses that to resolve indices relative to itself, so that the Go garbage collector can always keep track of the memory that is in use.