### PR TITLE
Keepalive config for context creation

### DIFF
--- a/context.go
+++ b/context.go
@@ -43,6 +43,9 @@ func NewContext(config *Config) (*Context, error) {
 		return nil, fmt.Errorf("error creating tiledb context: %w", err)
 	}
 
+	if config != nil {
+		runtime.KeepAlive(config)
+	}
 	return &context, nil
 }
 


### PR DESCRIPTION
If a config is passed in we need to keep it alive to ensure the config isn't garbage collected while it is being used in the cgo call for tiledb_ctx_alloc.