### PR TITLE
Remove unnecessary `Sleep` calls in tests.

### DIFF
--- a/examples_lib/reading_timestamp.go
+++ b/examples_lib/reading_timestamp.go
@@ -241,15 +241,12 @@ func RunTimestampArray() {
 	// Write data and metadata
 	t1 := getTimestamp()
 	writeTimestampArray(tmpDir1, "meta_key", "Write1", t1, 0)
-	time.Sleep(2000 * time.Millisecond)
 	// Write metadata only
 	t2 := getTimestamp()
 	writeTimestampArrayMeta(tmpDir1, "meta_key", "Write2", t2)
-	time.Sleep(2000 * time.Millisecond)
 	// Write metadata only
 	t3 := getTimestamp()
 	writeTimestampArrayMeta(tmpDir1, "meta_key", "Write3", t3)
-	time.Sleep(2000 * time.Millisecond)
 	// Write metadata only
 	t4 := getTimestamp()
 	writeTimestampArrayMeta(tmpDir1, "meta_key", "Write4", t4)
@@ -265,13 +262,10 @@ func RunTimestampArray() {
 	createTimestampArray(tmpDir2)
 	t1 = getTimestamp()
 	writeTimestampArray(tmpDir2, "meta_key", "Write1", t1, 0)
-	time.Sleep(2000 * time.Millisecond)
 	t2 = getTimestamp()
 	writeTimestampArray(tmpDir2, "meta_key", "Write2", t2, 1)
-	time.Sleep(2000 * time.Millisecond)
 	t3 = getTimestamp()
 	writeTimestampArray(tmpDir2, "meta_key", "Write3", t3, 2)
-	time.Sleep(2000 * time.Millisecond)
 	t4 = getTimestamp()
 	writeTimestampArray(tmpDir2, "meta_key", "Write4", t4, 3)
 	readTimestampArray(tmpDir2, t1)


### PR DESCRIPTION
As far as I can tell, these calls are not necessary and slow down our tests considerably.  After removing the `Sleep` calls, I ran the test multiple times as follows:

    go test \
        -race \
        -count=1 \
        -timeout 30s \
        -tags experimental \
        -run ^ExampleTimestampArray$ github.com/TileDB-Inc/TileDB-Go/examples

All tests passed, so we should be fine.