### PR TITLE
Add binding for tiledb_array_consolidate_fragments.

### DIFF
--- a/array.go
+++ b/array.go
@@ -1098,12 +1098,8 @@ func DeleteFragmentsList(tdbCtx *Context, uri string, fragmentURIs []string) err
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 
-	var list []*C.char
-	for _, furi := range fragmentURIs {
-		cfuri := C.CString(furi)
-		defer C.free(unsafe.Pointer(cfuri))
-		list = append(list, cfuri)
-	}
+	list, freeMemory := cStringArray(fragmentURIs)
+	defer freeMemory()
 
 	ret := C.tiledb_array_delete_fragments_list(tdbCtx.tiledbContext, curi, (**C.char)(unsafe.Pointer(&list[0])), C.size_t(len(list)))
 	if ret != C.TILEDB_OK {

--- a/array_experimental.go
+++ b/array_experimental.go
@@ -113,7 +113,7 @@ func (a *Array) ConsolidateFragments(config *Config, fragmentList []string) erro
 	list, freeMemory := cStringArray(fragmentList)
 	defer freeMemory()
 
-	ret := C.tiledb_array_consolidate_fragments(a.context.tiledbContext, curi, (**C.char)(unsafe.Pointer(&list[0])), C.uint64_t(len(list)), config.tiledbConfig)
+	ret := C.tiledb_array_consolidate_fragments(a.context.tiledbContext, curi, (**C.char)(slicePtr(list)), C.uint64_t(len(list)), config.tiledbConfig)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error consolidating tiledb array fragment list: %s", a.context.LastError())
 	}

--- a/array_experimental.go
+++ b/array_experimental.go
@@ -113,7 +113,7 @@ func (a *Array) ConsolidateFragments(config *Config, fragmentList []string) erro
 	list, freeMemory := cStringArray(fragmentList)
 	defer freeMemory()
 
-	ret := C.tiledb_array_consolidate_fragments(a.context.tiledbContext, curi, (**C.char)(unsafe.Pointer(&list[0])), C.size_t(len(list)), config.tiledbConfig)
+	ret := C.tiledb_array_consolidate_fragments(a.context.tiledbContext, curi, (**C.char)(unsafe.Pointer(&list[0])), C.uint64_t(len(list)), config.tiledbConfig)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error consolidating tiledb array fragment list: %s", a.context.LastError())
 	}

--- a/array_experimental.go
+++ b/array_experimental.go
@@ -6,7 +6,11 @@ package tiledb
 #include <stdlib.h>
 */
 import "C"
-import "fmt"
+import (
+	"fmt"
+	"runtime"
+	"unsafe"
+)
 
 // ConsolidationPlan is a consolidation plan for array
 type ConsolidationPlan struct {
@@ -93,4 +97,27 @@ func (cp *ConsolidationPlan) DumpJSON() (string, error) {
 	}
 
 	return json, nil
+}
+
+// ConsolidateFragments consolidates an explicit list of fragments in an array into a single fragment.
+// You must first finalize all queries to the array before consolidation can
+// begin (as consolidation temporarily acquires an exclusive lock on the array).
+func (a *Array) ConsolidateFragments(config *Config, fragmentList []string) error {
+	if config == nil {
+		return fmt.Errorf("Config must not be nil for Consolidate")
+	}
+
+	curi := C.CString(a.uri)
+	defer C.free(unsafe.Pointer(curi))
+
+	list, freeMemory := cStringArray(fragmentList)
+	defer freeMemory()
+
+	ret := C.tiledb_array_consolidate_fragments(a.context.tiledbContext, curi, (**C.char)(unsafe.Pointer(&list[0])), C.size_t(len(list)), config.tiledbConfig)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("Error consolidating tiledb array fragment list: %s", a.context.LastError())
+	}
+
+	runtime.KeepAlive(config)
+	return nil
 }

