### PR TITLE
Reapply simplification of memory handling with generics.

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -400,6 +400,21 @@ func TestArray_Metadata(t *testing.T) {
 		a.Close()
 		assert.NoError(t, err)
 	})
+
+	t.Run("empty", func(t *testing.T) {
+		a, err := newTestArray(t)
+		require.NoError(t, err)
+		require.NoError(t, a.Open(TILEDB_WRITE))
+		empty := []byte{}
+		require.NoError(t, arrayPutMetadata(a, TILEDB_STRING_UTF8, testKey, slicePtr(empty), 0))
+		require.NoError(t, a.Close())
+		require.NoError(t, a.Open(TILEDB_READ))
+		dataType, valNum, value, err := a.GetMetadata(testKey)
+		require.NoError(t, err)
+		assert.Equal(t, TILEDB_STRING_UTF8, dataType)
+		assert.EqualValues(t, 1, valNum)
+		assert.Equal(t, "", value.(string))
+	})
 }
 
 func TestDeleteFragments(t *testing.T) {

--- a/common.go
+++ b/common.go
@@ -1,7 +1,6 @@
 package tiledb
 
 import (
-	"reflect"
 	"unsafe"
 )
 
@@ -17,6 +16,5 @@ type scalarType interface {
 
 // slicePtr gives you an unsafe pointer to the start of a slice.
 func slicePtr[T any](slc []T) unsafe.Pointer {
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&slc))
-	return unsafe.Pointer(hdr.Data)
+	return unsafe.Pointer(unsafe.SliceData(slc))
 }

--- a/dimension.go
+++ b/dimension.go
@@ -353,131 +353,53 @@ func (d *Dimension) Domain() (interface{}, error) {
 		return nil, err
 	}
 
-	var ret C.int32_t
-	var domain interface{}
 	switch datatype {
 	case TILEDB_INT8:
-		cdomain := C.malloc(2 * C.sizeof_int8_t)
-		defer C.free(cdomain)
-		tmpDomain := make([]int8, 2)
-		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
-		tmpslice := (*[1 << 46]C.int8_t)(unsafe.Pointer(cdomain))[:2:2]
-		for i, s := range tmpslice {
-			tmpDomain[i] = int8(s)
-		}
-		domain = tmpDomain
+		return domainInternal[int8](d)
 	case TILEDB_INT16:
-		cdomain := C.malloc(2 * C.sizeof_int16_t)
-		defer C.free(cdomain)
-		tmpDomain := make([]int16, 2)
-		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
-		tmpslice := (*[1 << 46]C.int16_t)(unsafe.Pointer(cdomain))[:2:2]
-		for i, s := range tmpslice {
-			tmpDomain[i] = int16(s)
-		}
-		domain = tmpDomain
+		return domainInternal[int16](d)
 	case TILEDB_INT32:
-		cdomain := C.malloc(2 * C.sizeof_int32_t)
-		defer C.free(cdomain)
-		tmpDomain := make([]int32, 2)
-		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
-		tmpslice := (*[1 << 46]C.int32_t)(unsafe.Pointer(cdomain))[:2:2]
-		for i, s := range tmpslice {
-			tmpDomain[i] = int32(s)
-		}
-		domain = tmpDomain
+		return domainInternal[int32](d)
 	case TILEDB_INT64:
-		cdomain := C.malloc(2 * C.sizeof_int64_t)
-		defer C.free(cdomain)
-		tmpDomain := make([]int64, 2)
-		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
-		tmpslice := (*[1 << 46]C.int64_t)(unsafe.Pointer(cdomain))[:2:2]
-		for i, s := range tmpslice {
-			tmpDomain[i] = int64(s)
-		}
-		domain = tmpDomain
+		return domainInternal[int64](d)
 	case TILEDB_UINT8:
-		cdomain := C.malloc(2 * C.sizeof_uint8_t)
-		defer C.free(cdomain)
-		tmpDomain := make([]uint8, 2)
-		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
-		tmpslice := (*[1 << 46]C.uint8_t)(unsafe.Pointer(cdomain))[:2:2]
-		for i, s := range tmpslice {
-			tmpDomain[i] = uint8(s)
-		}
-		domain = tmpDomain
+		return domainInternal[uint8](d)
 	case TILEDB_UINT16:
-		cdomain := C.malloc(2 * C.sizeof_uint16_t)
-		defer C.free(cdomain)
-		tmpDomain := make([]uint16, 2)
-		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
-		tmpslice := (*[1 << 46]C.uint16_t)(unsafe.Pointer(cdomain))[:2:2]
-		for i, s := range tmpslice {
-			tmpDomain[i] = uint16(s)
-		}
-		domain = tmpDomain
+		return domainInternal[uint16](d)
 	case TILEDB_UINT32:
-		cdomain := C.malloc(2 * C.sizeof_uint32_t)
-		defer C.free(cdomain)
-		tmpDomain := make([]uint32, 2)
-		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
-		tmpslice := (*[1 << 46]C.uint32_t)(unsafe.Pointer(cdomain))[:2:2]
-		for i, s := range tmpslice {
-			tmpDomain[i] = uint32(s)
-		}
-		domain = tmpDomain
+		return domainInternal[uint32](d)
 	case TILEDB_UINT64:
-		cdomain := C.malloc(2 * C.sizeof_uint64_t)
-		defer C.free(cdomain)
-		tmpDomain := make([]uint64, 2)
-		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
-		tmpslice := (*[1 << 46]C.uint64_t)(unsafe.Pointer(cdomain))[:2:2]
-		for i, s := range tmpslice {
-			tmpDomain[i] = uint64(s)
-		}
-		domain = tmpDomain
+		return domainInternal[uint64](d)
 	case TILEDB_FLOAT32:
-		cdomain := C.malloc(2 * C.sizeof_float)
-		defer C.free(cdomain)
-		tmpDomain := make([]float32, 2)
-		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
-		tmpslice := (*[1 << 46]C.float)(unsafe.Pointer(cdomain))[:2:2]
-		for i, s := range tmpslice {
-			tmpDomain[i] = float32(s)
-		}
-		domain = tmpDomain
+		return domainInternal[float32](d)
 	case TILEDB_FLOAT64:
-		cdomain := C.malloc(2 * C.sizeof_double)
-		defer C.free(cdomain)
-		tmpDomain := make([]float64, 2)
-		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
-		tmpslice := (*[1 << 46]C.double)(unsafe.Pointer(cdomain))[:2:2]
-		for i, s := range tmpslice {
-			tmpDomain[i] = float64(s)
-		}
-		domain = tmpDomain
+		return domainInternal[float64](d)
 	case TILEDB_BOOL:
-		cdomain := C.malloc(2 * C.sizeof_double)
-		defer C.free(cdomain)
-		tmpDomain := make([]bool, 2)
-		ret = C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cdomain)
-		tmpslice := (*[1 << 46]C.uint8_t)(unsafe.Pointer(cdomain))[:2:2]
-		for i, s := range tmpslice {
-			if s != 0 {
-				tmpDomain[i] = true
-			}
+		// Ensure that our booleans are in canonical true/false form in case they're
+		// a value other than 0 or 1.
+		asUints, err := domainInternal[uint8](d)
+		if err != nil {
+			return nil, err
 		}
-		domain = tmpDomain
+		return []bool{asUints[0] != 0, asUints[1] != 0}, nil
 	case TILEDB_STRING_ASCII:
-		domain = nil
-	default:
-		return nil, fmt.Errorf("Unrecognized domain type: %d", datatype)
+		return nil, nil
 	}
