### PR TITLE
Update to TileDB 2.27.0.

### DIFF
--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -10,9 +10,9 @@ on:
 
 env:
   # The version of TileDB to test against.
-  CORE_VERSION: "2.26.1"
+  CORE_VERSION: "2.27.0"
   # The abbreviated git commit hash to use.
-  CORE_HASH: "db1cee4"
+  CORE_HASH: "2862c30"
 
 jobs:
   golangci:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ as such the below table reference which versions are compatible.
 | 0.30.0            | 2.24.X         |
 | 0.31.0            | 2.25.X         |
 | 0.32.0            | 2.26.X         |
+| 0.33.0            | 2.26.X         |
+| 0.34.0            | 2.27.X         |
 
 
 ## Deprecated Functionality


### PR DESCRIPTION
This updates TileDB-Go to use the latest TileDB 2.27.0