### PR TITLE
Add go mod retraction for v0.30.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
+// Local triggered panic when referencing enums
+retract v0.30.1
+
 go 1.20


### PR DESCRIPTION
Adds a module retraction for a regression in which a panic is triggered when referencing enums