### PR TITLE
Update Go versions to test.

### DIFF
--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.20", "1.21"]
+        go: ["1.21", "1.22"]
     steps:
 
     # Checks out repository
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.20", "1.21"]
+        go: ["1.21", "1.22"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v2
@@ -129,7 +129,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.20", "1.21"]
+        go: ["1.21", "1.22"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v2


### PR DESCRIPTION
We should include the latest minor release (1.22) and I see no harm in discontinuing testing with 1.20.