--- a/array_experimental_test.go
+++ b/array_experimental_test.go
@@ -160,11 +160,6 @@ func TestConsolidateFragments(t *testing.T) {
 	for i := uint32(0); i < numFrags; i++ {
 		uri, err := fragmentInfo.GetFragmentURI(i)
 		require.NoError(t, err)
-
-		// TODO: Remove temp (shouldn't need to split fragment URI string?)
-		// Seems to be a bug here if we supply full `file://` URIs for the fragment list.
-		// https://github.com/TileDB-Inc/TileDB/blob/dev/tiledb/sm/consolidator/fragment_consolidator.cc#L362-L388
-		//temp := strings.SplitAfter(uri, "__fragments/")[1]
 		fragUris[i] = uri
 	}
 
@@ -182,7 +177,8 @@ func TestConsolidateFragments(t *testing.T) {
 	require.NoError(t, err)
 	fragToVacuumNum, err := fragmentInfo.GetToVacuumNum()
 	require.NoError(t, err)
-	require.Equal(t, numFrags+1, fragToVacuumNum+fragInfoNum)
+	require.Equal(t, numFrags, fragToVacuumNum)
+	require.Equal(t, uint32(1), fragInfoNum)
 
 	err = array.Vacuum(config)
 	require.NoError(t, err)
@@ -194,5 +190,6 @@ func TestConsolidateFragments(t *testing.T) {
 	require.NoError(t, err)
 	fragToVacuumNum, err = fragmentInfo.GetToVacuumNum()
 	require.NoError(t, err)
-	require.Equal(t, uint32(1), fragInfoNum+fragToVacuumNum)
+	require.Equal(t, uint32(1), fragInfoNum)
+	require.Equal(t, uint32(0), fragToVacuumNum)
 }

--- a/array_experimental_test.go
+++ b/array_experimental_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createTestArray(t *testing.T) *Array {
+func create1DTestArray(t *testing.T) *Array {
 	// Create a 1d array
 
 	// Create configuration
@@ -66,7 +66,7 @@ func createTestArray(t *testing.T) *Array {
 	return array
 }
 
-func writeTestArray(t *testing.T, array *Array, data []int32) {
+func write1DTestArray(t *testing.T, array *Array, data []int32) {
 	// Open array for writing
 	err := array.Open(TILEDB_WRITE)
 	require.NoError(t, err)
@@ -103,9 +103,9 @@ func writeTestArray(t *testing.T, array *Array, data []int32) {
 }
 
 func TestGetConsolidationPlan(t *testing.T) {
-	array := createTestArray(t)
+	array := create1DTestArray(t)
 
-	writeTestArray(t, array, []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+	write1DTestArray(t, array, []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
 
 	checkConsolidationPlan := func(t *testing.T, cplan *ConsolidationPlan) {
 		numNodes, err := cplan.NumNodes()
@@ -144,11 +144,11 @@ func TestConsolidateFragments(t *testing.T) {
 	// https://github.com/TileDB-Inc/TileDB/pull/5135
 	t.Skip("Skipping fragment list consolidation SC-51140")
 
-	array := createTestArray(t)
+	array := create1DTestArray(t)
 
-	numFrags := uint32(5)
-	for i := uint32(0); i < numFrags; i++ {
-		writeTestArray(t, array, []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+	numFrags := 5
+	for i := 0; i < numFrags; i++ {
+		write1DTestArray(t, array, []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
 	}
 
 	fragmentInfo, err := NewFragmentInfo(array.context, array.uri)
@@ -159,10 +159,10 @@ func TestConsolidateFragments(t *testing.T) {
 
 	fragInfoNum, err := fragmentInfo.GetFragmentNum()
 	require.NoError(t, err)
-	require.Equal(t, numFrags, fragInfoNum)
+	require.EqualValues(t, numFrags, fragInfoNum)
 	fragUris := make([]string, numFrags)
-	for i := uint32(0); i < numFrags; i++ {
-		uri, err := fragmentInfo.GetFragmentURI(i)
+	for i := 0; i < numFrags; i++ {
+		uri, err := fragmentInfo.GetFragmentURI(uint32(i))
 		require.NoError(t, err)
 		fragUris[i] = uri
 	}
@@ -181,7 +181,7 @@ func TestConsolidateFragments(t *testing.T) {
 	require.NoError(t, err)
 	fragToVacuumNum, err := fragmentInfo.GetToVacuumNum()
 	require.NoError(t, err)
-	require.Equal(t, numFrags, fragToVacuumNum)
+	require.EqualValues(t, numFrags, fragToVacuumNum)
 	require.Equal(t, uint32(1), fragInfoNum)
 
 	err = array.Vacuum(config)

--- a/array_experimental_test.go
+++ b/array_experimental_test.go
@@ -140,6 +140,10 @@ func TestGetConsolidationPlan(t *testing.T) {
 }
 
 func TestConsolidateFragments(t *testing.T) {
+	// The test is skipped pending a core release for 2.25.0 that includes this fix:
+	// https://github.com/TileDB-Inc/TileDB/pull/5135
+	t.Skip("Skipping fragment list consolidation SC-51140")
+
 	array := createTestArray(t)
 
 	numFrags := uint32(5)

--- a/array_experimental_test.go
+++ b/array_experimental_test.go
@@ -170,18 +170,29 @@ func TestConsolidateFragments(t *testing.T) {
 
 	// Default consolidation mode is 'fragments'.
 	config, err := array.context.Config()
+	require.NoError(t, err)
 
 	err = array.ConsolidateFragments(config, fragUris)
 	require.NoError(t, err)
+
 	// Check that the new consolidated fragment was created.
-	require.Equal(t, numFrags+1, fragInfoNum+1)
-
-	err = array.Vacuum(config)
-	require.NoError(t, err)
-
 	err = fragmentInfo.Load()
 	require.NoError(t, err)
 	fragInfoNum, err = fragmentInfo.GetFragmentNum()
 	require.NoError(t, err)
-	require.Equal(t, uint32(1), fragInfoNum)
+	fragToVacuumNum, err := fragmentInfo.GetToVacuumNum()
+	require.NoError(t, err)
+	require.Equal(t, numFrags+1, fragToVacuumNum+fragInfoNum)
+
+	err = array.Vacuum(config)
+	require.NoError(t, err)
+
+	// Check for one fragment after vacuum.
+	err = fragmentInfo.Load()
+	require.NoError(t, err)
+	fragInfoNum, err = fragmentInfo.GetFragmentNum()
+	require.NoError(t, err)
+	fragToVacuumNum, err = fragmentInfo.GetToVacuumNum()
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), fragInfoNum+fragToVacuumNum)
 }

--- a/common.go
+++ b/common.go
@@ -1,5 +1,9 @@
 package tiledb
 
+/*
+#include <stdlib.h>
+*/
+import "C"
 import (
 	"reflect"
 	"unsafe"
@@ -19,4 +23,19 @@ type scalarType interface {
 func slicePtr[T any](slc []T) unsafe.Pointer {
 	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&slc))
 	return unsafe.Pointer(hdr.Data)
+}
+
+// cStringArray takes an array of Go strings and converts it to an array of CStrings.
+// The function returned should be deferred by the caller to free allocated memory.
+func cStringArray(stringList []string) ([]*C.char, func()) {
+	list := make([]*C.char, len(stringList))
+	for i, str := range stringList {
+		list[i] = C.CString(str)
+	}
+
+	return list, func() {
+		for _, str := range list {
+			C.free(unsafe.Pointer(str))
+		}
+	}
 }


### PR DESCRIPTION
This adds the  `tiledb_array_consolidate_fragments` binding required for cloud fragment list consolidation.

CI will fail on this PR until https://github.com/TileDB-Inc/TileDB/pull/5135 is merged and backported to the core version in use by TileDB-Go.