### PR TITLE
Add tar flag to fix corrupt macOS workflow.

### DIFF
--- a/.github/scripts/install_tiledb_macos.sh
+++ b/.github/scripts/install_tiledb_macos.sh
@@ -1,4 +1,4 @@
 set -e -x
 source "$(dirname $0)/tiledb-version.sh"
 curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/${TILEDB_VERSION}/tiledb-macos-x86_64-${TILEDB_VERSION}-${COMMIT_ID}.tar.gz \
-&& sudo tar -C /usr/local -xf tiledb.tar.gz
+&& sudo tar -C /usr/local -xSf tiledb.tar.gz


### PR DESCRIPTION
Our macOS job's tar often fails with the error message "Can't restore
time".  The following issue's detective work revealed that the problem
is caused by Apple's tar choking on extracting sparse files:
https://github.com/actions/runner-images/issues/2619

This commit adds the `-S` flag to tar, which fixes the problem.