### PR TITLE
Update to TileDB 0.23.0.

### DIFF
--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -9,9 +9,9 @@ on:
 
 env:
   # The version of TileDB to test against.
-  CORE_VERSION: "2.22.0"
+  CORE_VERSION: "2.23.0"
   # The abbreviated git commit hash to use.
-  CORE_HASH: "52e981e"
+  CORE_HASH: "152093b"
 
 jobs:
   golangci:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ as such the below table reference which versions are compatible.
 | 0.26.0            | 2.20.X         |
 | 0.27.0            | 2.21.X         |
 | 0.28.0            | 2.22.X         |
+| 0.29.0            | 2.23.X         |
 
 
 ## Missing Functionality


### PR DESCRIPTION
...which was released on May 8, 2024:
https://github.com/TileDB-Inc/TileDB/releases/tag/2.23.0