### PR TITLE
Replace individual accounts with team.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Use for automatic reviewer tagging. (anyone with merge rights is encouraged
 # to review and approve PRs they understand)
-*   @NullHypothesis @ypatia @shaunrd0 @snagles
+* @TileDB-Inc/tiledb-cloud-core


### PR DESCRIPTION
Going forward, this will allow for more consistent reviewer management.