### PR TITLE
Prepare for TileDB's superbuild removal.

### DIFF
--- a/.github/scripts/install_tiledb_linux_debug.sh
+++ b/.github/scripts/install_tiledb_linux_debug.sh
@@ -3,6 +3,5 @@ git clone https://github.com/TileDB-Inc/TileDB.git -b ${CORE_VERSION}
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_WERROR=OFF -DTILEDB_VCPKG=ON -DSANITIZER=leak -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr/local ..
-make -j4
-sudo make -C tiledb install
+sudo make -j4 install-tiledb
 sudo ldconfig /usr/local/lib

--- a/.github/scripts/install_tiledb_linux_debug.sh
+++ b/.github/scripts/install_tiledb_linux_debug.sh
@@ -3,5 +3,5 @@ git clone https://github.com/TileDB-Inc/TileDB.git -b ${CORE_VERSION}
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_WERROR=OFF -DTILEDB_VCPKG=ON -DSANITIZER=leak -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr/local ..
-sudo make -j4 install-tiledb
+sudo make -j4 tiledb install-tiledb
 sudo ldconfig /usr/local/lib

--- a/.github/scripts/install_tiledb_source_linux.sh
+++ b/.github/scripts/install_tiledb_source_linux.sh
@@ -3,6 +3,5 @@ git clone https://github.com/TileDB-Inc/TileDB.git -b ${CORE_VERSION}
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_WERROR=OFF -DTILEDB_VCPKG=ON -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
-make -j$(nproc)
-sudo make -C tiledb install
+sudo make -j$(nproc) install-tiledb
 sudo ldconfig

--- a/.github/scripts/install_tiledb_source_linux.sh
+++ b/.github/scripts/install_tiledb_source_linux.sh
@@ -3,5 +3,5 @@ git clone https://github.com/TileDB-Inc/TileDB.git -b ${CORE_VERSION}
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_WERROR=OFF -DTILEDB_VCPKG=ON -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
-sudo make -j$(nproc) install-tiledb
+sudo make -j$(nproc) tiledb install-tiledb
 sudo ldconfig

--- a/.github/scripts/install_tiledb_source_macos.sh
+++ b/.github/scripts/install_tiledb_source_macos.sh
@@ -3,5 +3,4 @@ git clone https://github.com/TileDB-Inc/TileDB.git -b ${CORE_VERSION}
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_WERROR=OFF -DTILEDB_VCPKG=ON -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
-make -j$(sysctl -n hw.ncpu)
-sudo make -C tiledb install
+sudo make -j$(sysctl -n hw.ncpu) install-tiledb

--- a/.github/scripts/install_tiledb_source_macos.sh
+++ b/.github/scripts/install_tiledb_source_macos.sh
@@ -3,4 +3,4 @@ git clone https://github.com/TileDB-Inc/TileDB.git -b ${CORE_VERSION}
 cd TileDB
 mkdir build && cd build
 cmake -DTILEDB_WERROR=OFF -DTILEDB_VCPKG=ON -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
-sudo make -j$(sysctl -n hw.ncpu) install-tiledb
+sudo make -j$(sysctl -n hw.ncpu) tiledb install-tiledb


### PR DESCRIPTION
Preparation for SC-36913

This PR updates the shell scripts to use the `install-tiledb` target to build and install TileDB, instead of invoking `make` twice – once in the build directory, and once in the `tiledb` subdirectory.

TileDB is going to remove the superbuild and become a single CMake project without the `tiledb` subdirectory, and with this PR the Go API will be prepared for this.