### PR TITLE
Fix ASAN failures.

### DIFF
--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -166,5 +166,4 @@ jobs:
 
     # Tests TileDB-Go
     - name: Running examples using address sanitizer flags
-      continue-on-error: true
       run: ./.github/scripts/build_with_sanitizer_and_run.sh

--- a/context.go
+++ b/context.go
@@ -59,6 +59,7 @@ func NewContextFromMap(cfgMap map[string]string) (*Context, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer config.Free()
 	for k, v := range cfgMap {
 		if err := config.Set(k, v); err != nil {
 			// The value is not included in the error message in case it is sensitive,

--- a/dimension_label_experimental.go
+++ b/dimension_label_experimental.go
@@ -258,11 +258,13 @@ func (q *Query) getDimensionLabelDataType(labelName string) (Datatype, error) {
 	if err != nil {
 		return 0, fmt.Errorf("Could not get schema for getDimensionLabelDatatype: %s", err)
 	}
+	defer schema.Free()
 
 	dimLabel, err := schema.DimensionLabelFromName(labelName)
 	if err != nil {
 		return 0, fmt.Errorf("Could not get dimension label %s for getDimensionLabelDatatype: %s", labelName, err)
 	}
+	defer dimLabel.Free()
 
 	datatype, err := dimLabel.Type()
 	if err != nil {

--- a/examples_lib/encryption.go
+++ b/examples_lib/encryption.go
@@ -32,8 +32,10 @@ func createEncryptedArray(dir string) {
 
 	rowDim, err := tiledb.NewDimension(ctx, "rows", tiledb.TILEDB_INT32, []int32{1, 4}, int32(4))
 	checkError(err)
+	defer rowDim.Free()
 	colDim, err := tiledb.NewDimension(ctx, "cols", tiledb.TILEDB_INT32, []int32{1, 4}, int32(4))
 	checkError(err)
+	defer colDim.Free()
 	err = domain.AddDimensions(rowDim, colDim)
 	checkError(err)
 
@@ -113,6 +115,7 @@ func readEncryptedArray(dir string) {
 	// Slice only rows 1, 2 and cols 2, 3, 4
 	subarray, err := array.NewSubarray()
 	checkError(err)
+	defer subarray.Free()
 	err = subarray.SetSubArray([]int32{1, 2, 2, 4})
 	checkError(err)
 

--- a/examples_lib/filters.go
+++ b/examples_lib/filters.go
@@ -2,7 +2,6 @@ package examples_lib
 
 import (
 	"fmt"
-
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 

--- a/examples_lib/quickstart_sparse.go
+++ b/examples_lib/quickstart_sparse.go
@@ -2,7 +2,6 @@ package examples_lib
 
 import (
 	"fmt"
-
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 	"github.com/TileDB-Inc/TileDB-Go/bytesizes"
 )

--- a/examples_lib/vacuum.go
+++ b/examples_lib/vacuum.go
@@ -179,6 +179,7 @@ func consolidateVacuum(dir string) {
 
 	ctx, err := tiledb.NewContext(nil)
 	checkError(err)
+	defer ctx.Free()
 
 	// Prepare the array for reading
 	array, err := tiledb.NewArray(ctx, dir)
@@ -194,6 +195,7 @@ func consolidateVacuum(dir string) {
 
 	config, err := tiledb.NewConfig()
 	checkError(err)
+	defer config.Free()
 
 	err = config.Set("sm.consolidation.buffer_size", "8")
 	checkError(err)

--- a/examples_lib/writing_dense_global_expansion.go
+++ b/examples_lib/writing_dense_global_expansion.go
@@ -20,8 +20,10 @@ func createDenseGlobalExpansionArray(dir string) {
 
 	rowDim, err := tiledb.NewDimension(ctx, "rows", tiledb.TILEDB_INT32, []int32{1, 4}, int32(2))
 	checkError(err)
+	defer rowDim.Free()
 	colDim, err := tiledb.NewDimension(ctx, "cols", tiledb.TILEDB_INT32, []int32{1, 3}, int32(2))
 	checkError(err)
+	defer colDim.Free()
 	err = domain.AddDimensions(rowDim, colDim)
 	checkError(err)
 

--- a/examples_lib/writing_sparse_multiple.go
+++ b/examples_lib/writing_sparse_multiple.go
@@ -16,7 +16,7 @@ func createMultipleWritesSparseArray(dir string) {
 	// with domain [1,4].
 	domain, err := tiledb.NewDomain(ctx)
 	checkError(err)
-	defer ctx.Free()
+	defer domain.Free()
 
 	rowDim, err := tiledb.NewDimension(ctx, "rows", tiledb.TILEDB_INT32, []int32{1, 4}, int32(4))
 	checkError(err)

--- a/query_test.go
+++ b/query_test.go
@@ -2,7 +2,6 @@ package tiledb
 
 import (
 	"os"
-	"reflect"
 	"testing"
 	"unsafe"
 
@@ -2900,7 +2899,7 @@ func TestSetDataBufferUnsafe(t *testing.T) {
 	require.NoError(t, s.AddRangeByName("x", MakeRange[int8](4, 7)))
 	require.NoError(t, q.SetSubarray(s))
 	dataBuffer := []int32{4, 5, 6, 7}
-	dataPtr := unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(&dataBuffer)).Data)
+	dataPtr := slicePtr(dataBuffer)
 	n, err := q.SetDataBufferUnsafe("a", dataPtr, 16)
 	require.NoError(t, err)
 	require.NotNil(t, n)
@@ -2922,7 +2921,7 @@ func TestSetDataBufferUnsafe(t *testing.T) {
 	require.NoError(t, s.AddRangeByName("x", MakeRange[int8](1, 10)))
 	require.NoError(t, q.SetSubarray(s))
 	dataBuffer = []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-	dataPtr = unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(&dataBuffer)).Data)
+	dataPtr = slicePtr(dataBuffer)
 	n, err = q.SetDataBufferUnsafe("a", dataPtr, 40)
 	require.NoError(t, err)
 	require.NotNil(t, n)
@@ -2941,8 +2940,7 @@ func TestSetDataBufferUnsafe(t *testing.T) {
 	require.NoError(t, err)
 	storedDataBuffer, ok := storedBuffer.([]int32)
 	require.True(t, ok)
-	require.Equal(t, uintptr(dataPtr),
-		((*reflect.SliceHeader)(unsafe.Pointer(&storedDataBuffer)).Data))
+	require.Equal(t, dataPtr, slicePtr(storedDataBuffer))
 }
 
 func TestGetDataBuffer(t *testing.T) {
@@ -2986,8 +2984,7 @@ func TestGetDataBuffer(t *testing.T) {
 	require.NoError(t, err)
 	storedDataBuffer, ok := storedBuffer.([]int32)
 	require.True(t, ok)
-	require.Equal(t, ((*reflect.SliceHeader)(unsafe.Pointer(&dataBuffer)).Data),
-		((*reflect.SliceHeader)(unsafe.Pointer(&storedDataBuffer)).Data))
+	require.Equal(t, slicePtr(dataBuffer), slicePtr(storedDataBuffer))
 }
 
 func TestSetDataBuffer(t *testing.T) {
@@ -3183,7 +3180,7 @@ func TestSetValidityBufferUnsafe(t *testing.T) {
 	_, err = q.SetDataBuffer("a", dataBuffer)
 	require.NoError(t, err)
 	validityBuffer := []uint8{1, 1, 0, 1}
-	validityPtr := unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(&validityBuffer)).Data)
+	validityPtr := slicePtr(validityBuffer)
 	n, err := q.SetValidityBufferUnsafe("a", validityPtr, 4)
 	require.NoError(t, err)
 	require.NotNil(t, n)
@@ -3208,7 +3205,7 @@ func TestSetValidityBufferUnsafe(t *testing.T) {
 	_, err = q.SetDataBuffer("a", dataBuffer)
 	require.NoError(t, err)
 	validityBuffer = []uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-	validityPtr = unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(&validityBuffer)).Data)
+	validityPtr = slicePtr(validityBuffer)
 	n, err = q.SetValidityBufferUnsafe("a", validityPtr, 10)
 	require.NoError(t, err)
 	require.NotNil(t, n)
@@ -3225,8 +3222,7 @@ func TestSetValidityBufferUnsafe(t *testing.T) {
 	// verify that GetDataBuffer works for buffers passed unsafe
 	storedValidityBuffer, err := q.GetValidityBuffer("a")
 	require.NoError(t, err)
-	require.Equal(t, uintptr(validityPtr),
-		((*reflect.SliceHeader)(unsafe.Pointer(&storedValidityBuffer)).Data))
+	require.Equal(t, validityPtr, slicePtr(storedValidityBuffer))
 }
 
 func TestGetValidityBuffer(t *testing.T) {
@@ -3269,8 +3265,7 @@ func TestGetValidityBuffer(t *testing.T) {
 
 	storedValidityBuffer, err := q.GetValidityBuffer("a")
 	require.NoError(t, err)
-	require.Equal(t, ((*reflect.SliceHeader)(unsafe.Pointer(&validityBuffer)).Data),
-		((*reflect.SliceHeader)(unsafe.Pointer(&storedValidityBuffer)).Data))
+	require.Equal(t, slicePtr(validityBuffer), slicePtr(storedValidityBuffer))
 }
 
 func TestSetValidityBuffer(t *testing.T) {
@@ -3483,7 +3478,7 @@ func TestSetOffsetsBufferUnsafe(t *testing.T) {
 	require.NotNil(t, np)
 	require.Equal(t, uint64(len(dataBuffer))*uint64(unsafe.Sizeof(dataBuffer[0])), *np)
 	offsetsBuffer := []uint64{0, 5, 10, 14}
-	offsetsPtr := unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(&offsetsBuffer)).Data)
+	offsetsPtr := slicePtr(offsetsBuffer)
 	vnp, err := q.SetOffsetsBufferUnsafe("a", offsetsPtr, 32)
 	require.NoError(t, err)
 	require.NotNil(t, np)
@@ -3510,7 +3505,7 @@ func TestSetOffsetsBufferUnsafe(t *testing.T) {
 	require.NotNil(t, np)
 	require.Equal(t, uint64(len(dataBuffer))*uint64(unsafe.Sizeof(dataBuffer[0])), *np)
 	offsetsBuffer = make([]uint64, 10)
-	offsetsPtr = unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(&offsetsBuffer)).Data)
+	offsetsPtr = slicePtr(offsetsBuffer)
 	vnp, err = q.SetOffsetsBufferUnsafe("a", offsetsPtr, 80)
 	require.NoError(t, err)
 	require.NotNil(t, vnp)
@@ -3524,8 +3519,7 @@ func TestSetOffsetsBufferUnsafe(t *testing.T) {
 	// verify that GetOffsetsBuffer works for buffers passed unsafe
 	storedOffsetsBuffer, err := q.GetOffsetsBuffer("a")
 	require.NoError(t, err)
-	require.Equal(t, uintptr(offsetsPtr),
-		((*reflect.SliceHeader)(unsafe.Pointer(&storedOffsetsBuffer)).Data))
+	require.Equal(t, offsetsPtr, slicePtr(storedOffsetsBuffer))
 }
 
 func TestGetOffsetsBuffer(t *testing.T) {
@@ -3568,8 +3562,7 @@ func TestGetOffsetsBuffer(t *testing.T) {
 
 	storedOffsetsBuffer, err := q.GetOffsetsBuffer("a")
 	require.NoError(t, err)
-	require.Equal(t, ((*reflect.SliceHeader)(unsafe.Pointer(&offsetsBuffer)).Data),
-		((*reflect.SliceHeader)(unsafe.Pointer(&storedOffsetsBuffer)).Data))
+	require.Equal(t, slicePtr(offsetsBuffer), slicePtr(storedOffsetsBuffer))
 }
 
 func TestSetOffsetsBuffer(t *testing.T) {

--- a/reflection.go
+++ b/reflection.go
@@ -15,16 +15,19 @@ func datatypeOfDimensionFromIndex(arr *Array, dimIdx uint32) (Datatype, bool, er
 	if err != nil {
 		return Datatype(0), false, err
 	}
+	defer schema.Free()
 
 	domain, err := schema.Domain()
 	if err != nil {
 		return Datatype(0), false, err
 	}
+	defer domain.Free()
 
 	dimension, err := domain.DimensionFromIndex(uint(dimIdx))
 	if err != nil {
 		return Datatype(0), false, err
 	}
+	defer dimension.Free()
 
 	datatype, err := dimension.Type()
 	if err != nil {


### PR DESCRIPTION
This fixes ASAN failures seen on CI, it looks like they were due to missing calls to `Free()` either in the example code or internal definitions.

If this looks correct I can follow up and look for similar errors. At the moment this only fixes those reported by `build_with_sanitizer_and_run.sh` so ASAN CI should pass now, but I would expect there's other similar errors that are not covered by the examples.