### PR TITLE
Support the TileDB core Subarray API for queries

### DIFF
--- a/enums.go
+++ b/enums.go
@@ -207,6 +207,54 @@ func (d Datatype) ReflectKind() reflect.Kind {
 	}
 }
 
+// ReflectType returns the reflect type given a datatype
+func (d Datatype) ReflectType() reflect.Type {
+	switch d {
+	case TILEDB_INT8:
+		return reflect.TypeOf(int8(0))
+	case TILEDB_INT16:
+		return reflect.TypeOf(int16(0))
+	case TILEDB_INT32:
+		return reflect.TypeOf(int32(0))
+	case TILEDB_INT64:
+		return reflect.TypeOf(int64(0))
+	case TILEDB_UINT8, TILEDB_BLOB:
+		return reflect.TypeOf(uint8(0))
+	case TILEDB_UINT16:
+		return reflect.TypeOf(uint16(0))
+	case TILEDB_UINT32:
+		return reflect.TypeOf(uint32(0))
+	case TILEDB_UINT64:
+		return reflect.TypeOf(uint64(0))
+	case TILEDB_FLOAT32:
+		return reflect.TypeOf(float32(0))
+	case TILEDB_FLOAT64:
+		return reflect.TypeOf(float64(0))
+	case TILEDB_CHAR:
+		return reflect.TypeOf(uint8(0))
+	case TILEDB_STRING_ASCII:
+		return reflect.TypeOf(uint8(0))
+	case TILEDB_STRING_UTF8:
+		return reflect.TypeOf(uint8(0))
+	case TILEDB_STRING_UTF16:
+		return reflect.TypeOf(uint16(0))
+	case TILEDB_STRING_UTF32:
+		return reflect.TypeOf(uint32(0))
+	case TILEDB_STRING_UCS2:
+		return reflect.TypeOf(uint16(0))
+	case TILEDB_STRING_UCS4:
+		return reflect.TypeOf(uint32(0))
+	case TILEDB_ANY: // deprecated type since 2.7.0, treat as invalid
+		return reflect.TypeOf(nil)
+	case TILEDB_DATETIME_YEAR, TILEDB_DATETIME_MONTH, TILEDB_DATETIME_WEEK, TILEDB_DATETIME_DAY, TILEDB_DATETIME_HR, TILEDB_DATETIME_MIN, TILEDB_DATETIME_SEC, TILEDB_DATETIME_MS, TILEDB_DATETIME_US, TILEDB_DATETIME_NS, TILEDB_DATETIME_PS, TILEDB_DATETIME_FS, TILEDB_DATETIME_AS, TILEDB_TIME_HR, TILEDB_TIME_MIN, TILEDB_TIME_SEC, TILEDB_TIME_MS, TILEDB_TIME_US, TILEDB_TIME_NS, TILEDB_TIME_PS, TILEDB_TIME_FS, TILEDB_TIME_AS:
+		return reflect.TypeOf(int64(0))
+	case TILEDB_BOOL:
+		return reflect.TypeOf(true)
+	default:
+		return reflect.TypeOf(nil)
+	}
+}
+
 // Size returns the datatype size in bytes
 func (d Datatype) Size() uint64 {
 	return uint64(C.tiledb_datatype_size(C.tiledb_datatype_t(d)))

--- a/query.go
+++ b/query.go
@@ -4129,3 +4129,24 @@ func (q *Query) getOffsetsBufferAndSize(attributeOrDimension string) ([]uint64, 
 
 	return offsets, offsetNumElements, nil
 }
+
+// SetSubarray sets the subarray for the query
+func (q *Query) SetSubarray(sa *Subarray) error {
+	ret := C.tiledb_query_set_subarray_t(q.context.tiledbContext, q.tiledbQuery, sa.subarray)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error setting tiledb query subarray: %s", q.context.LastError())
+	}
+	return nil
+}
+
+// GetSubarray get the subarray set on the query
+func (q *Query) GetSubarray() (*Subarray, error) {
+	var sa *C.tiledb_subarray_t
+
+	ret := C.tiledb_query_get_subarray_t(q.context.tiledbContext, q.tiledbQuery, &sa)
+	if ret != C.TILEDB_OK {
+		return nil, fmt.Errorf("Error getting tiledb query subarray: %s", q.context.LastError())
+	}
+
+	return &Subarray{array: q.array, subarray: sa, context: q.context}, nil
+}

--- a/range.go
+++ b/range.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 )
 
