### PR TITLE
Replace all slice-pointer use with slicePtr function.

### DIFF
--- a/array.go
+++ b/array.go
@@ -1101,7 +1101,7 @@ func DeleteFragmentsList(tdbCtx *Context, uri string, fragmentURIs []string) err
 	list, freeMemory := cStringArray(fragmentURIs)
 	defer freeMemory()
 
-	ret := C.tiledb_array_delete_fragments_list(tdbCtx.tiledbContext, curi, (**C.char)(unsafe.Pointer(&list[0])), C.size_t(len(list)))
+	ret := C.tiledb_array_delete_fragments_list(tdbCtx.tiledbContext, curi, (**C.char)(slicePtr(list)), C.size_t(len(list)))
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error deleting fragments list from array: %s", tdbCtx.LastError())
 	}

--- a/dimension.go
+++ b/dimension.go
@@ -69,7 +69,7 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 		// Create domain void*
 		tmpDomain := domain.([]int8)
 		domainPtr = &tmpDomain
-		cdomain = unsafe.Pointer(&tmpDomain[0])
+		cdomain = slicePtr(tmpDomain)
 		// Create extent void*
 		tmpExtent := extent.(int8)
 		extentPtr = &tmpExtent
@@ -82,7 +82,7 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 		// Create domain void*
 		tmpDomain := domain.([]int16)
 		domainPtr = &tmpDomain
-		cdomain = unsafe.Pointer(&tmpDomain[0])
+		cdomain = slicePtr(tmpDomain)
 		// Create extent void*
 		tmpExtent := extent.(int16)
 		extentPtr = &tmpExtent
@@ -100,7 +100,7 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 		// Create domain void*
 		tmpDomain := domain.([]int32)
 		domainPtr = &tmpDomain
-		cdomain = unsafe.Pointer(&tmpDomain[0])
+		cdomain = slicePtr(tmpDomain)
 		// Create extent void*
 		tmpExtent := extent.(int32)
 		extentPtr = &tmpExtent
@@ -118,7 +118,7 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 		// Create domain void*
 		tmpDomain := domain.([]int64)
 		domainPtr = &tmpDomain
-		cdomain = unsafe.Pointer(&tmpDomain[0])
+		cdomain = slicePtr(tmpDomain)
 		// Create extent void*
 		tmpExtent := extent.(int64)
 		extentPtr = &tmpExtent
@@ -131,7 +131,7 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 		// Create domain void*
 		tmpDomain := domain.([]uint8)
 		domainPtr = &tmpDomain
-		cdomain = unsafe.Pointer(&tmpDomain[0])
+		cdomain = slicePtr(tmpDomain)
 		// Create extent void*
 		tmpExtent := extent.(uint8)
 		extentPtr = &tmpExtent
@@ -144,7 +144,7 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 		// Create domain void*
 		tmpDomain := domain.([]uint16)
 		domainPtr = &tmpDomain
-		cdomain = unsafe.Pointer(&tmpDomain[0])
+		cdomain = slicePtr(tmpDomain)
 		// Create extent void*
 		tmpExtent := extent.(uint16)
 		extentPtr = &tmpExtent
@@ -162,7 +162,7 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 		// Create domain void*
 		tmpDomain := domain.([]uint32)
 		domainPtr = &tmpDomain
-		cdomain = unsafe.Pointer(&tmpDomain[0])
+		cdomain = slicePtr(tmpDomain)
 		// Create extent void*
 		tmpExtent := extent.(uint32)
 		extentPtr = &tmpExtent
@@ -180,7 +180,7 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 		// Create domain void*
 		tmpDomain := domain.([]uint64)
 		domainPtr = &tmpDomain
-		cdomain = unsafe.Pointer(&tmpDomain[0])
+		cdomain = slicePtr(tmpDomain)
 		// Create extent void*
 		tmpExtent := extent.(uint64)
 		extentPtr = &tmpExtent
@@ -193,7 +193,7 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 		// Create domain void*
 		tmpDomain := domain.([]float32)
 		domainPtr = &tmpDomain
-		cdomain = unsafe.Pointer(&tmpDomain[0])
+		cdomain = slicePtr(tmpDomain)
 		// Create extent void*
 		tmpExtent := extent.(float32)
 		extentPtr = &tmpExtent
@@ -206,7 +206,7 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 		// Create domain void*
 		tmpDomain := domain.([]float64)
 		domainPtr = &tmpDomain
