### PR TITLE
Update config test cases for new config parameter

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -15,12 +15,12 @@ func ExampleConfig_Set() {
 		// handle error
 	}
 
-	err = config.Set("sm.tile_cache_size", "10")
+	err = config.Set("sm.mem.total_budget", "10")
 	if err != nil {
 		// handle error
 	}
 
-	val, err := config.Get("sm.tile_cache_size")
+	val, err := config.Get("sm.mem.total_budget")
 	if err != nil {
 		// handle error
 	}
@@ -34,12 +34,12 @@ func ExampleConfig_Get() {
 		// handle error
 	}
 
-	val, err := config.Get("sm.tile_cache_size")
+	val, err := config.Get("sm.mem.total_budget")
 	if err != nil {
 		// handle error
 	}
 	fmt.Println(val)
-	// Output: 10000000
+	// Output: 10737418240
 }
 
 func TestNewConfig(t *testing.T) {
@@ -50,58 +50,58 @@ func TestNewConfig(t *testing.T) {
 	config.Free()
 }
 
-//TestSettingConfig
+// TestSettingConfig
 func TestSettingConfig(t *testing.T) {
 	config, err := NewConfig()
 	require.NoError(t, err)
-	assert.Error(t, config.Set("sm.tile_cache_size", "fail"))
+	assert.Error(t, config.Set("sm.mem.total_budget", "fail"))
 
-	require.NoError(t, config.Set("sm.tile_cache_size", "10"))
+	require.NoError(t, config.Set("sm.mem.total_budget", "10"))
 
-	val, err := config.Get("sm.tile_cache_size")
+	val, err := config.Get("sm.mem.total_budget")
 	require.NoError(t, err)
 	assert.Equal(t, "10", val)
 }
 
-//TestGettingConfig
+// TestGettingConfig
 func TestGettingConfig(t *testing.T) {
 	config, err := NewConfig()
 	require.NoError(t, err)
 
-	val, err := config.Get("sm.tile_cache_size")
+	val, err := config.Get("sm.mem.total_budget")
 	require.NoError(t, err)
-	assert.Equal(t, "10000000", val)
+	assert.Equal(t, "10737418240", val)
 
 	val, err = config.Get("sm.does_not_exists")
 	require.NoError(t, err)
 	assert.Empty(t, val)
 }
 
-//TestUnSettingConfig
+// TestUnSettingConfig
 func TestUnSettingConfig(t *testing.T) {
 	config, err := NewConfig()
 	require.NoError(t, err)
-	require.NoError(t, config.Set("sm.tile_cache_size", "10"))
+	require.NoError(t, config.Set("sm.mem.total_budget", "10"))
 
-	val, err := config.Get("sm.tile_cache_size")
+	val, err := config.Get("sm.mem.total_budget")
 	require.NoError(t, err)
 	assert.Equal(t, "10", val)
 
-	require.NoError(t, config.Unset("sm.tile_cache_size"))
+	require.NoError(t, config.Unset("sm.mem.total_budget"))
 
-	val, err = config.Get("sm.tile_cache_size")
+	val, err = config.Get("sm.mem.total_budget")
 	require.NoError(t, err)
-	assert.Equal(t, "10000000", val)
+	assert.Equal(t, "10737418240", val)
 }
 
-//TestFileConfig
+// TestFileConfig
 func TestFileConfig(t *testing.T) {
 	config, err := NewConfig()
 	require.NoError(t, err)
 	assert.NotNil(t, config)
-	require.NoError(t, config.Set("sm.tile_cache_size", "10"))
+	require.NoError(t, config.Set("sm.mem.total_budget", "10"))
 
-	val, err := config.Get("sm.tile_cache_size")
+	val, err := config.Get("sm.mem.total_budget")
 	require.NoError(t, err)
 	assert.Equal(t, "10", val)
 
@@ -114,12 +114,12 @@ func TestFileConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, config2)
 
-	val, err = config2.Get("sm.tile_cache_size")
+	val, err = config2.Get("sm.mem.total_budget")
 	require.NoError(t, err)
 	assert.Equal(t, "10", val)
 }
 
-//TestConfigIter
+// TestConfigIter
 func TestConfigIter(t *testing.T) {
 	config, err := NewConfig()
 	require.NoError(t, err)

--- a/context_test.go
+++ b/context_test.go
@@ -95,14 +95,14 @@ func TestCancelAllTasks(t *testing.T) {
 func TestGetContextConfig(t *testing.T) {
 	// Create a context with a non-default value:
 	context, err := NewContextFromMap(map[string]string{
-		"sm.tile_cache_size": "10",
+		"sm.mem.total_budget": "10",
 	})
 	require.NoError(t, err)
 	config, err := context.Config()
 	require.NoError(t, err)
 
 	// Validate config has setting changed
-	val, err := config.Get("sm.tile_cache_size")
+	val, err := config.Get("sm.mem.total_budget")
 	require.NoError(t, err)
 	assert.Equal(t, "10", val)
 }

--- a/examples_lib/config.go
+++ b/examples_lib/config.go
@@ -63,9 +63,9 @@ func setGetConfig() {
 	fmt.Printf("VFS connect timeout in ms is: %s\n", vfsConnectTimeoutMs)
 
 	// Get another value and print it
-	tileCacheSize, err := config.Get("sm.tile_cache_size")
+	memTotalBudget, err := config.Get("sm.mem.total_budget")
 	checkError(err)
-	fmt.Printf("Tile cache size: %s\n", tileCacheSize)
+	fmt.Printf("Total memory budget: %s\n", memTotalBudget)
 }
 
 func printDefault() {
@@ -167,10 +167,10 @@ func printDefault() {
 	fmt.Printf("\"sm.num_writer_threads\" : \"%s\"\n",
 		smNumWriterThreads)
 
-	smTileCacheSize, err := config.Get("sm.tile_cache_size")
+	smMemTotalBudget, err := config.Get("sm.mem.total_budget")
 	checkError(err)
-	fmt.Printf("\"sm.tile_cache_size\" : \"%s\"\n",
-		smTileCacheSize)
+	fmt.Printf("\"sm.mem.total_budget\" : \"%s\"\n",
+		smMemTotalBudget)
 
 	vfsFileMaxParallelOps, err := config.Get("vfs.file.max_parallel_ops")
 	checkError(err)
@@ -314,7 +314,7 @@ func saveLoadConfig() {
 	defer config.Free()
 
 	// Set a value
-	err = config.Set("sm.tile_cache_size", "8")
+	err = config.Set("sm.mem.total_budget", "500000")
 	checkError(err)
 
 	// Save to disk
@@ -326,10 +326,10 @@ func saveLoadConfig() {
 	checkError(err)
 
 	// Print the retrieved value
-	smTileCacheSize, err := newConfig.Get("sm.tile_cache_size")
+	smMemTotalBudget, err := newConfig.Get("sm.mem.total_budget")
 	checkError(err)
-	fmt.Printf("\"sm.tile_cache_size\" : \"%s\"\n",
-		smTileCacheSize)
+	fmt.Printf("\"sm.mem.total_budget\" : \"%s\"\n",
+		smMemTotalBudget)
 
 	newConfig.Free()
 }


### PR DESCRIPTION
This adjusts the config and context tests to not use the removed "sm.tile_cache_size" parameter. The tests now use "sm.mem.total_budget".

This fixes one of the issues from #251 