-// TileDBDimensionType is a constraint for the types allowed for a TileDB dimension
-type TileDBDimensionType interface {
+// DimensionType is a constraint for the types allowed for a TileDB dimension
+type DimensionType interface {
 	~string | ~float32 | ~float64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~int | ~int8 | ~int16 | ~int32 | ~int64
 }
 
@@ -18,14 +18,14 @@ type Range struct {
 }
 
 // MakeRange returns a typed range [from, to]. It can be used with AddRange to add ranges to a dimension.
-func MakeRange[T TileDBDimensionType](start, end T) Range {
+func MakeRange[T DimensionType](start, end T) Range {
 	return Range{start: start, end: end}
 }
 
 // ExtractRange extracts the endpoints of the range.
 // It returns []T{start, end, stride}. The stride is not supported by TileDB core yet,
 // so it gets the zero value of T
-func ExtractRange[T TileDBDimensionType](r Range) ([]T, error) {
+func ExtractRange[T DimensionType](r Range) ([]T, error) {
 	// we compare reflect.Kind because they give more versatility. Reflect.Type is more strict
 	// Consider:
 	// type Tag string

--- a/range.go
+++ b/range.go
@@ -1,0 +1,63 @@
+package tiledb
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// TileDBDimensionType is a constraint for the types allowed for a TileDB dimension
+type TileDBDimensionType interface {
+	~string | ~float32 | ~float64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+// Range is an 1D range along a subarray dimension
+type Range struct {
+	start interface{} // start of range, inclusive
+	end   interface{} // end of range, inclusive
+}
+
+// MakeRange returns a typed range [from, to]. It can be used with AddRange to add ranges to a dimension.
+func MakeRange[T TileDBDimensionType](start, end T) Range {
+	return Range{start: start, end: end}
+}
+
+// ExtractRange extracts the endpoints of the range.
+// It returns [3]T{start, end, stride}. The stride is not supported by TileDB core yet,
+// so it gets the zero value of T
+func ExtractRange[T TileDBDimensionType](r Range) ([]T, error) {
+	tKind := genericType[T]().Kind()
+	rKind := reflect.ValueOf(r.start).Kind()
+	if tKind != rKind {
+		return nil, fmt.Errorf("cannot extract a range of %s to a slice of %s", rKind, tKind)
+	}
+
+	res := make([]T, 3)
+	res[0] = r.start.(T)
+	res[1] = r.end.(T)
+	// res[2] is stride
+
+	return res, nil
+}
+
+// assertCompatibility checks that the datatype of an array dimension are the same as the range's.
+func (r Range) assertCompatibility(dimType Datatype, dimIsVar bool) error {
+	dKind := dimType.ReflectKind()
+	rKind := reflect.ValueOf(r.start).Kind()
+	rIsVar := rKind == reflect.String
+
+	if dimIsVar && dKind != reflect.Uint8 {
+		return errors.New("only []byte var dimensions are supported")
+	}
+	if dimIsVar && !rIsVar {
+		return errors.New("dimension is of variable size but range is not")
+	}
+	if !dimIsVar && rIsVar {
+		return errors.New("range is of variable size but dimension is not")
+	}
+	if !dimIsVar && dKind != rKind {
+		return fmt.Errorf("dimension and range types mismatch, range: %s dimension: %s", rKind, dKind)
+	}
+
+	return nil
+}

--- a/range.go
+++ b/range.go
@@ -26,6 +26,12 @@ func MakeRange[T TileDBDimensionType](start, end T) Range {
 // It returns []T{start, end, stride}. The stride is not supported by TileDB core yet,
 // so it gets the zero value of T
 func ExtractRange[T TileDBDimensionType](r Range) ([]T, error) {
+	// we compare reflect.Kind because they give more versatility. Reflect.Type is more strict
+	// Consider:
+	// type Tag string
+	// type Label string
+	// Label and Tag have different Type but same Kind. To interface with TileDB Core we use Kind
+	// which is reflected to the core dimensions types.
 	tKind := genericType[T]().Kind()
 	rKind := reflect.ValueOf(r.start).Kind()
 	if tKind != rKind {

--- a/range.go
+++ b/range.go
@@ -23,13 +23,13 @@ func MakeRange[T TileDBDimensionType](start, end T) Range {
 }
 
 // ExtractRange extracts the endpoints of the range.
-// It returns [3]T{start, end, stride}. The stride is not supported by TileDB core yet,
+// It returns []T{start, end, stride}. The stride is not supported by TileDB core yet,
 // so it gets the zero value of T
 func ExtractRange[T TileDBDimensionType](r Range) ([]T, error) {
 	tKind := genericType[T]().Kind()
 	rKind := reflect.ValueOf(r.start).Kind()
 	if tKind != rKind {
-		return nil, fmt.Errorf("cannot extract a range of %s to a slice of %s", rKind, tKind)
+		return nil, fmt.Errorf("cannot extract a range of %T to a slice of %v", r.start, genericType[T]())
 	}
 
 	res := make([]T, 3)

--- a/range_test.go
+++ b/range_test.go
@@ -1,0 +1,31 @@
+package tiledb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRange(t *testing.T) {
+	r := MakeRange(uint8(10), uint8(20))
+	iBounds, err := ExtractRange[uint8](r)
+	require.NoError(t, err)
+	require.Equal(t, uint8(10), iBounds[0])
+	require.Equal(t, uint8(20), iBounds[1])
+
+	// extract for other types should fail
+	_, err = ExtractRange[uint16](r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot extract a range of uint8 to a slice of uint16")
+
+	s := MakeRange("start", "end")
+	sBounds, err := ExtractRange[string](s)
+	require.NoError(t, err)
+	require.Equal(t, "start", sBounds[0])
+	require.Equal(t, "end", sBounds[1])
+
+	// extract for other types should fail
+	_, err = ExtractRange[uint16](s)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot extract a range of string to a slice of uint16")
+}

--- a/range_test.go
+++ b/range_test.go
@@ -3,6 +3,7 @@ package tiledb
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -10,22 +11,22 @@ func TestRange(t *testing.T) {
 	r := MakeRange(uint8(10), uint8(20))
 	iBounds, err := ExtractRange[uint8](r)
 	require.NoError(t, err)
-	require.Equal(t, uint8(10), iBounds[0])
-	require.Equal(t, uint8(20), iBounds[1])
+	assert.Equal(t, uint8(10), iBounds[0])
+	assert.Equal(t, uint8(20), iBounds[1])
 
 	// extract for other types should fail
 	_, err = ExtractRange[uint16](r)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot extract a range of uint8 to a slice of uint16")
+	assert.Contains(t, err.Error(), "cannot extract a range of uint8 to a slice of uint16")
 
 	s := MakeRange("start", "end")
 	sBounds, err := ExtractRange[string](s)
 	require.NoError(t, err)
-	require.Equal(t, "start", sBounds[0])
-	require.Equal(t, "end", sBounds[1])
+	assert.Equal(t, "start", sBounds[0])
+	assert.Equal(t, "end", sBounds[1])
 
 	// extract for other types should fail
 	_, err = ExtractRange[uint16](s)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot extract a range of string to a slice of uint16")
+	assert.Contains(t, err.Error(), "cannot extract a range of string to a slice of uint16")
 }

--- a/reflection.go
+++ b/reflection.go
@@ -1,0 +1,70 @@
+package tiledb
+
+import (
+	"reflect"
+)
+
+// genericType returns the reflect.Type for T
+func genericType[T any]() reflect.Type {
+	return reflect.TypeOf((*T)(nil)).Elem()
+}
+
+// datatypeOfDimensionFromIndex returns for a dimension the Datatype and whether it is of variable size
+func datatypeOfDimensionFromIndex(arr *Array, dimIdx uint32) (Datatype, bool, error) {
+	schema, err := arr.Schema()
+	if err != nil {
+		return Datatype(0), false, err
+	}
+
+	domain, err := schema.Domain()
+	if err != nil {
+		return Datatype(0), false, err
+	}
+
+	dimension, err := domain.DimensionFromIndex(uint(dimIdx))
+	if err != nil {
+		return Datatype(0), false, err
+	}
+
+	datatype, err := dimension.Type()
+	if err != nil {
+		return Datatype(0), false, err
+	}
+
+	cellValNum, err := dimension.CellValNum()
+	if err != nil {
+		return Datatype(0), false, err
+	}
+
+	return datatype, cellValNum == TILEDB_VAR_NUM, nil
+}
+
+// datatypeOfDimensionFromName returns for a dimension the Datatype and whether it is of variable size
+func datatypeOfDimensionFromName(arr *Array, dimName string) (Datatype, bool, error) {
+	schema, err := arr.Schema()
+	if err != nil {
+		return Datatype(0), false, err
+	}
+
+	domain, err := schema.Domain()
+	if err != nil {
+		return Datatype(0), false, err
+	}
+
+	dimension, err := domain.DimensionFromName(dimName)
+	if err != nil {
+		return Datatype(0), false, err
+	}
+
+	datatype, err := dimension.Type()
+	if err != nil {
+		return Datatype(0), false, err
+	}
+
+	cellValNum, err := dimension.CellValNum()
+	if err != nil {
+		return Datatype(0), false, err
+	}
+
+	return datatype, cellValNum == TILEDB_VAR_NUM, nil
+}

--- a/reflection.go
+++ b/reflection.go
@@ -68,3 +68,12 @@ func datatypeOfDimensionFromName(arr *Array, dimName string) (Datatype, bool, er
 
 	return datatype, cellValNum == TILEDB_VAR_NUM, nil
 }
+
+// addressableValue copies the value of `val` into an addressable location.
+// This is used to return a Value that can always give as an UnsafePointer reflectively.
+func addressableValue(val any) reflect.Value {
+	valVal := reflect.ValueOf(val)
+	pointable := reflect.New(valVal.Type())
+	pointable.Elem().Set(valVal)
+	return pointable
+}

--- a/subarray.go
+++ b/subarray.go
@@ -87,12 +87,8 @@ func (sa *Subarray) AddRange(dimIdx uint32, r Range) error {
 		ret = C.tiledb_subarray_add_range_var(sa.context.tiledbContext, sa.subarray, C.uint32_t(dimIdx),
 			unsafe.Pointer(&startSlice[0]), C.uint64_t(len(startSlice)), unsafe.Pointer(&endSlice[0]), C.uint64_t(len(endSlice)))
 	} else {
-		sp := reflect.New(reflect.ValueOf(r.start).Type())
-		sp.Elem().Set(reflect.ValueOf(r.start))
-		ep := reflect.New(reflect.ValueOf(r.end).Type())
-		ep.Elem().Set(reflect.ValueOf(r.end))
 		ret = C.tiledb_subarray_add_range(sa.context.tiledbContext, sa.subarray, C.uint32_t(dimIdx),
-			sp.UnsafePointer(), ep.UnsafePointer(), nil)
+			addressableValue(r.start).UnsafePointer(), addressableValue(r.end).UnsafePointer(), nil)
 	}
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error adding subarray range: %s", sa.context.LastError())
@@ -122,12 +118,8 @@ func (sa *Subarray) AddRangeByName(dimName string, r Range) error {
 		ret = C.tiledb_subarray_add_range_var_by_name(sa.context.tiledbContext, sa.subarray, cDimName,
 			unsafe.Pointer(&startSlice[0]), C.uint64_t(len(startSlice)), unsafe.Pointer(&endSlice[0]), C.uint64_t(len(endSlice)))
 	} else {
-		sp := reflect.New(reflect.ValueOf(r.start).Type())
-		sp.Elem().Set(reflect.ValueOf(r.start))
-		ep := reflect.New(reflect.ValueOf(r.end).Type())
-		ep.Elem().Set(reflect.ValueOf(r.end))
 		ret = C.tiledb_subarray_add_range_by_name(sa.context.tiledbContext, sa.subarray, cDimName,
-			sp.UnsafePointer(), ep.UnsafePointer(), nil)
+			addressableValue(r.start).UnsafePointer(), addressableValue(r.end).UnsafePointer(), nil)
 	}
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error adding subarray range: %s", sa.context.LastError())

--- a/subarray.go
+++ b/subarray.go
@@ -82,23 +82,22 @@ func (sa *Subarray) AddRange(dimIdx uint32, r Range) error {
 	}
 
 	var ret C.int32_t
-	var startSlice, endSlice []byte
 	if isVar {
 		startSlice := []byte(r.start.(string))
 		endSlice := []byte(r.end.(string))
 		ret = C.tiledb_subarray_add_range_var(sa.context.tiledbContext, sa.subarray, C.uint32_t(dimIdx),
 			unsafe.Pointer(&startSlice[0]), C.uint64_t(len(startSlice)), unsafe.Pointer(&endSlice[0]), C.uint64_t(len(endSlice)))
+		runtime.KeepAlive(startSlice)
+		runtime.KeepAlive(endSlice)
 	} else {
 		ret = C.tiledb_subarray_add_range(sa.context.tiledbContext, sa.subarray, C.uint32_t(dimIdx),
 			addressableValue(r.start).UnsafePointer(), addressableValue(r.end).UnsafePointer(), nil)
+		runtime.KeepAlive(r.start)
+		runtime.KeepAlive(r.end)
 	}
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error adding subarray range: %s", sa.context.LastError())
 	}
-
-	runtime.KeepAlive(startSlice)
-	runtime.KeepAlive(endSlice)
-	runtime.KeepAlive(r)
 
 	return nil
 }
@@ -118,23 +117,22 @@ func (sa *Subarray) AddRangeByName(dimName string, r Range) error {
 	defer C.free(unsafe.Pointer(cDimName))
 
 	var ret C.int32_t
-	var startSlice, endSlice []byte
 	if isVar {
-		startSlice = []byte(r.start.(string))
-		endSlice = []byte(r.end.(string))
+		startSlice := []byte(r.start.(string))
+		endSlice := []byte(r.end.(string))
 		ret = C.tiledb_subarray_add_range_var_by_name(sa.context.tiledbContext, sa.subarray, cDimName,
 			unsafe.Pointer(&startSlice[0]), C.uint64_t(len(startSlice)), unsafe.Pointer(&endSlice[0]), C.uint64_t(len(endSlice)))
+		runtime.KeepAlive(startSlice)
+		runtime.KeepAlive(endSlice)
 	} else {
 		ret = C.tiledb_subarray_add_range_by_name(sa.context.tiledbContext, sa.subarray, cDimName,
 			addressableValue(r.start).UnsafePointer(), addressableValue(r.end).UnsafePointer(), nil)
+		runtime.KeepAlive(r.start)
+		runtime.KeepAlive(r.end)
 	}
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error adding subarray range: %s", sa.context.LastError())
 	}
-
-	runtime.KeepAlive(startSlice)
-	runtime.KeepAlive(endSlice)
-	runtime.KeepAlive(r)
 
 	return nil
 }

--- a/subarray.go
+++ b/subarray.go
@@ -10,6 +10,7 @@ import "C"
 import (
 	"fmt"
 	"reflect"
+	"runtime"
 	"unsafe"
 )
 
@@ -81,6 +82,7 @@ func (sa *Subarray) AddRange(dimIdx uint32, r Range) error {
 	}
 
 	var ret C.int32_t
+	var startSlice, endSlice []byte
 	if isVar {
 		startSlice := []byte(r.start.(string))
 		endSlice := []byte(r.end.(string))
@@ -93,6 +95,10 @@ func (sa *Subarray) AddRange(dimIdx uint32, r Range) error {
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error adding subarray range: %s", sa.context.LastError())
 	}
+
+	runtime.KeepAlive(startSlice)
+	runtime.KeepAlive(endSlice)
+	runtime.KeepAlive(r)
 
 	return nil
 }
@@ -112,9 +118,10 @@ func (sa *Subarray) AddRangeByName(dimName string, r Range) error {
 	defer C.free(unsafe.Pointer(cDimName))
 
 	var ret C.int32_t
+	var startSlice, endSlice []byte
 	if isVar {
-		startSlice := []byte(r.start.(string))
-		endSlice := []byte(r.end.(string))
+		startSlice = []byte(r.start.(string))
+		endSlice = []byte(r.end.(string))
 		ret = C.tiledb_subarray_add_range_var_by_name(sa.context.tiledbContext, sa.subarray, cDimName,
 			unsafe.Pointer(&startSlice[0]), C.uint64_t(len(startSlice)), unsafe.Pointer(&endSlice[0]), C.uint64_t(len(endSlice)))
 	} else {
@@ -124,6 +131,10 @@ func (sa *Subarray) AddRangeByName(dimName string, r Range) error {
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error adding subarray range: %s", sa.context.LastError())
 	}
+
+	runtime.KeepAlive(startSlice)
+	runtime.KeepAlive(endSlice)
+	runtime.KeepAlive(r)
 
 	return nil
 }

--- a/subarray.go
+++ b/subarray.go
@@ -1,0 +1,263 @@
+package tiledb
+
+/*
+#cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
+#include <tiledb/tiledb.h>
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"fmt"
+	"reflect"
+	"unsafe"
+)
+
+// Subarray is a container of dimension ranges for a tiledb Query.
+type Subarray struct {
+	array    *Array
+	subarray *C.tiledb_subarray_t
+	context  *Context
+}
+
+// NewSubarray creates a new subarray for array. It has internal coalesce_ranges == true.
+func (a *Array) NewSubarray() (*Subarray, error) {
+	var sa *C.tiledb_subarray_t
+
+	ret := C.tiledb_subarray_alloc(a.context.tiledbContext, a.tiledbArray, &sa)
+	if ret != C.TILEDB_OK {
+		return nil, fmt.Errorf("Error creating Subarray: %s", a.context.LastError())
+	}
+
+	subarray := &Subarray{array: a, subarray: sa, context: a.context}
+	freeOnGC(subarray)
+
+	return subarray, nil
+}
+
+// SetConfig sets the subarray config. Currently it overrides only sm.read_range_oob
+func (sa *Subarray) SetConfig(cfg *Config) error {
+	ret := C.tiledb_subarray_set_config(sa.context.tiledbContext, sa.subarray, cfg.tiledbConfig)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error setting Config: %s", sa.context.LastError())
+	}
+	return nil
+}
+
+// Free releases the internal TileDB core data that was allocated on the C heap.
+// It is automatically called when this object is garbage collected, but can be called earlier to
+// manually release memory if needed. Free is idempotent and can safely be called many times on the same object.
+func (sa *Subarray) Free() {
+	if sa.subarray != nil {
+		C.tiledb_subarray_free(&sa.subarray)
+	}
+}
+
+// SetCoalesceRanges sets coalesce_ranges property on a TileDB subarray object.
+// Intended to be used just after array.NewSubarray to replace the initial coalesce_ranges == true with coalesce_ranges = false if needed.
+func (sa *Subarray) SetCoalesceRanges(b bool) error {
+	var coalesce C.int
+	if b {
+		coalesce = 1
+	}
+
+	ret := C.tiledb_subarray_set_coalesce_ranges(sa.context.tiledbContext, sa.subarray, coalesce)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error setting coalesce ranges on subarray: %s", sa.context.LastError())
+	}
+
+	return nil
+}
+
+// AddRange adds a range along a subarray dimension. It checks the types of range and dimension and
+// if the datatype of the range is not the same as the type of the dimension it returns an error.
+func (sa *Subarray) AddRange(dimIdx uint32, r Range) error {
+	dt, isVar, err := datatypeOfDimensionFromIndex(sa.array, dimIdx)
+	if err != nil {
+		return err
+	}
+	if err := r.assertCompatibility(dt, isVar); err != nil {
+		return err
+	}
+
+	var ret C.int32_t
+	if isVar {
+		startSlice := []byte(r.start.(string))
+		endSlice := []byte(r.end.(string))
+		ret = C.tiledb_subarray_add_range_var(sa.context.tiledbContext, sa.subarray, C.uint32_t(dimIdx),
+			unsafe.Pointer(&startSlice[0]), C.uint64_t(len(startSlice)), unsafe.Pointer(&endSlice[0]), C.uint64_t(len(endSlice)))
+	} else {
+		sp := reflect.New(reflect.ValueOf(r.start).Type())
+		sp.Elem().Set(reflect.ValueOf(r.start))
+		ep := reflect.New(reflect.ValueOf(r.end).Type())
+		ep.Elem().Set(reflect.ValueOf(r.end))
+		ret = C.tiledb_subarray_add_range(sa.context.tiledbContext, sa.subarray, C.uint32_t(dimIdx),
+			sp.UnsafePointer(), ep.UnsafePointer(), nil)
+	}
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error adding subarray range: %s", sa.context.LastError())
+	}
+
+	return nil
+}
+
+// AddRangeByName adds a range along a subarray dimension. It checks the types of range and dimension and
+// if the datatype of the range is not the same as the type of the dimension it returns an error.
+func (sa *Subarray) AddRangeByName(dimName string, r Range) error {
+	dt, isVar, err := datatypeOfDimensionFromName(sa.array, dimName)
+	if err != nil {
+		return err
+	}
+	if err := r.assertCompatibility(dt, isVar); err != nil {
+		return err
+	}
+
+	cDimName := C.CString(dimName)
+	defer C.free(unsafe.Pointer(cDimName))
+
+	var ret C.int32_t
+	if isVar {
+		startSlice := []byte(r.start.(string))
+		endSlice := []byte(r.end.(string))
+		ret = C.tiledb_subarray_add_range_var_by_name(sa.context.tiledbContext, sa.subarray, cDimName,
+			unsafe.Pointer(&startSlice[0]), C.uint64_t(len(startSlice)), unsafe.Pointer(&endSlice[0]), C.uint64_t(len(endSlice)))
+	} else {
+		sp := reflect.New(reflect.ValueOf(r.start).Type())
+		sp.Elem().Set(reflect.ValueOf(r.start))
+		ep := reflect.New(reflect.ValueOf(r.end).Type())
+		ep.Elem().Set(reflect.ValueOf(r.end))
+		ret = C.tiledb_subarray_add_range_by_name(sa.context.tiledbContext, sa.subarray, cDimName,
+			sp.UnsafePointer(), ep.UnsafePointer(), nil)
+	}
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error adding subarray range: %s", sa.context.LastError())
+	}
+
+	return nil
+}
+
+// GetRangeNum retrieves the number of ranges of the query subarray along a given dimension index.
+func (sa *Subarray) GetRangeNum(dimIdx uint32) (uint64, error) {
+	var rangeNum uint64
+
+	ret := C.tiledb_subarray_get_range_num(sa.context.tiledbContext, sa.subarray, C.uint32_t(dimIdx), (*C.uint64_t)(unsafe.Pointer(&rangeNum)))
+	if ret != C.TILEDB_OK {
+		return 0, fmt.Errorf("Error retrieving subarray range num: %s", sa.context.LastError())
+	}
+
+	return rangeNum, nil
+}
+
+// GetRangeNum retrieves the number of ranges of the query subarray along a given dimension name.
+func (sa *Subarray) GetRangeNumFromName(dimName string) (uint64, error) {
+	var rangeNum uint64
+
+	cDimName := C.CString(dimName)
+	defer C.free(unsafe.Pointer(cDimName))
+
+	ret := C.tiledb_subarray_get_range_num_from_name(sa.context.tiledbContext, sa.subarray, cDimName, (*C.uint64_t)(unsafe.Pointer(&rangeNum)))
+	if ret != C.TILEDB_OK {
+		return 0, fmt.Errorf("Error retrieving subarray range num: %s", sa.context.LastError())
+	}
+
+	return rangeNum, nil
+}
+
+// GetRange retrieves a specific range of the subarray along a given dimension index.
+func (sa *Subarray) GetRange(dimIdx uint32, rangeNum uint64) (Range, error) {
+	dt, isVar, err := datatypeOfDimensionFromIndex(sa.array, dimIdx)
+	if err != nil {
+		return Range{}, err
+	}
+
+	var r Range
+	var ret C.int32_t
+	if isVar {
+		var startSize, endSize uint64
+		ret = C.tiledb_subarray_get_range_var_size(sa.context.tiledbContext, sa.subarray, C.uint32_t(dimIdx), C.uint64_t(rangeNum),
+			(*C.uint64_t)(unsafe.Pointer(&startSize)), (*C.uint64_t)(unsafe.Pointer(&endSize)))
+		if ret == C.TILEDB_OK {
+			var sp, ep unsafe.Pointer
+			var startData, endData []byte
+			if startSize > 0 {
+				startData = make([]byte, int(startSize))
+				sp = unsafe.Pointer(&startData[0])
+			}
+			if endSize > 0 {
+				endData = make([]byte, int(endSize))
+				ep = unsafe.Pointer(&endData[0])
+			}
+			ret = C.tiledb_subarray_get_range_var(sa.context.tiledbContext, sa.subarray,
+				C.uint32_t(dimIdx), C.uint64_t(rangeNum), sp, ep)
+			if ret == C.TILEDB_OK {
+				r.start = string(startData)
+				r.end = string(endData)
+			}
+		}
+	} else {
+		var startPointer, endPointer, stridePointer unsafe.Pointer
+		ret = C.tiledb_subarray_get_range(sa.context.tiledbContext, sa.subarray,
+			C.uint32_t(dimIdx), C.uint64_t(rangeNum), &startPointer, &endPointer, &stridePointer)
+		typ := dt.ReflectType()
+		if ret == C.TILEDB_OK {
+			r.start = reflect.NewAt(typ, startPointer).Elem().Interface()
+			r.end = reflect.NewAt(typ, endPointer).Elem().Interface()
+		}
+	}
+	if ret != C.TILEDB_OK {
+		return Range{}, fmt.Errorf("Error retrieving subarray range for dimension %d and range num %d: %s", dimIdx, rangeNum, sa.context.LastError())
+	}
+
+	return r, err
+}
+
+// GetRangeFromName retrieves a specific range of the subarray along a given dimension name.
+func (sa *Subarray) GetRangeFromName(dimName string, rangeNum uint64) (Range, error) {
+	dt, isVar, err := datatypeOfDimensionFromName(sa.array, dimName)
+	if err != nil {
+		return Range{}, err
+	}
+
+	cDimName := C.CString(dimName)
+	defer C.free(unsafe.Pointer(cDimName))
+
+	var r Range
+	var ret C.int32_t
+	if isVar {
+		var startSize, endSize uint64
+		ret = C.tiledb_subarray_get_range_var_size_from_name(sa.context.tiledbContext, sa.subarray, cDimName, C.uint64_t(rangeNum),
+			(*C.uint64_t)(unsafe.Pointer(&startSize)), (*C.uint64_t)(unsafe.Pointer(&endSize)))
+		if ret == C.TILEDB_OK {
+			var sp, ep unsafe.Pointer
+			var startData, endData []byte
+			if startSize > 0 {
+				startData = make([]byte, int(startSize))
+				sp = unsafe.Pointer(&startData[0])
+			}
+			if endSize > 0 {
+				endData = make([]byte, int(endSize))
+				ep = unsafe.Pointer(&endData[0])
+			}
+			ret = C.tiledb_subarray_get_range_var_from_name(sa.context.tiledbContext, sa.subarray,
+				cDimName, C.uint64_t(rangeNum), sp, ep)
+			if ret == C.TILEDB_OK {
+				r.start = string(startData)
+				r.end = string(endData)
+			}
+		}
+	} else {
+		var startPointer, endPointer, stridePointer unsafe.Pointer
+		ret = C.tiledb_subarray_get_range_from_name(sa.context.tiledbContext, sa.subarray,
+			cDimName, C.uint64_t(rangeNum), &startPointer, &endPointer, &stridePointer)
+		typ := dt.ReflectType()
+		if ret == C.TILEDB_OK {
+			r.start = reflect.NewAt(typ, startPointer).Elem().Interface()
+			r.end = reflect.NewAt(typ, endPointer).Elem().Interface()
+		}
+	}
+	if ret != C.TILEDB_OK {
+		return Range{}, fmt.Errorf("Error retrieving subarray range for dimension %s and range num %d: %s", dimName, rangeNum, sa.context.LastError())
+	}
+
+	return r, err
+}

--- a/subarray.go
+++ b/subarray.go
@@ -90,10 +90,12 @@ func (sa *Subarray) AddRange(dimIdx uint32, r Range) error {
 		runtime.KeepAlive(startSlice)
 		runtime.KeepAlive(endSlice)
 	} else {
+		startValue := addressableValue(r.start)
+		endValue := addressableValue(r.end)
 		ret = C.tiledb_subarray_add_range(sa.context.tiledbContext, sa.subarray, C.uint32_t(dimIdx),
-			addressableValue(r.start).UnsafePointer(), addressableValue(r.end).UnsafePointer(), nil)
-		runtime.KeepAlive(r.start)
-		runtime.KeepAlive(r.end)
+			startValue.UnsafePointer(), endValue.UnsafePointer(), nil)
+		runtime.KeepAlive(startValue)
+		runtime.KeepAlive(endValue)
 	}
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error adding subarray range: %s", sa.context.LastError())
@@ -125,10 +127,12 @@ func (sa *Subarray) AddRangeByName(dimName string, r Range) error {
 		runtime.KeepAlive(startSlice)
 		runtime.KeepAlive(endSlice)
 	} else {
+		startValue := addressableValue(r.start)
+		endValue := addressableValue(r.end)
 		ret = C.tiledb_subarray_add_range_by_name(sa.context.tiledbContext, sa.subarray, cDimName,
-			addressableValue(r.start).UnsafePointer(), addressableValue(r.end).UnsafePointer(), nil)
-		runtime.KeepAlive(r.start)
-		runtime.KeepAlive(r.end)
+			startValue.UnsafePointer(), endValue.UnsafePointer(), nil)
+		runtime.KeepAlive(startValue)
+		runtime.KeepAlive(endValue)
 	}
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error adding subarray range: %s", sa.context.LastError())

--- a/subarray_test.go
+++ b/subarray_test.go
@@ -1,0 +1,358 @@
+package tiledb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubarrayForDenseArray(t *testing.T) {
+	arrPath := createDenseIntegerGrid(t, 16)
+	arr := openArray(t, arrPath, TILEDB_READ)
+
+	t.Run("GetRange", func(t *testing.T) {
+		sa, err := arr.NewSubarray()
+		require.NoError(t, err)
+
+		rangeY, err := sa.GetRange(0, 0)
+		require.NoError(t, err)
+		checkRange[uint8](t, rangeY, 0, 15)
+
+		rangeX, err := sa.GetRange(1, 0)
+		require.NoError(t, err)
+		checkRange[uint8](t, rangeX, 0, 15)
+	})
+
+	t.Run("GetRangeFromName", func(t *testing.T) {
+		sa, err := arr.NewSubarray()
+		require.NoError(t, err)
+
+		rangeY, err := sa.GetRangeFromName("y", 0)
+		require.NoError(t, err)
+		checkRange[uint8](t, rangeY, 0, 15)
+
+		rangeX, err := sa.GetRangeFromName("x", 0)
+		require.NoError(t, err)
+		checkRange[uint8](t, rangeX, 0, 15)
+	})
+
+	t.Run("AddRange", func(t *testing.T) {
+		sa, err := arr.NewSubarray()
+		require.NoError(t, err)
+
+		require.NoError(t, sa.AddRange(0, MakeRange[uint8](0, 3)))
+		require.NoError(t, sa.AddRange(1, MakeRange[uint8](4, 7)))
+
+		rangeY, err := sa.GetRange(0, 0)
+		require.NoError(t, err)
+		checkRange[uint8](t, rangeY, 0, 3)
+
+		rangeX, err := sa.GetRange(1, 0)
+		require.NoError(t, err)
+		checkRange[uint8](t, rangeX, 4, 7)
+	})
+
+	t.Run("AddRangeChecks", func(t *testing.T) {
+		sa, err := arr.NewSubarray()
+		require.NoError(t, err)
+
+		err = sa.AddRange(0, MakeRange[uint32](0x04040404, 0x07070707))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "mismatch, range: uint32 dimension: uint8")
+	})
+
+	t.Run("AddRangeByName", func(t *testing.T) {
+		sa, err := arr.NewSubarray()
+		require.NoError(t, err)
+
+		require.NoError(t, sa.AddRangeByName("y", MakeRange[uint8](0, 3)))
+		require.NoError(t, sa.AddRangeByName("x", MakeRange[uint8](4, 7)))
+
+		rangeY, err := sa.GetRangeFromName("y", 0)
+		require.NoError(t, err)
+		checkRange[uint8](t, rangeY, 0, 3)
+
+		rangeX, err := sa.GetRangeFromName("x", 0)
+		require.NoError(t, err)
+		checkRange[uint8](t, rangeX, 4, 7)
+	})
+
+	t.Run("AddRangeByNameChecks", func(t *testing.T) {
+		sa, err := arr.NewSubarray()
+		require.NoError(t, err)
+
+		err = sa.AddRangeByName("y", MakeRange[uint32](0x04040404, 0x07070707))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "mismatch, range: uint32 dimension: uint8")
+	})
+
+	t.Run("AddRangeMixed", func(t *testing.T) {
+		sa, err := arr.NewSubarray()
+		require.NoError(t, err)
+
+		require.NoError(t, sa.AddRangeByName("y", MakeRange[uint8](0, 3)))
+		require.NoError(t, sa.AddRange(1, MakeRange[uint8](4, 7)))
+
+		rangeY, err := sa.GetRange(0, 0)
+		require.NoError(t, err)
+		checkRange[uint8](t, rangeY, 0, 3)
+
+		rangeX, err := sa.GetRangeFromName("x", 0)
+		require.NoError(t, err)
+		checkRange[uint8](t, rangeX, 4, 7)
+	})
+}
+
+func TestSubarrayForSparseArray(t *testing.T) {
+	arrPath := createSparse2dTable(t)
+	arr := openArray(t, arrPath, TILEDB_READ)
+
+	t.Run("GetRange", func(t *testing.T) {
+		sa, err := arr.NewSubarray()
+		require.NoError(t, err)
+
+		rangeS, err := sa.GetRange(0, 0)
+		require.NoError(t, err)
+		checkRange[string](t, rangeS, "", "")
+
+		rangeN, err := sa.GetRange(1, 0)
+		require.NoError(t, err)
+		checkRange[float32](t, rangeN, 0.0, 100.0)
+	})
+
+	t.Run("GetRangeFromName", func(t *testing.T) {
+		sa, err := arr.NewSubarray()
+		require.NoError(t, err)
+
+		rangeS, err := sa.GetRangeFromName("str", 0)
+		require.NoError(t, err)
+		checkRange[string](t, rangeS, "", "")
+
+		rangeN, err := sa.GetRangeFromName("num", 0)
+		require.NoError(t, err)
+		checkRange[float32](t, rangeN, 0.0, 100.0)
+	})
+
+	t.Run("AddRange", func(t *testing.T) {
+		sa, err := arr.NewSubarray()
+		require.NoError(t, err)
+
+		require.NoError(t, sa.AddRange(0, MakeRange("from", "to")))
+		require.NoError(t, sa.AddRange(1, MakeRange[float32](2.0, 4.0)))
+
+		rangeS, err := sa.GetRange(0, 0)
+		require.NoError(t, err)
+		checkRange[string](t, rangeS, "from", "to")
+
+		rangeN, err := sa.GetRange(1, 0)
+		require.NoError(t, err)
+		checkRange[float32](t, rangeN, 2.0, 4.0)
+	})
+
+	t.Run("AddRangeChecks", func(t *testing.T) {
+		sa, err := arr.NewSubarray()
+		require.NoError(t, err)
+
+		err = sa.AddRange(0, MakeRange[uint32](0x04040404, 0x07070707))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "dimension is of variable size but range is not")
+
+		err = sa.AddRange(1, MakeRange[uint32](0x04040404, 0x07070707))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "mismatch, range: uint32 dimension: float32")
+	})
+
+	t.Run("AddRangeByName", func(t *testing.T) {
+		sa, err := arr.NewSubarray()
+		require.NoError(t, err)
+
+		require.NoError(t, sa.AddRangeByName("str", MakeRange("from", "to")))
+		require.NoError(t, sa.AddRangeByName("num", MakeRange[float32](2.0, 4.0)))
+
+		rangeS, err := sa.GetRange(0, 0)
+		require.NoError(t, err)
+		checkRange[string](t, rangeS, "from", "to")
+
+		rangeN, err := sa.GetRange(1, 0)
+		require.NoError(t, err)
+		checkRange[float32](t, rangeN, 2.0, 4.0)
+	})
+
+	t.Run("AddRangeByNameChecks", func(t *testing.T) {
+		sa, err := arr.NewSubarray()
+		require.NoError(t, err)
+
+		err = sa.AddRangeByName("str", MakeRange[uint32](0x04040404, 0x07070707))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "dimension is of variable size but range is not")
+
+		err = sa.AddRangeByName("num", MakeRange[uint32](0x04040404, 0x07070707))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "mismatch, range: uint32 dimension: float32")
+	})
+}
+
+func TestQueryWithSubarrayOnFixedDimensions(t *testing.T) {
+	arrPath := createDenseIntegerGrid(t, 16)
+	cfg, err := NewConfig()
+	require.NoError(t, err)
+	tdbCtx, err := NewContext(cfg)
+	require.NoError(t, err)
+
+	// write the full grid
+	arr := openArray(t, arrPath, TILEDB_WRITE)
+	q, err := NewQuery(tdbCtx, arr)
+	require.NoError(t, err)
+	sa, err := arr.NewSubarray()
+	require.NoError(t, err)
+	err = sa.AddRange(0, MakeRange[uint8](0, 15))
+	require.NoError(t, err)
+	err = sa.AddRange(1, MakeRange[uint8](0, 15))
+	require.NoError(t, err)
+	err = q.SetSubarray(sa)
+	require.NoError(t, err)
+	data := make([]uint16, 16*16)
+	for i := range data {
+		data[i] = uint16(i)
+	}
+	_, err = q.SetDataBuffer("v", data)
+	require.NoError(t, err)
+	err = q.Submit()
+	require.NoError(t, err)
+
+	// read back the central inner 2x2 subgrid
+	arr = openArray(t, arrPath, TILEDB_READ)
+	q, err = NewQuery(tdbCtx, arr)
+	require.NoError(t, err)
+	sa, err = arr.NewSubarray()
+	require.NoError(t, err)
+	err = sa.AddRange(0, MakeRange[uint8](7, 8))
+	require.NoError(t, err)
+	err = sa.AddRange(1, MakeRange[uint8](7, 8))
+	require.NoError(t, err)
+	err = q.SetSubarray(sa)
+	require.NoError(t, err)
+	data = make([]uint16, 2*2)
+	_, err = q.SetDataBuffer("v", data)
+	require.NoError(t, err)
+	err = q.Submit()
+	require.NoError(t, err)
+	require.Equal(t, []uint16{119, 120, 135, 136}, data)
+}
+
+func TestQueryWithSubarrayOnVarDimensions(t *testing.T) {
+	arrPath := createSparse2dTable(t)
+	cfg, err := NewConfig()
+	require.NoError(t, err)
+	tdbCtx, err := NewContext(cfg)
+	require.NoError(t, err)
+
+	// write some values
+	arr := openArray(t, arrPath, TILEDB_WRITE)
+	q, err := NewQuery(tdbCtx, arr)
+	require.NoError(t, err)
+	_, err = q.SetDataBuffer("str", []byte("aaaabbbbccccdddd"))
+	require.NoError(t, err)
+	_, err = q.SetOffsetsBuffer("str", []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15})
+	require.NoError(t, err)
+	_, err = q.SetDataBuffer("num", []float32{1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0})
+	require.NoError(t, err)
+	_, err = q.SetDataBuffer("v", []uint16{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15})
+	require.NoError(t, err)
+	require.NoError(t, q.Submit())
+
+	// read back the central inner 2x2 subgrid
+	arr = openArray(t, arrPath, TILEDB_READ)
+	q, err = NewQuery(tdbCtx, arr)
+	require.NoError(t, err)
+	sa, err := arr.NewSubarray()
+	require.NoError(t, err)
+	err = sa.AddRangeByName("str", MakeRange("b", "c"))
+	require.NoError(t, err)
+	err = sa.AddRangeByName("num", MakeRange[float32](2.0, 3.0))
+	require.NoError(t, err)
+	err = q.SetSubarray(sa)
+	require.NoError(t, err)
+	data := make([]uint16, 2*2)
+	_, err = q.SetDataBuffer("v", data)
+	require.NoError(t, err)
+	err = q.Submit()
+	require.NoError(t, err)
+	require.Equal(t, []uint16{5.0, 6.0, 9.0, 10.0}, data)
+}
+
+func createDenseIntegerGrid(t *testing.T, n uint8) string {
+	tileSize := uint8(4)
+	if n < 4 {
+		tileSize = n
+	}
+	arrPath := t.TempDir()
+
+	cfg, err := NewConfig()
+	require.NoError(t, err)
+	tdbCtx, err := NewContext(cfg)
+	require.NoError(t, err)
+	schema, err := NewArraySchema(tdbCtx, TILEDB_DENSE)
+	require.NoError(t, err)
+	domain, err := NewDomain(tdbCtx)
+	require.NoError(t, err)
+	yDim, err := NewDimension(tdbCtx, "y", TILEDB_UINT8, []uint8{0, n - 1}, tileSize)
+	require.NoError(t, err)
+	xDim, err := NewDimension(tdbCtx, "x", TILEDB_UINT8, []uint8{0, n - 1}, tileSize)
+	require.NoError(t, err)
+	require.NoError(t, domain.AddDimensions(yDim, xDim))
+	require.NoError(t, schema.SetDomain(domain))
+	vAttr, err := NewAttribute(tdbCtx, "v", TILEDB_UINT16)
+	require.NoError(t, err)
+	require.NoError(t, schema.AddAttributes(vAttr))
+	array, err := NewArray(tdbCtx, arrPath)
+	require.NoError(t, err)
+	require.NoError(t, array.Create(schema))
+	return arrPath
+}
+
+func createSparse2dTable(t *testing.T) string {
+	arrPath := t.TempDir()
+	cfg, err := NewConfig()
+	require.NoError(t, err)
+	tdbCtx, err := NewContext(cfg)
+	require.NoError(t, err)
+	schema, err := NewArraySchema(tdbCtx, TILEDB_SPARSE)
+	require.NoError(t, err)
+	domain, err := NewDomain(tdbCtx)
+	require.NoError(t, err)
+	sDim, err := NewStringDimension(tdbCtx, "str")
+	require.NoError(t, err)
+	nDim, err := NewDimension(tdbCtx, "num", TILEDB_FLOAT32, []float32{0.0, 100.0}, float32(4.0))
+	require.NoError(t, err)
+	require.NoError(t, domain.AddDimensions(sDim, nDim))
+	require.NoError(t, schema.SetDomain(domain))
+	vAttr, err := NewAttribute(tdbCtx, "v", TILEDB_UINT16)
+	require.NoError(t, err)
+	require.NoError(t, schema.AddAttributes(vAttr))
+	array, err := NewArray(tdbCtx, arrPath)
+	require.NoError(t, err)
+	require.NoError(t, array.Create(schema))
+	return arrPath
+}
+
+func openArray(t *testing.T, arrPath string, qt QueryType) *Array {
+	cfg, err := NewConfig()
+	require.NoError(t, err)
+	tdbCtx, err := NewContext(cfg)
+	require.NoError(t, err)
+	arr, err := NewArray(tdbCtx, arrPath)
+	require.NoError(t, err)
+	require.NoError(t, arr.Open(qt))
+	t.Cleanup(func() { arr.Close() })
+	return arr
+}
+
+func checkRange[T TileDBDimensionType](t *testing.T, r Range, start, end T) {
+	bounds, err := ExtractRange[T](r)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(bounds))
+	require.EqualValues(t, start, bounds[0])
+	require.EqualValues(t, end, bounds[1])
+	require.EqualValues(t, *new(T), bounds[2])
+}

--- a/subarray_test.go
+++ b/subarray_test.go
@@ -349,7 +349,7 @@ func openArray(t *testing.T, arrPath string, qt QueryType) *Array {
 	return arr
 }
 
-func checkRange[T TileDBDimensionType](t *testing.T, r Range, start, end T) {
+func checkRange[T DimensionType](t *testing.T, r Range, start, end T) {
 	bounds, err := ExtractRange[T](r)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(bounds))

--- a/subarray_test.go
+++ b/subarray_test.go
@@ -3,6 +3,7 @@ package tiledb
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,7 +59,7 @@ func TestSubarrayForDenseArray(t *testing.T) {
 
 		err = sa.AddRange(0, MakeRange[uint32](0x04040404, 0x07070707))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "mismatch, range: uint32 dimension: uint8")
+		assert.Contains(t, err.Error(), "mismatch, range: uint32 dimension: uint8")
 	})
 
 	t.Run("AddRangeByName", func(t *testing.T) {
@@ -83,7 +84,7 @@ func TestSubarrayForDenseArray(t *testing.T) {
 
 		err = sa.AddRangeByName("y", MakeRange[uint32](0x04040404, 0x07070707))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "mismatch, range: uint32 dimension: uint8")
+		assert.Contains(t, err.Error(), "mismatch, range: uint32 dimension: uint8")
 	})
 
 	t.Run("AddRangeMixed", func(t *testing.T) {
@@ -155,11 +156,11 @@ func TestSubarrayForSparseArray(t *testing.T) {
 
 		err = sa.AddRange(0, MakeRange[uint32](0x04040404, 0x07070707))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "dimension is of variable size but range is not")
+		assert.Contains(t, err.Error(), "dimension is of variable size but range is not")
 
 		err = sa.AddRange(1, MakeRange[uint32](0x04040404, 0x07070707))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "mismatch, range: uint32 dimension: float32")
+		assert.Contains(t, err.Error(), "mismatch, range: uint32 dimension: float32")
 	})
 
 	t.Run("AddRangeByName", func(t *testing.T) {
@@ -184,11 +185,11 @@ func TestSubarrayForSparseArray(t *testing.T) {
 
 		err = sa.AddRangeByName("str", MakeRange[uint32](0x04040404, 0x07070707))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "dimension is of variable size but range is not")
+		assert.Contains(t, err.Error(), "dimension is of variable size but range is not")
 
 		err = sa.AddRangeByName("num", MakeRange[uint32](0x04040404, 0x07070707))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "mismatch, range: uint32 dimension: float32")
+		assert.Contains(t, err.Error(), "mismatch, range: uint32 dimension: float32")
 	})
 }
 
@@ -352,7 +353,7 @@ func checkRange[T TileDBDimensionType](t *testing.T, r Range, start, end T) {
 	bounds, err := ExtractRange[T](r)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(bounds))
-	require.EqualValues(t, start, bounds[0])
-	require.EqualValues(t, end, bounds[1])
-	require.EqualValues(t, *new(T), bounds[2])
+	assert.EqualValues(t, start, bounds[0])
+	assert.EqualValues(t, end, bounds[1])
+	assert.EqualValues(t, *new(T), bounds[2])
 }


### PR DESCRIPTION
This adds support for the TileDB core Subarray API for queries, see https://tiledb-inc-tiledb.readthedocs-hosted.com/en/stable/c-api.html#subarray

The API uses go generics to avoid casts and passing type unsafe `interface{}` values. Check the tests for usage examples.
