### PR TITLE
Add automatic reviewer tagging via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Use for automatic reviewer tagging. (anyone with merge rights is encouraged
 # to review and approve PRs they understand)
-*   @NullHypothesis @ypatia @shaunrd0 @snagles
+*   @NullHypothesis @ypatia @shaunrd0 @snagles @thetorpedodog

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Use for automatic reviewer tagging. (anyone with merge rights is encouraged
+# to review and approve PRs they understand)
+*   @NullHypothesis @ypatia @shaunrd0 @snagles


### PR DESCRIPTION
Add CODEOWNERS for automatic reviewer tagging. (anyone with merge rights is encouraged
to review and approve PRs they understand)