### PR TITLE
Deduplicate cgo flags

### DIFF
--- a/array.go
+++ b/array.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/array.go
+++ b/array.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/array_schema.go
+++ b/array_schema.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <tiledb/tiledb_serialization.h>
 #include <stdlib.h>

--- a/array_schema.go
+++ b/array_schema.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <tiledb/tiledb_serialization.h>
 #include <stdlib.h>

--- a/array_schema_evolution.go
+++ b/array_schema_evolution.go
@@ -7,8 +7,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb_experimental.h>
 #include <stdlib.h>
 */

--- a/array_schema_evolution.go
+++ b/array_schema_evolution.go
@@ -7,8 +7,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb_experimental.h>
 #include <stdlib.h>
 */

--- a/attribute.go
+++ b/attribute.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/attribute.go
+++ b/attribute.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/buffer.go
+++ b/buffer.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/buffer.go
+++ b/buffer.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/buffer_list.go
+++ b/buffer_list.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/buffer_list.go
+++ b/buffer_list.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/cgo_flags.go
+++ b/cgo_flags.go
@@ -1,0 +1,11 @@
+package tiledb
+
+// cgo concatenates all flags within a package, so just define them once here
+// (https://pkg.go.dev/cmd/cgo).
+
+
+/*
+#cgo LDFLAGS: -ltiledb
+#cgo linux LDFLAGS: -ldl
+*/
+import "C"

--- a/config.go
+++ b/config.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/config.go
+++ b/config.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/config_iter.go
+++ b/config_iter.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/config_iter.go
+++ b/config_iter.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/context.go
+++ b/context.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/dimension.go
+++ b/dimension.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/dimension.go
+++ b/dimension.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/dimension_label.go
+++ b/dimension_label.go
@@ -7,8 +7,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb_experimental.h>
 #include <tiledb/tiledb_serialization.h>
 #include <stdlib.h>

--- a/dimension_label.go
+++ b/dimension_label.go
@@ -7,8 +7,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb_experimental.h>
 #include <tiledb/tiledb_serialization.h>
 #include <stdlib.h>

--- a/dimension_label_unimplemented.go
+++ b/dimension_label_unimplemented.go
@@ -5,9 +5,7 @@
 package tiledb
 
 /*
-	#cgo LDFLAGS: -ltiledb
-	#cgo linux LDFLAGS: -ldl
-   	#include <stdlib.h>
+#include <stdlib.h>
 */
 import "C"
 import "fmt"

--- a/domain.go
+++ b/domain.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/domain.go
+++ b/domain.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/enums.go
+++ b/enums.go
@@ -1,9 +1,6 @@
 package tiledb
 
 /*
-#cgo CFLAGS: -I/usr/local/include
-
-
 #include <tiledb/tiledb.h>
 #include <tiledb/tiledb_enum.h>
 #include <tiledb/tiledb_serialization.h>

--- a/enums.go
+++ b/enums.go
@@ -2,8 +2,8 @@ package tiledb
 
 /*
 #cgo CFLAGS: -I/usr/local/include
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <tiledb/tiledb_enum.h>
 #include <tiledb/tiledb_serialization.h>

--- a/filestore.go
+++ b/filestore.go
@@ -7,11 +7,9 @@
 package tiledb
 
 /*
-   	
-   	
-	#include <tiledb/tiledb_experimental.h>
-	#include <tiledb/tiledb_serialization.h>
-	#include <stdlib.h>
+#include <tiledb/tiledb_experimental.h>
+#include <tiledb/tiledb_serialization.h>
+#include <stdlib.h>
 */
 import "C"
 import (

--- a/filestore.go
+++ b/filestore.go
@@ -7,8 +7,8 @@
 package tiledb
 
 /*
-   	#cgo LDFLAGS: -ltiledb
-   	#cgo linux LDFLAGS: -ldl
+   	
+   	
 	#include <tiledb/tiledb_experimental.h>
 	#include <tiledb/tiledb_serialization.h>
 	#include <stdlib.h>

--- a/filter.go
+++ b/filter.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/filter.go
+++ b/filter.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/filter_list.go
+++ b/filter_list.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/filter_list.go
+++ b/filter_list.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/fragment_info.go
+++ b/fragment_info.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/fragment_info.go
+++ b/fragment_info.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/group.go
+++ b/group.go
@@ -14,8 +14,8 @@ import (
 )
 
 /*
-   	#cgo LDFLAGS: -ltiledb
-   	#cgo linux LDFLAGS: -ldl
+   	
+   	
 	#include <tiledb/tiledb_experimental.h>
 	#include <tiledb/tiledb_serialization.h>
 	#include <stdlib.h>

--- a/object.go
+++ b/object.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 #include "clibrary.h"

--- a/object.go
+++ b/object.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 #include "clibrary.h"

--- a/query.go
+++ b/query.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/query.go
+++ b/query.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/query_condition.go
+++ b/query_condition.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/query_condition.go
+++ b/query_condition.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/query_experimental.go
+++ b/query_experimental.go
@@ -7,8 +7,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <tiledb/tiledb_experimental.h>
 #include <stdlib.h>

--- a/query_experimental.go
+++ b/query_experimental.go
@@ -7,8 +7,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <tiledb/tiledb_experimental.h>
 #include <stdlib.h>

--- a/serialize.go
+++ b/serialize.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <tiledb/tiledb_serialization.h>
 #include <stdio.h>

--- a/serialize.go
+++ b/serialize.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <tiledb/tiledb_serialization.h>
 #include <stdio.h>

--- a/serialize_array_schema_evolution.go
+++ b/serialize_array_schema_evolution.go
@@ -7,8 +7,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb_experimental.h>
 #include <tiledb/tiledb_serialization.h>
 #include <stdlib.h>

--- a/serialize_array_schema_evolution.go
+++ b/serialize_array_schema_evolution.go
@@ -7,8 +7,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb_experimental.h>
 #include <tiledb/tiledb_serialization.h>
 #include <stdlib.h>

--- a/stats.go
+++ b/stats.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/stats.go
+++ b/stats.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/subarray.go
+++ b/subarray.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/subarray.go
+++ b/subarray.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 */

--- a/version.go
+++ b/version.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 */
 import "C"

--- a/version.go
+++ b/version.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 */
 import "C"

--- a/vfs.go
+++ b/vfs.go
@@ -1,8 +1,8 @@
 package tiledb
 
 /*
-#cgo LDFLAGS: -ltiledb
-#cgo linux LDFLAGS: -ldl
+
+
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 #include "clibrary.h"

--- a/vfs.go
+++ b/vfs.go
@@ -1,8 +1,6 @@
 package tiledb
 
 /*
-
-
 #include <tiledb/tiledb.h>
 #include <stdlib.h>
 #include "clibrary.h"


### PR DESCRIPTION
1. cgo concatenates all flags in a package:
> All the cgo CPPFLAGS and CFLAGS directives in a package are concatenated and used to compile C files in that package. (https://pkg.go.dev/cmd/cgo)

  So we can put them in a standalone file and remove duplication, which
  causes linker warnings on some platforms.

2. Note that `cgo_flags.go` must:
   - start with `package tiledb`
   - the cgo comments must be immediately followed by `import "C"`
     (or else they are ignored)