### PR TITLE
Return an error if the buffer is too large.

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -8,6 +8,7 @@ import "C"
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"runtime"
 	"unsafe"
 )
@@ -148,6 +149,10 @@ func (b *Buffer) dataCopy() ([]byte, error) {
 		// Since this buffer is TileDB-managed, make sure it's not GC'd before we're
 		// done with its memory.
 		defer runtime.KeepAlive(b)
+
+		if csize > math.MaxInt32 {
+			return nil, fmt.Errorf("TileDB's buffer (%d) larger than maximum allowed CGo buffer (%d)", csize, math.MaxInt32)
+		}
 		return C.GoBytes(cbuffer, C.int(csize)), nil
 	}
 


### PR DESCRIPTION
So far, we would cast a uint64 to a int32 but that may result in an integer overflow. At this point, GoBytes does not seem to support buffers this large, so the next best thing to do is return an error if the given buffer is too large.

---

According to the test below, this check works correctly. I'd rather not add this (or a similar) test because it relies on allocating a 2 GiB buffer.
```go
func TestBufferOverflow(t *testing.T) {
        context, err := NewContext(nil)
        require.NoError(t, err)
        buffer, err := NewBuffer(context)
        require.NoError(t, err)

        require.NoError(t, buffer.SetBuffer(make([]byte, math.MaxInt32+10)))
        buffer.data = nil
        c, err := buffer.dataCopy()
        t.Logf("buf len: %d", len(c))
        t.Log(err)
}
```