-	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting tiledb dimension's domain: %s", d.context.LastError())
-	}
+	return nil, fmt.Errorf("unrecognized domain type: %d", datatype)
+}
 
-	return domain, nil
+func domainInternal[T any](d *Dimension) ([]T, error) {
+	// tiledb_dimension_get_domain writes *a pointer to the memory it owns*
+	// into cDomain, so we need to ensure that the dimension stays alive for
+	// the entire duration of this call.
+	defer runtime.KeepAlive(d)
+	var cDomain unsafe.Pointer
+	ret := C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cDomain)
+	if ret != C.TILEDB_OK {
+		return nil, fmt.Errorf("could not get tiledb dimension's domain: %w", d.context.LastError())
+	}
+	asArray := (*[2]T)(cDomain)
+	return []T{asArray[0], asArray[1]}, nil
 }
 
 // Extent returns the dimension's extent.
@@ -486,75 +408,48 @@ func (d *Dimension) Extent() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	var ret C.int32_t
-	var extent interface{}
 	switch datatype {
 	case TILEDB_INT8:
-		cextent := C.malloc(C.sizeof_int8_t)
-		defer C.free(cextent)
-		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
-		extent = *(*int8)(unsafe.Pointer(cextent))
+		return extentInternal[int8](d)
 	case TILEDB_INT16:
-		cextent := C.malloc(C.sizeof_int16_t)
-		defer C.free(cextent)
-		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
-		extent = *(*int16)(unsafe.Pointer(cextent))
+		return extentInternal[int16](d)
 	case TILEDB_INT32:
-		cextent := C.malloc(C.sizeof_int32_t)
-		defer C.free(cextent)
-		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
-		extent = *(*int32)(unsafe.Pointer(cextent))
+		return extentInternal[int32](d)
 	case TILEDB_INT64:
-		cextent := C.malloc(C.sizeof_int64_t)
-		defer C.free(cextent)
-		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
-		extent = *(*int64)(unsafe.Pointer(cextent))
+		return extentInternal[int64](d)
 	case TILEDB_UINT8:
-		cextent := C.malloc(C.sizeof_uint8_t)
-		defer C.free(cextent)
-		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
-		extent = *(*uint8)(unsafe.Pointer(cextent))
+		return extentInternal[uint8](d)
 	case TILEDB_UINT16:
-		cextent := C.malloc(C.sizeof_uint16_t)
-		defer C.free(cextent)
-		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
-		extent = *(*uint16)(unsafe.Pointer(cextent))
+		return extentInternal[uint16](d)
 	case TILEDB_UINT32:
-		cextent := C.malloc(C.sizeof_uint32_t)
-		defer C.free(cextent)
-		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
-		extent = *(*uint32)(unsafe.Pointer(cextent))
+		return extentInternal[uint32](d)
 	case TILEDB_UINT64:
-		cextent := C.malloc(C.sizeof_uint64_t)
-		defer C.free(cextent)
-		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
-		extent = *(*uint64)(unsafe.Pointer(cextent))
+		return extentInternal[uint64](d)
 	case TILEDB_FLOAT32:
-		cextent := C.malloc(C.sizeof_float)
-		defer C.free(cextent)
-		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
-		extent = *(*float32)(unsafe.Pointer(cextent))
+		return extentInternal[float32](d)
 	case TILEDB_FLOAT64:
-		cextent := C.malloc(C.sizeof_double)
-		defer C.free(cextent)
-		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
-		extent = *(*float64)(unsafe.Pointer(cextent))
+		return extentInternal[float64](d)
 	case TILEDB_BOOL:
-		cextent := C.malloc(C.sizeof_uint8_t)
-		defer C.free(cextent)
-		ret = C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cextent)
-		extent = *(*bool)(unsafe.Pointer(cextent))
+		xt, err := extentInternal[uint8](d)
+		return xt != 0, err
 	case TILEDB_STRING_ASCII:
