### PR TITLE
Migrate away from deprecated TileDB C APIs.

### DIFF
--- a/group_experimental.go
+++ b/group_experimental.go
@@ -274,42 +274,47 @@ func (g *Group) GetMemberCount() (uint64, error) {
 }
 
 func (g *Group) GetMemberFromIndex(index uint64) (string, string, ObjectTypeEnum, error) {
-	var curi *C.char
-	defer C.free(unsafe.Pointer(curi))
+	var curi *C.tiledb_string_t
 
-	var cname *C.char
-	defer C.free(unsafe.Pointer(cname))
+	var cname *C.tiledb_string_t
 
 	var objectTypeEnum C.tiledb_object_t
-	ret := C.tiledb_group_get_member_by_index(g.context.tiledbContext, g.group, C.uint64_t(index), &curi, &objectTypeEnum, &cname)
+	ret := C.tiledb_group_get_member_by_index_v2(g.context.tiledbContext, g.group, C.uint64_t(index), &curi, &objectTypeEnum, &cname)
 	if ret != C.TILEDB_OK {
 		return "", "", TILEDB_INVALID, fmt.Errorf("Error getting member by index for group: %s", g.context.LastError())
 	}
+	defer C.tiledb_string_free(&curi)
+	defer C.tiledb_string_free(&cname)
 
-	uri := C.GoString(curi)
-	if uri == "" {
-		return "", "", TILEDB_INVALID, fmt.Errorf("Error getting URI for member %d: uri is empty", index)
+	uri, err := stringHandleToString(curi)
+	if err != nil {
+		return "", "", TILEDB_INVALID, err
 	}
 
-	return uri, C.GoString(cname), ObjectTypeEnum(objectTypeEnum), nil
+	name, err := stringHandleToString(cname)
+	if err != nil {
+		return "", "", TILEDB_INVALID, err
+	}
+
+	return uri, name, ObjectTypeEnum(objectTypeEnum), nil
 }
 
 func (g *Group) GetMemberByName(name string) (string, string, ObjectTypeEnum, error) {
-	var curi *C.char
-	defer C.free(unsafe.Pointer(curi))
+	var curi *C.tiledb_string_t
 
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 
 	var objectTypeEnum C.tiledb_object_t
-	ret := C.tiledb_group_get_member_by_name(g.context.tiledbContext, g.group, cname, &curi, &objectTypeEnum)
+	ret := C.tiledb_group_get_member_by_name_v2(g.context.tiledbContext, g.group, cname, &curi, &objectTypeEnum)
 	if ret != C.TILEDB_OK {
 		return "", "", TILEDB_INVALID, fmt.Errorf("Error getting member by index for group: %s", g.context.LastError())
 	}
+	defer C.tiledb_string_free(&curi)
 
-	uri := C.GoString(curi)
-	if uri == "" {
-		return "", "", TILEDB_INVALID, fmt.Errorf("Error getting URI for member %s: uri is empty", name)
+	uri, err := stringHandleToString(curi)
+	if err != nil {
+		return "", "", TILEDB_INVALID, err
 	}
 
 	if name == "" {

--- a/query.go
+++ b/query.go
@@ -3170,6 +3170,8 @@ polled:
 	  }
 	  // Do something when query is finished
 	}(query)
+
+Deprecated: Call Submit on a goroutine
 */
 func (q *Query) SubmitAsync() error {
 	ret := C.tiledb_query_submit_async(q.context.tiledbContext, q.tiledbQuery, nil, nil)

--- a/string.go
+++ b/string.go
@@ -14,7 +14,7 @@ import (
 // Converts a TileDB string handle to a Go string
 func stringHandleToString(str *C.tiledb_string_t) (string, error) {
 	var chars *C.char
-	var length C.uint64_t
+	var length C.size_t
 	ret := C.tiledb_string_view(str, &chars, &length)
 	if ret != C.TILEDB_OK {
 		return "", errors.New("could not get view of string handle")

--- a/string.go
+++ b/string.go
@@ -1,0 +1,26 @@
+package tiledb
+
+/*
+#include <tiledb/tiledb.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"errors"
+	"math"
+)
+
+// Converts a TileDB string handle to a Go string
+func stringHandleToString(str *C.tiledb_string_t) (string, error) {
+	var chars *C.char
+	var length C.uint64_t
+	ret := C.tiledb_string_view(str, &chars, &length)
+	if ret != C.TILEDB_OK {
+		return "", errors.New("could not get view of string handle")
+	}
+	if length > math.MaxInt32 {
+		return "", errors.New("string returned by TileDB is > 2GB")
+	}
+	return C.GoStringN(chars, C.int(length)), nil
+}


### PR DESCRIPTION
[SC-45987](https://app.shortcut.com/tiledb-inc/story/45987/tiledb-go-migrate-away-from-deprecated-tiledb-c-apis)

This PR updates TileDB-Go's usage of deprecated C APIs. The first commit migrates the `Group.GetMember***` functions to use `tiledb_group_get_member_by_(index|name)_v2`, while also adding code to work with TileDB string handles. The second commit deprecates `Query.SubmitAsync`, whose underlying C API has been deprecated since 2.15.

After that, the only deprecated C APIs used by TileDB-Go are inside deprecated Go APIs.