### PR TITLE
Make various improvements to our GitHub workflow

### DIFF
--- a/.github/scripts/install_tiledb_macos.sh
+++ b/.github/scripts/install_tiledb_macos.sh
@@ -1,3 +1,3 @@
 set -e -x
-curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/${CORE_VERSION}/tiledb-macos-x86_64-${CORE_VERSION}-${CORE_HASH}.tar.gz \
+curl --location -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/${CORE_VERSION}/tiledb-macos-arm64-${CORE_VERSION}-${CORE_HASH}.tar.gz \
 && sudo tar -C /usr/local -xSf tiledb.tar.gz

--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -60,16 +60,6 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
     - name: Install dependencies
       run: go get -t .
 
@@ -103,16 +93,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
-
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/Library/Caches/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
 
     - name: Install dependencies
       run: go get -t .
@@ -149,17 +129,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
-
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-asan
-        restore-keys: |
-          ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          ${{ runner.os }}-go-
 
     - name: Install dependencies
       run: go get -t .

--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     # Install TileDB because the linter needs the C header files.
@@ -33,7 +33,7 @@ jobs:
         version: latest
 
   Linux_Test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         # Will be checking following versions
@@ -78,7 +78,7 @@ jobs:
       run: go test -v ./...
 
   Macos_Test:
-    runs-on: macos-12
+    runs-on: macos-latest
     strategy:
       matrix:
         # Will be checking following versions
@@ -124,7 +124,7 @@ jobs:
   Linux_Address_Sanitizer:
     # Only run this job for releases
     if: github.event_name == 'release' && github.event.action == 'published'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         # Will be checking following versions

--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -99,6 +99,9 @@ jobs:
 
     # Tests TileDB-Go
     - name: Test TileDB-Go
+      # We need to explicitly pass the path to libtiledb.dylib to Go because of
+      # changes in recent macOS versions:
+      # https://github.com/golang/go/issues/36572#issuecomment-817205746
       run: CGO_LDFLAGS="-Wl,-rpath,/usr/local/lib" go test -v ./...
 
   Linux_Address_Sanitizer:

--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -99,7 +99,7 @@ jobs:
 
     # Tests TileDB-Go
     - name: Test TileDB-Go
-      run: go test -v ./...
+      run: CGO_LDFLAGS="-Wl,-rpath,/usr/local/lib" go test -v ./...
 
   Linux_Address_Sanitizer:
     # Only run this job for releases

--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.20", "1.21", "1.22"]
+        go: ["1.20", "1.21", "1.22", "1.23"]
     steps:
 
     # Checks out repository
@@ -82,7 +82,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.20", "1.21", "1.22"]
+        go: ["1.20", "1.21", "1.22", "1.23"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v2
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.20", "1.21", "1.22"]
+        go: ["1.20", "1.21", "1.22", "1.23"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v2

--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
 
     # Checks out repository
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # Log details for the runner. Useful for debugging
     - name: Run lscpu for runner details
@@ -56,12 +56,12 @@ jobs:
     # Following action sets up Go and uses the strategy matrix to test on
     # specific versions
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/go-build
@@ -85,7 +85,7 @@ jobs:
         go: ["1.20", "1.21", "1.22", "1.23"]
     steps:
     # Checks out repository
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # Log details for the runner. Useful for debugging
     - name: Run sysctl for runner details
@@ -100,12 +100,12 @@ jobs:
     # Following action sets up Go and uses the strategy matrix to test on
     # specific versions
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/Library/Caches/go-build
@@ -131,7 +131,7 @@ jobs:
         go: ["1.20", "1.21", "1.22", "1.23"]
     steps:
     # Checks out repository
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # Log details for the runner. Useful for debugging
     - name: Run lscpu for runner details
@@ -146,12 +146,12 @@ jobs:
     # Following action sets up Go and uses the strategy matrix to test on
     # specific versions
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/go-build


### PR DESCRIPTION
In particular:
* Test Go 1.23.
* Use the latest version for our Ubuntu and macOS runners.
* Remove the cache action as it's no longer needed.
* A few fixes for the test to run on new macOS instances.

I recommend reviewing the PR commit by commit.