### PR TITLE
Update to TileDB v2.22.0.

### DIFF
--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -9,9 +9,9 @@ on:
 
 env:
   # The version of TileDB to test against.
-  CORE_VERSION: "2.21.0"
+  CORE_VERSION: "2.22.0"
   # The abbreviated git commit hash to use.
-  CORE_HASH: "0ea9c13"
+  CORE_HASH: "52e981e"
 
 jobs:
   golangci:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ as such the below table reference which versions are compatible.
 | 0.25.0            | 2.19.X         |
 | 0.26.0            | 2.20.X         |
 | 0.27.0            | 2.21.X         |
+| 0.28.0            | 2.22.X         |
 
 
 ## Missing Functionality


### PR DESCRIPTION
Go through the release ritual of updating to the latest TileDB release.