-		extent = nil
-	default:
-		return nil, fmt.Errorf("Unrecognized extent type: %d", datatype)
+		return nil, nil
 	}
-	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting tiledb dimension's extent: %s", d.context.LastError())
-	}
+	return nil, fmt.Errorf("unrecognized extent type: %d", datatype)
+}
 
-	return extent, nil
+func extentInternal[T any](d *Dimension) (T, error) {
+	// As in domainInternal, tiledb_dimension_get_tile_extent writes a pointer
+	// to memory it owns into cExtent. Ensure this Dimension stays alive.
+	defer runtime.KeepAlive(d)
+	var cExtent unsafe.Pointer
+	var output T
+	cRet := C.tiledb_dimension_get_tile_extent(d.context.tiledbContext, d.tiledbDimension, &cExtent)
+	if cRet != C.TILEDB_OK {
+		return output, fmt.Errorf("could not get TileDB dimension's extent: %w", d.context.LastError())
+	}
+	output = *(*T)(cExtent)
+	return output, nil
 }
 
 // DumpSTDOUT dumps the dimension in ASCII format to stdout.

--- a/enums.go
+++ b/enums.go
@@ -323,6 +323,9 @@ func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, e
 	case TILEDB_FLOAT64:
 		return getValueInternal[float64](valueNum, cvalue)
 	case TILEDB_CHAR, TILEDB_STRING_ASCII, TILEDB_STRING_UTF8:
+		if cvalue == nil || valueNum == 0 {
+			return "", nil
+		}
 		return C.GoStringN((*C.char)(cvalue), C.int(valueNum)), nil
 	case TILEDB_DATETIME_YEAR, TILEDB_DATETIME_MONTH, TILEDB_DATETIME_WEEK,
 		TILEDB_DATETIME_DAY, TILEDB_DATETIME_HR, TILEDB_DATETIME_MIN,

--- a/memory.go
+++ b/memory.go
@@ -55,3 +55,12 @@ func (bb byteBuffer) subSlice(sliceStart unsafe.Pointer, sliceBytes uintptr) []b
 	startIdx := uintptr(sliceStart) - uintptr(bb.start())
 	return bb[startIdx:sliceBytes]
 }
+
+// unsafeSlice creates a slice pointing at the given memory.
+func unsafeSlice[T any](ptr unsafe.Pointer, length uint) []T {
+	if ptr == nil {
+		return nil
+	}
+	typedPtr := (*T)(ptr)
+	return unsafe.Slice(typedPtr, length)
+}


### PR DESCRIPTION
This reverts #331 and #330, thus reintroducing #248 and #321.

The issue in those changes was that when attempting to copy a null/zero-length string, we would do something like `C.GoStringN(nil, 0)` or maybe `C.GoStringN(someInvalidAddress, 0)`. Either of those should (in theory) give you a zero-length string, but in practice we want to manually check (as the code did before I removed that check). The check remained present in the *other* uses, since they all had an equivalent check before their copying operation in `getValueInternal`.

This change is also currently running through a server-side test suite.