-		cdomain = unsafe.Pointer(&tmpDomain[0])
+		cdomain = slicePtr(tmpDomain)
 		// Create extent void*
 		tmpExtent := extent.(float64)
 		extentPtr = &tmpExtent
@@ -219,7 +219,7 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 		// Create domain void*
 		tmpDomain := domain.([]bool)
 		domainPtr = &tmpDomain
-		cdomain = unsafe.Pointer(&tmpDomain[0])
+		cdomain = slicePtr(tmpDomain)
 		// Create extent void*
 		tmpExtent := extent.(bool)
 		extentPtr = &tmpExtent

--- a/dimension_label_experimental.go
+++ b/dimension_label_experimental.go
@@ -306,7 +306,7 @@ func (sa *Subarray) AddDimensionLabelRange(labelName string, r Range) error {
 		startSlice := []byte(r.start.(string))
 		endSlice := []byte(r.end.(string))
 		ret = C.tiledb_subarray_add_label_range_var(sa.context.tiledbContext, sa.subarray, cLabelName,
-			unsafe.Pointer(&startSlice[0]), C.uint64_t(len(startSlice)), unsafe.Pointer(&endSlice[0]), C.uint64_t(len(endSlice)))
+			slicePtr(startSlice), C.uint64_t(len(startSlice)), slicePtr(endSlice), C.uint64_t(len(endSlice)))
 		runtime.KeepAlive(startSlice)
 		runtime.KeepAlive(endSlice)
 	} else {
@@ -345,11 +345,11 @@ func (sa *Subarray) GetDimensionLabelRange(labelName string, rangeNum uint64) (R
 			var startData, endData []byte
 			if startSize > 0 {
 				startData = make([]byte, int(startSize))
-				sp = unsafe.Pointer(&startData[0])
+				sp = slicePtr(startData)
 			}
 			if endSize > 0 {
 				endData = make([]byte, int(endSize))
-				ep = unsafe.Pointer(&endData[0])
+				ep = slicePtr(endData)
 			}
 			ret = C.tiledb_subarray_get_label_range_var(sa.context.tiledbContext, sa.subarray,
 				cLabelName, C.uint64_t(rangeNum), sp, ep)

--- a/filestore_experimental.go
+++ b/filestore_experimental.go
@@ -178,7 +178,7 @@ func bufferExport(tdbCtx *Context, uri *C.char, off int64, p []byte) error {
 		return nil
 	}
 
-	ret := C.tiledb_filestore_buffer_export(tdbCtx.tiledbContext, uri, C.size_t(off), unsafe.Pointer(&p[0]), C.size_t(len(p)))
+	ret := C.tiledb_filestore_buffer_export(tdbCtx.tiledbContext, uri, C.size_t(off), slicePtr(p), C.size_t(len(p)))
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error exporting buffer data: %s", tdbCtx.LastError())
 	}
@@ -193,7 +193,7 @@ func bufferImport(tdbCtx *Context, uri *C.char, data []byte, mimeType FileStoreM
 		return errors.New("Error importing buffer data: empty data")
 	}
 
-	ret := C.tiledb_filestore_buffer_import(tdbCtx.tiledbContext, uri, unsafe.Pointer(&data[0]), C.size_t(len(data)), C.tiledb_mime_type_t(mimeType))
+	ret := C.tiledb_filestore_buffer_import(tdbCtx.tiledbContext, uri, slicePtr(data), C.size_t(len(data)), C.tiledb_mime_type_t(mimeType))
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("Error importing buffer data: %s", tdbCtx.LastError())
 	}

--- a/serialize.go
+++ b/serialize.go
@@ -81,7 +81,7 @@ func SerializeArrayNonEmptyDomain(a *Array, serializationType SerializationType)
 
 	var isEmpty C.int32_t
 	tmpDomain := make([]uint8, subarraySize)
-	ret := C.tiledb_array_get_non_empty_domain(a.context.tiledbContext, a.tiledbArray, unsafe.Pointer(&tmpDomain[0]), &isEmpty)
+	ret := C.tiledb_array_get_non_empty_domain(a.context.tiledbContext, a.tiledbArray, slicePtr(tmpDomain), &isEmpty)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error serializing array nonempty domain: %s", a.context.LastError())
 	}
