### PR TITLE
Upgrade TileDB to 2.20.0-rc2

### DIFF
--- a/.github/scripts/install_tiledb_linux.sh
+++ b/.github/scripts/install_tiledb_linux.sh
@@ -1,4 +1,4 @@
 set -e -x
-curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-linux-x86_64-2.19.1-29ceb3e7.tar.gz \
+curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.20.0-rc2/tiledb-linux-x86_64-2.20.0-rc2-40552aa.tar.gz \
 && sudo tar -C /usr/local -xf tiledb.tar.gz
 sudo ldconfig /usr/local/lib

--- a/.github/scripts/install_tiledb_linux_debug.sh
+++ b/.github/scripts/install_tiledb_linux_debug.sh
@@ -1,5 +1,5 @@
 set -e -x
-git clone https://github.com/TileDB-Inc/TileDB.git -b 2.19.1
+git clone https://github.com/TileDB-Inc/TileDB.git -b 2.20.0-rc2
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_WERROR=OFF -DTILEDB_VCPKG=ON -DSANITIZER=leak -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr/local ..

--- a/.github/scripts/install_tiledb_macos.sh
+++ b/.github/scripts/install_tiledb_macos.sh
@@ -1,3 +1,3 @@
 set -e -x
-curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.19.1/tiledb-macos-x86_64-2.19.1-29ceb3e7.tar.gz \
+curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.20.0-rc2/tiledb-macos-x86_64-2.20.0-rc2-40552aa.tar.gz \
 && sudo tar -C /usr/local -xf tiledb.tar.gz

--- a/.github/scripts/install_tiledb_source_linux.sh
+++ b/.github/scripts/install_tiledb_source_linux.sh
@@ -1,5 +1,5 @@
 set -e -x
-git clone https://github.com/TileDB-Inc/TileDB.git -b 2.19.1
+git clone https://github.com/TileDB-Inc/TileDB.git -b 2.20.0-rc2
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_WERROR=OFF -DTILEDB_VCPKG=ON -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..

--- a/.github/scripts/install_tiledb_source_macos.sh
+++ b/.github/scripts/install_tiledb_source_macos.sh
@@ -1,5 +1,5 @@
 set -e -x
-git clone https://github.com/TileDB-Inc/TileDB.git -b 2.19.1
+git clone https://github.com/TileDB-Inc/TileDB.git -b 2.20.0-rc2
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_WERROR=OFF -DTILEDB_VCPKG=ON -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..


### PR DESCRIPTION
This setups github actions to use TileDB 2.20.0-rc1 and effectively upgrades the master to merge PRs for 2.20
