### PR TITLE
Allow nil contexts to be passed when they can be inferred.

### DIFF
--- a/array.go
+++ b/array.go
@@ -54,7 +54,15 @@ type NonEmptyDomain struct {
 }
 
 // NewArray allocates a new array.
+// If the provided Context is nil, a default context is allocated and used.
 func NewArray(tdbCtx *Context, uri string) (*Array, error) {
+	if tdbCtx == nil {
+		newCtx, err := NewContext(nil)
+		if err != nil {
+			return nil, err
+		}
+		tdbCtx = newCtx
+	}
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	array := Array{context: tdbCtx, uri: uri}

--- a/query.go
+++ b/query.go
@@ -46,9 +46,7 @@ func (r RangeLimits) MarshalJSON() ([]byte, error) {
 /*
 NewQuery creates a TileDB query object.
 
-The query type (read or write) must be the same as the type used
-to open the array object.
-
+If the provided Context is nil, the context of the Array is used instead.
 The storage manager also acquires a shared lock on the array.
 This means multiple read and write queries to the same array can be made
 concurrently (in TileDB, only consolidation requires an exclusive lock for
@@ -57,6 +55,9 @@ a short period of time).
 func NewQuery(tdbCtx *Context, array *Array) (*Query, error) {
 	if array == nil {
 		return nil, fmt.Errorf("Error creating tiledb query: passed array is nil")
+	}
+	if tdbCtx == nil {
+		tdbCtx = array.context
 	}
 
 	queryType, err := array.QueryType()


### PR DESCRIPTION
This makes it a bit more convenient to do a few things:

- You can now allocate a new Array and provide a nil Context and a new (empty) Context will be created for you.
- When you create a new Query from an Array, you can provide a nil context and the array’s context will be used.

---

Another thing I ran into while working on stuff, which might make things a little more convenient for the majority of these constructor functions.