### PR TITLE
Sa/release 0.25.0

### DIFF
--- a/.github/scripts/install_tiledb_linux.sh
+++ b/.github/scripts/install_tiledb_linux.sh
@@ -1,4 +1,4 @@
 set -e -x
-curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.18.4/tiledb-linux-x86_64-2.18.4-3531ce7.tar.gz \
+curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-linux-x86_64-2.19.1-29ceb3e7.tar.gz \
 && sudo tar -C /usr/local -xf tiledb.tar.gz
 sudo ldconfig /usr/local/lib

--- a/.github/scripts/install_tiledb_linux_debug.sh
+++ b/.github/scripts/install_tiledb_linux_debug.sh
@@ -1,5 +1,5 @@
 set -e -x
-git clone https://github.com/TileDB-Inc/TileDB.git -b 2.18.4
+git clone https://github.com/TileDB-Inc/TileDB.git -b 2.19.1
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_WERROR=OFF -DTILEDB_VCPKG=ON -DSANITIZER=leak -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr/local ..

--- a/.github/scripts/install_tiledb_macos.sh
+++ b/.github/scripts/install_tiledb_macos.sh
@@ -1,3 +1,3 @@
 set -e -x
-curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.18.4/tiledb-macos-x86_64-2.18.4-3531ce7.tar.gz \
+curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-macos-x86_64-2.19.1-29ceb3e7.tar.gz \
 && sudo tar -C /usr/local -xf tiledb.tar.gz

--- a/.github/scripts/install_tiledb_source_linux.sh
+++ b/.github/scripts/install_tiledb_source_linux.sh
@@ -1,5 +1,5 @@
 set -e -x
-git clone https://github.com/TileDB-Inc/TileDB.git -b 2.18.4
+git clone https://github.com/TileDB-Inc/TileDB.git -b 2.19.1
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_WERROR=OFF -DTILEDB_VCPKG=ON -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..

--- a/.github/scripts/install_tiledb_source_macos.sh
+++ b/.github/scripts/install_tiledb_source_macos.sh
@@ -1,5 +1,5 @@
 set -e -x
-git clone https://github.com/TileDB-Inc/TileDB.git -b 2.18.4
+git clone https://github.com/TileDB-Inc/TileDB.git -b 2.19.1
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_WERROR=OFF -DTILEDB_VCPKG=ON -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ as such the below table reference which versions are compatible.
 | 0.22.0            | 2.16.X         |
 | 0.23.0            | 2.17.X         |
 | 0.24.0            | 2.18.X         |
+| 0.25.0            | 2.19.X         |
 
 
 ## Missing Functionality
@@ -88,6 +89,11 @@ The following TileDB core library features are missing from the Go API:
 
 - TileDB generic object management
 - TileDB group creation
+
+### 0.25.0
+
+Release does not include bindings for consolidation plan `tiledb_consolidation_plan_create_with_mbr` and
+query plan `tiledb_query_get_plan`. These will be included in 0.26.0
 
 ## Deprecated Functionality
 


### PR DESCRIPTION
This is a release to support TileDB 2.19.0. Core contains new experimental functionality like consolidation and query plans but there are no bindings here. These will be included in the next release with TileDB 2.20 support.
