### PR TITLE
Update to TileDB 2.26.0

### DIFF
--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -10,9 +10,9 @@ on:
 
 env:
   # The version of TileDB to test against.
-  CORE_VERSION: "2.25.0"
+  CORE_VERSION: "2.26.0"
   # The abbreviated git commit hash to use.
-  CORE_HASH: "bbcbd3f"
+  CORE_HASH: "983b716"
 
 jobs:
   golangci:

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ as such the below table reference which versions are compatible.
 | 0.29.0            | 2.23.X         |
 | 0.30.0            | 2.24.X         |
 | 0.31.0            | 2.25.X         |
+| 0.32.0            | 2.26.X         |
 
 
 ## Deprecated Functionality


### PR DESCRIPTION
Update to the latest TileDB release.