### PR TITLE
Update CI to use 2.26.1

### DIFF
--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -10,9 +10,9 @@ on:
 
 env:
   # The version of TileDB to test against.
-  CORE_VERSION: "2.26.0"
+  CORE_VERSION: "2.26.1"
   # The abbreviated git commit hash to use.
-  CORE_HASH: "983b716"
+  CORE_HASH: "db1cee4"
 
 jobs:
   golangci:


### PR DESCRIPTION
Update the TileDB core release for CI