@@ -90,7 +90,7 @@ func SerializeArrayNonEmptyDomain(a *Array, serializationType SerializationType)
 	freeOnGC(&buffer)
 
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
-	ret = C.tiledb_serialize_array_nonempty_domain(a.context.tiledbContext, a.tiledbArray, unsafe.Pointer(&tmpDomain[0]), isEmpty, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
+	ret = C.tiledb_serialize_array_nonempty_domain(a.context.tiledbContext, a.tiledbArray, slicePtr(tmpDomain), isEmpty, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("Error serializing array nonempty domain: %s", a.context.LastError())
 	}

--- a/subarray.go
+++ b/subarray.go
@@ -87,55 +87,55 @@ func (sa *Subarray) SetSubArray(subArray interface{}) error {
 	case reflect.Int:
 		// Create subArray void*
 		tmpSubArray := subArray.([]int)
-		csubArray = unsafe.Pointer(&tmpSubArray[0])
+		csubArray = slicePtr(tmpSubArray)
 	case reflect.Int8:
 		// Create subArray void*
 		tmpSubArray := subArray.([]int8)
-		csubArray = unsafe.Pointer(&tmpSubArray[0])
+		csubArray = slicePtr(tmpSubArray)
 	case reflect.Int16:
 		// Create subArray void*
 		tmpSubArray := subArray.([]int16)
-		csubArray = unsafe.Pointer(&tmpSubArray[0])
+		csubArray = slicePtr(tmpSubArray)
 	case reflect.Int32:
 		// Create subArray void*
 		tmpSubArray := subArray.([]int32)
-		csubArray = unsafe.Pointer(&tmpSubArray[0])
+		csubArray = slicePtr(tmpSubArray)
 	case reflect.Int64:
 		// Create subArray void*
 		tmpSubArray := subArray.([]int64)
-		csubArray = unsafe.Pointer(&tmpSubArray[0])
+		csubArray = slicePtr(tmpSubArray)
 	case reflect.Uint:
 		// Create subArray void*
 		tmpSubArray := subArray.([]uint)
-		csubArray = unsafe.Pointer(&tmpSubArray[0])
+		csubArray = slicePtr(tmpSubArray)
 	case reflect.Uint8:
 		// Create subArray void*
 		tmpSubArray := subArray.([]uint8)
-		csubArray = unsafe.Pointer(&tmpSubArray[0])
+		csubArray = slicePtr(tmpSubArray)
 	case reflect.Uint16:
 		// Create subArray void*
 		tmpSubArray := subArray.([]uint16)
-		csubArray = unsafe.Pointer(&tmpSubArray[0])
+		csubArray = slicePtr(tmpSubArray)
 	case reflect.Uint32:
 		// Create subArray void*
 		tmpSubArray := subArray.([]uint32)
-		csubArray = unsafe.Pointer(&tmpSubArray[0])
+		csubArray = slicePtr(tmpSubArray)
 	case reflect.Uint64:
 		// Create subArray void*
 		tmpSubArray := subArray.([]uint64)
-		csubArray = unsafe.Pointer(&tmpSubArray[0])
+		csubArray = slicePtr(tmpSubArray)
 	case reflect.Float32:
 		// Create subArray void*
 		tmpSubArray := subArray.([]float32)
-		csubArray = unsafe.Pointer(&tmpSubArray[0])
+		csubArray = slicePtr(tmpSubArray)
 	case reflect.Float64:
 		// Create subArray void*
 		tmpSubArray := subArray.([]float64)
-		csubArray = unsafe.Pointer(&tmpSubArray[0])
+		csubArray = slicePtr(tmpSubArray)
 	case reflect.Bool:
 		// Create subArray void*
 		tmpSubArray := subArray.([]bool)
-		csubArray = unsafe.Pointer(&tmpSubArray[0])
+		csubArray = slicePtr(tmpSubArray)
 	default:
 		return fmt.Errorf("Unrecognized subArray type passed: %s", subArrayType.String())
 	}
@@ -179,7 +179,7 @@ func (sa *Subarray) AddRange(dimIdx uint32, r Range) error {
 		startSlice := []byte(r.start.(string))
 		endSlice := []byte(r.end.(string))
 		ret = C.tiledb_subarray_add_range_var(sa.context.tiledbContext, sa.subarray, C.uint32_t(dimIdx),
-			unsafe.Pointer(&startSlice[0]), C.uint64_t(len(startSlice)), unsafe.Pointer(&endSlice[0]), C.uint64_t(len(endSlice)))
+			slicePtr(startSlice), C.uint64_t(len(startSlice)), slicePtr(endSlice), C.uint64_t(len(endSlice)))
 		runtime.KeepAlive(startSlice)
 		runtime.KeepAlive(endSlice)
 	} else {
@@ -216,7 +216,7 @@ func (sa *Subarray) AddRangeByName(dimName string, r Range) error {
 		startSlice := []byte(r.start.(string))
 		endSlice := []byte(r.end.(string))
 		ret = C.tiledb_subarray_add_range_var_by_name(sa.context.tiledbContext, sa.subarray, cDimName,
-			unsafe.Pointer(&startSlice[0]), C.uint64_t(len(startSlice)), unsafe.Pointer(&endSlice[0]), C.uint64_t(len(endSlice)))
+			slicePtr(startSlice), C.uint64_t(len(startSlice)), slicePtr(endSlice), C.uint64_t(len(endSlice)))
 		runtime.KeepAlive(startSlice)
 		runtime.KeepAlive(endSlice)
 	} else {
@@ -342,11 +342,11 @@ func (sa *Subarray) GetRange(dimIdx uint32, rangeNum uint64) (Range, error) {
 			var startData, endData []byte
 			if startSize > 0 {
 				startData = make([]byte, int(startSize))
-				sp = unsafe.Pointer(&startData[0])
+				sp = slicePtr(startData)
 			}
 			if endSize > 0 {
 				endData = make([]byte, int(endSize))
-				ep = unsafe.Pointer(&endData[0])
+				ep = slicePtr(endData)
 			}
 			ret = C.tiledb_subarray_get_range_var(sa.context.tiledbContext, sa.subarray,
 				C.uint32_t(dimIdx), C.uint64_t(rangeNum), sp, ep)
@@ -393,11 +393,11 @@ func (sa *Subarray) GetRangeFromName(dimName string, rangeNum uint64) (Range, er
 			var startData, endData []byte
 			if startSize > 0 {
 				startData = make([]byte, int(startSize))
-				sp = unsafe.Pointer(&startData[0])
+				sp = slicePtr(startData)
 			}
 			if endSize > 0 {
 				endData = make([]byte, int(endSize))
-				ep = unsafe.Pointer(&endData[0])
+				ep = slicePtr(endData)
 			}
 			ret = C.tiledb_subarray_get_range_var_from_name(sa.context.tiledbContext, sa.subarray,
 				cDimName, C.uint64_t(rangeNum), sp, ep)

--- a/vfs.go
+++ b/vfs.go
@@ -369,7 +369,7 @@ func (v *VFS) Close(fh *VFSfh) error {
 // Read reads part of a file.
 func (v *VFS) Read(fh *VFSfh, offset uint64, nbytes uint64) ([]byte, error) {
 	bytes := make([]byte, nbytes)
-	cbuffer := unsafe.Pointer(&bytes[0])
+	cbuffer := slicePtr(bytes)
 	ret := C.tiledb_vfs_read(v.context.tiledbContext, fh.tiledbVFSfh, C.uint64_t(offset), cbuffer, C.uint64_t(nbytes))
 
 	if ret != C.TILEDB_OK {
@@ -511,7 +511,7 @@ func (v *VFSfh) Read(p []byte) (int, error) {
 		return 0, io.EOF
 	}
 
-	cbuffer := unsafe.Pointer(&p[0])
+	cbuffer := slicePtr(p)
 	ret := C.tiledb_vfs_read(v.context.tiledbContext, v.tiledbVFSfh, C.uint64_t(v.offset), cbuffer, C.uint64_t(nbytes))
 
 	if ret != C.TILEDB_OK {
@@ -529,7 +529,7 @@ func (v *VFSfh) Write(bytes []byte) (int, error) {
 	if len(bytes) == 0 {
 		return 0, nil
 	}
-	cbuffer := unsafe.Pointer(&bytes[0])
+	cbuffer := slicePtr(bytes)
 	ret := C.tiledb_vfs_write(v.context.tiledbContext, v.tiledbVFSfh, cbuffer, C.uint64_t(len(bytes)))
 
 	if ret != C.TILEDB_OK {


### PR DESCRIPTION
Since replacing other uses of the `&someSlice[0]` construction with `slicePtr(someSlice)` has already saved us from errors, this change replaces the remaining uses, for more robustness and easier reading.