### PR TITLE
Add warning about temporary incompatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This package provides [TileDB](https://github.com/TileDB-Inc/TileDB) golang bind
 designed to be idomatic Go. `runtime.SetFinalizer` is used to ensure proper
 free'ing of C heap allocated structures.
 
+> [!CAUTION]
+> As of May 14, 2024, TileDB-Go is temporarily incompatible with [TileDB](https://github.com/TileDB-Inc/TileDB)'s dev branch.
+> TileDB-Go continues to work with TileDB's v2.23.X as only the dev branch is affected.
+
 ## Quick Links
 
 - GoDoc API documentation: https://pkg.go.dev/github.com/TileDB-Inc/TileDB-Go


### PR DESCRIPTION
TileDB's dev branch [contains a PR](https://github.com/TileDB-Inc/TileDB/pull/4961) that breaks compatibility with TileDB-Go. The problem will be fixed in the next release but in the meanwhile we should warn users to not use TileDB-Go with TileDB's dev branch.