### PR TITLE
Add keepalive to config for consolidate/vacuum

### DIFF
--- a/array.go
+++ b/array.go
@@ -11,6 +11,7 @@ import "C"
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"unsafe"
 )
 
@@ -200,6 +201,8 @@ func (a *Array) Consolidate(config *Config) error {
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error consolidating tiledb array: %s", a.context.LastError())
 	}
+	
+	runtime.KeepAlive(config)
 	return nil
 }
 
@@ -215,6 +218,8 @@ func (a *Array) Vacuum(config *Config) error {
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error vacuumimg tiledb array: %s", a.context.LastError())
 	}
+	
+	runtime.KeepAlive(config)
 	return nil
 }
 


### PR DESCRIPTION
This ensure the consolidation/vacuum configs are not gc'ed during the Cgo call to TileDB.