### PR TITLE
Shorten datatype conversions in enums.go with generics.

### DIFF
--- a/common.go
+++ b/common.go
@@ -1,7 +1,6 @@
 package tiledb
 
 import (
-	"reflect"
 	"unsafe"
 )
 
@@ -17,6 +16,5 @@ type scalarType interface {
 
 // slicePtr gives you an unsafe pointer to the start of a slice.
 func slicePtr[T any](slc []T) unsafe.Pointer {
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&slc))
-	return unsafe.Pointer(hdr.Data)
+	return unsafe.Pointer(unsafe.SliceData(slc))
 }

--- a/memory.go
+++ b/memory.go
@@ -55,3 +55,12 @@ func (bb byteBuffer) subSlice(sliceStart unsafe.Pointer, sliceBytes uintptr) []b
 	startIdx := uintptr(sliceStart) - uintptr(bb.start())
 	return bb[startIdx:sliceBytes]
 }
+
+// unsafeSlice creates a slice pointing at the given memory.
+func unsafeSlice[T any](ptr unsafe.Pointer, length uint) []T {
+	if ptr == nil {
+		return nil
+	}
+	typedPtr := (*T)(ptr)
+	return unsafe.Slice(typedPtr, length)
+}


### PR DESCRIPTION
Yet another step on the road of consolidating things and making memory handling more straightforward. This stuff eventually helps lead to removing the deprecation warnings that show up on every compile, I promise.