### PR TITLE
Improve error reporting et al.

### DIFF
--- a/array.go
+++ b/array.go
@@ -242,7 +242,7 @@ func (a *Array) Vacuum(config *Config) error {
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_array_vacuum(a.context.tiledbContext, curi, config.tiledbConfig)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error vacuumimg tiledb array: %w", a.context.LastError())
+		return fmt.Errorf("error vacuuming tiledb array: %w", a.context.LastError())
 	}
 
 	runtime.KeepAlive(config)
@@ -1016,7 +1016,7 @@ func (a *Array) GetMetadata(key string) (Datatype, uint, interface{}, error) {
 	datatype := Datatype(cType)
 	value, err := datatype.GetValue(valueNum, cvalue)
 	if err != nil {
-		return 0, 0, nil, fmt.Errorf("%w, key: %s", err, key)
+		return 0, 0, nil, fmt.Errorf("error getting metadata from array: %w, key: %s", err, key)
 	}
 
 	return datatype, valueNum, value, nil

--- a/array_schema.go
+++ b/array_schema.go
@@ -32,7 +32,7 @@ type ArraySchema struct {
 func (a *ArraySchema) MarshalJSON() ([]byte, error) {
 	bs, err := SerializeArraySchema(a, TILEDB_JSON, false)
 	if err != nil {
-		return nil, fmt.Errorf("Error marshaling json for array schema: %s", a.context.LastError())
+		return nil, fmt.Errorf("error marshaling json for array schema: %w", a.context.LastError())
 	}
 	return bs, nil
 }
@@ -67,11 +67,11 @@ func (a *ArraySchema) UnmarshalJSON(b []byte) error {
 	// Wrap the input byte slice in a Buffer (does not copy)
 	buffer, err := NewBuffer(a.context)
 	if err != nil {
-		return fmt.Errorf("Error unmarshaling json for array schema: %s", a.context.LastError())
+		return fmt.Errorf("error unmarshaling json for array schema: %w", a.context.LastError())
 	}
 	err = buffer.SetBuffer(bytesWithNullTerminator)
 	if err != nil {
-		return fmt.Errorf("Error unmarshaling json for array schema: %s", a.context.LastError())
+		return fmt.Errorf("error unmarshaling json for array schema: %w", a.context.LastError())
 	}
 
 	// Deserialize into a new array schema
@@ -79,7 +79,7 @@ func (a *ArraySchema) UnmarshalJSON(b []byte) error {
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
 	ret := C.tiledb_deserialize_array_schema(a.context.tiledbContext, buffer.tiledbBuffer, C.TILEDB_JSON, cClientSide, &newCSchema)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error deserializing array schema: %s", a.context.LastError())
+		return fmt.Errorf("error deserializing array schema: %w", a.context.LastError())
 	}
 
 	// Replace the C schema object with the deserialized one.
@@ -96,7 +96,7 @@ func NewArraySchema(tdbCtx *Context, arrayType ArrayType) (*ArraySchema, error) 
 	arraySchema := ArraySchema{context: tdbCtx}
 	ret := C.tiledb_array_schema_alloc(arraySchema.context.tiledbContext, C.tiledb_array_type_t(arrayType), &arraySchema.tiledbArraySchema)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error creating tiledb arraySchema: %s", arraySchema.context.LastError())
+		return nil, fmt.Errorf("error creating tiledb arraySchema: %w", arraySchema.context.LastError())
 	}
 	freeOnGC(&arraySchema)
 	return &arraySchema, nil
@@ -118,7 +118,7 @@ func (a *ArraySchema) AddAttributes(attributes ...*Attribute) error {
 	for _, attribute := range attributes {
 		ret := C.tiledb_array_schema_add_attribute(a.context.tiledbContext, a.tiledbArraySchema, attribute.tiledbAttribute)
 		if ret != C.TILEDB_OK {
-			return fmt.Errorf("Error adding attributes to tiledb arraySchema: %s", a.context.LastError())
+			return fmt.Errorf("error adding attributes to tiledb arraySchema: %w", a.context.LastError())
 		}
 	}
 	return nil
@@ -129,7 +129,7 @@ func (a *ArraySchema) AttributeNum() (uint, error) {
 	var attrNum C.uint32_t
 	ret := C.tiledb_array_schema_get_attribute_num(a.context.tiledbContext, a.tiledbArraySchema, &attrNum)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting attribute number for tiledb arraySchema: %s", a.context.LastError())
+		return 0, fmt.Errorf("error getting attribute number for tiledb arraySchema: %w", a.context.LastError())
 	}
 	return uint(attrNum), nil
 }
@@ -143,7 +143,7 @@ func (a *ArraySchema) AttributeFromIndex(index uint) (*Attribute, error) {
 		C.uint32_t(index),
 		&attr.tiledbAttribute)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting attribute %d for tiledb arraySchema: %s", index, a.context.LastError())
+		return nil, fmt.Errorf("error getting attribute %d for tiledb arraySchema: %w", index, a.context.LastError())
 	}
 	freeOnGC(&attr)
 	return &attr, nil
@@ -158,7 +158,7 @@ func (a *ArraySchema) AttributeFromName(attrName string) (*Attribute, error) {
 	attr := Attribute{context: a.context}
 	ret := C.tiledb_array_schema_get_attribute_from_name(a.context.tiledbContext, a.tiledbArraySchema, cAttrName, &attr.tiledbAttribute)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting attribute %s for tiledb arraySchema: %s", attrName, a.context.LastError())
+		return nil, fmt.Errorf("error getting attribute %s for tiledb arraySchema: %w", attrName, a.context.LastError())
 	}
 	freeOnGC(&attr)
 	return &attr, nil
@@ -171,7 +171,7 @@ func (a *ArraySchema) HasAttribute(attrName string) (bool, error) {
 	defer C.free(unsafe.Pointer(cAttrName))
 	ret := C.tiledb_array_schema_has_attribute(a.context.tiledbContext, a.tiledbArraySchema, cAttrName, &hasAttr)
 	if ret != C.TILEDB_OK {
-		return false, fmt.Errorf("Error finding attribute %s in schema: %s", attrName, a.context.LastError())
+		return false, fmt.Errorf("error finding attribute %s in schema: %w", attrName, a.context.LastError())
 	}
 
 	if hasAttr == 0 {
@@ -193,7 +193,7 @@ func (a *ArraySchema) SetAllowsDups(allowsDups bool) error {
 	ret := C.tiledb_array_schema_set_allows_dups(a.context.tiledbContext, a.tiledbArraySchema, C.int32_t(allowsDupsInt))
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting allows dups for schema: %s", a.context.LastError())
+		return fmt.Errorf("error setting allows dups for schema: %w", a.context.LastError())
 	}
 
 	return nil
@@ -205,7 +205,7 @@ func (a *ArraySchema) AllowsDups() (bool, error) {
 	var allowsDups C.int32_t
 	ret := C.tiledb_array_schema_get_allows_dups(a.context.tiledbContext, a.tiledbArraySchema, &allowsDups)
 	if ret != C.TILEDB_OK {
-		return false, fmt.Errorf("Error getting allows dups for schema: %s", a.context.LastError())
+		return false, fmt.Errorf("error getting allows dups for schema: %w", a.context.LastError())
 	}
 
 	if allowsDups == 0 {
@@ -221,13 +221,13 @@ func (a *ArraySchema) Attributes() ([]*Attribute, error) {
 
 	attrNum, err := a.AttributeNum()
 	if err != nil {
-		return nil, fmt.Errorf("Error getting AttributeNum: %s", err)
+		return nil, fmt.Errorf("error getting AttributeNum: %w", err)
 	}
 
 	for i := uint(0); i < attrNum; i++ {
 		attribute, err := a.AttributeFromIndex(i)
 		if err != nil {
-			return nil, fmt.Errorf("Error getting Attribute: %s", err)
+			return nil, fmt.Errorf("error getting Attribute: %w", err)
 		}
 		attributes = append(attributes, attribute)
 	}
@@ -238,7 +238,7 @@ func (a *ArraySchema) Attributes() ([]*Attribute, error) {
 func (a *ArraySchema) SetDomain(domain *Domain) error {
 	ret := C.tiledb_array_schema_set_domain(a.context.tiledbContext, a.tiledbArraySchema, domain.tiledbDomain)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting domain for tiledb arraySchema: %s", a.context.LastError())
+		return fmt.Errorf("error setting domain for tiledb arraySchema: %w", a.context.LastError())
 	}
 	return nil
 }
@@ -248,7 +248,7 @@ func (a *ArraySchema) Domain() (*Domain, error) {
 	domain := Domain{context: a.context}
 	ret := C.tiledb_array_schema_get_domain(a.context.tiledbContext, a.tiledbArraySchema, &domain.tiledbDomain)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error setting domain for tiledb arraySchema: %s", a.context.LastError())
+		return nil, fmt.Errorf("error setting domain for tiledb arraySchema: %w", a.context.LastError())
 	}
 	freeOnGC(&domain)
 	return &domain, nil
@@ -258,7 +258,7 @@ func (a *ArraySchema) Domain() (*Domain, error) {
 func (a *ArraySchema) SetCapacity(capacity uint64) error {
 	ret := C.tiledb_array_schema_set_capacity(a.context.tiledbContext, a.tiledbArraySchema, C.uint64_t(capacity))
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting capacity for tiledb arraySchema: %s", a.context.LastError())
+		return fmt.Errorf("error setting capacity for tiledb arraySchema: %w", a.context.LastError())
 	}
 	return nil
 }
@@ -268,7 +268,7 @@ func (a *ArraySchema) Capacity() (uint64, error) {
 	var capacity C.uint64_t
 	ret := C.tiledb_array_schema_get_capacity(a.context.tiledbContext, a.tiledbArraySchema, &capacity)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting capacity for tiledb arraySchema: %s", a.context.LastError())
+		return 0, fmt.Errorf("error getting capacity for tiledb arraySchema: %w", a.context.LastError())
 	}
 	return uint64(capacity), nil
 }
@@ -277,7 +277,7 @@ func (a *ArraySchema) Capacity() (uint64, error) {
 func (a *ArraySchema) SetCellOrder(cellOrder Layout) error {
 	ret := C.tiledb_array_schema_set_cell_order(a.context.tiledbContext, a.tiledbArraySchema, C.tiledb_layout_t(cellOrder))
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting cell order for tiledb arraySchema: %s", a.context.LastError())
+		return fmt.Errorf("error setting cell order for tiledb arraySchema: %w", a.context.LastError())
 	}
 	return nil
 }
@@ -287,7 +287,7 @@ func (a *ArraySchema) CellOrder() (Layout, error) {
 	var cellOrder C.tiledb_layout_t
 	ret := C.tiledb_array_schema_get_cell_order(a.context.tiledbContext, a.tiledbArraySchema, &cellOrder)
 	if ret != C.TILEDB_OK {
-		return -1, fmt.Errorf("Error getting cell order for tiledb arraySchema: %s", a.context.LastError())
+		return -1, fmt.Errorf("error getting cell order for tiledb arraySchema: %w", a.context.LastError())
 	}
 	return Layout(cellOrder), nil
 }
@@ -296,7 +296,7 @@ func (a *ArraySchema) CellOrder() (Layout, error) {
 func (a *ArraySchema) SetTileOrder(tileOrder Layout) error {
 	ret := C.tiledb_array_schema_set_tile_order(a.context.tiledbContext, a.tiledbArraySchema, C.tiledb_layout_t(tileOrder))
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting cell order for tiledb arraySchema: %s", a.context.LastError())
+		return fmt.Errorf("error setting cell order for tiledb arraySchema: %w", a.context.LastError())
 	}
 	return nil
 }
@@ -306,7 +306,7 @@ func (a *ArraySchema) TileOrder() (Layout, error) {
 	var cellOrder C.tiledb_layout_t
 	ret := C.tiledb_array_schema_get_tile_order(a.context.tiledbContext, a.tiledbArraySchema, &cellOrder)
 	if ret != C.TILEDB_OK {
-		return -1, fmt.Errorf("Error getting cell order for tiledb arraySchema: %s", a.context.LastError())
+		return -1, fmt.Errorf("error getting cell order for tiledb arraySchema: %w", a.context.LastError())
 	}
 	return Layout(cellOrder), nil
 }
@@ -315,7 +315,7 @@ func (a *ArraySchema) TileOrder() (Layout, error) {
 func (a *ArraySchema) SetCoordsFilterList(filterList *FilterList) error {
 	ret := C.tiledb_array_schema_set_coords_filter_list(a.context.tiledbContext, a.tiledbArraySchema, filterList.tiledbFilterList)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting coordinates filter list for tiledb arraySchema: %s", a.context.LastError())
+		return fmt.Errorf("error setting coordinates filter list for tiledb arraySchema: %w", a.context.LastError())
 	}
 	return nil
 }
@@ -325,7 +325,7 @@ func (a *ArraySchema) CoordsFilterList() (*FilterList, error) {
 	filterList := FilterList{context: a.context}
 	ret := C.tiledb_array_schema_get_coords_filter_list(a.context.tiledbContext, a.tiledbArraySchema, &filterList.tiledbFilterList)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting coordinates filter list for tiledb arraySchema: %s", a.context.LastError())
+		return nil, fmt.Errorf("error getting coordinates filter list for tiledb arraySchema: %w", a.context.LastError())
 	}
 	freeOnGC(&filterList)
 	return &filterList, nil
@@ -336,7 +336,7 @@ func (a *ArraySchema) CoordsFilterList() (*FilterList, error) {
 func (a *ArraySchema) SetOffsetsFilterList(filterList *FilterList) error {
 	ret := C.tiledb_array_schema_set_offsets_filter_list(a.context.tiledbContext, a.tiledbArraySchema, filterList.tiledbFilterList)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting offsets filter list for tiledb arraySchema: %s", a.context.LastError())
+		return fmt.Errorf("error setting offsets filter list for tiledb arraySchema: %w", a.context.LastError())
 	}
 	return nil
 }
@@ -347,7 +347,7 @@ func (a *ArraySchema) OffsetsFilterList() (*FilterList, error) {
 	filterList := FilterList{context: a.context}
 	ret := C.tiledb_array_schema_get_offsets_filter_list(a.context.tiledbContext, a.tiledbArraySchema, &filterList.tiledbFilterList)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting offsets filter list for tiledb arraySchema: %s", a.context.LastError())
+		return nil, fmt.Errorf("error getting offsets filter list for tiledb arraySchema: %w", a.context.LastError())
 	}
 	freeOnGC(&filterList)
 	return &filterList, nil
@@ -357,7 +357,7 @@ func (a *ArraySchema) OffsetsFilterList() (*FilterList, error) {
 func (a *ArraySchema) Check() error {
 	ret := C.tiledb_array_schema_check(a.context.tiledbContext, a.tiledbArraySchema)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error in checking arraySchema: %s", a.context.LastError())
+		return fmt.Errorf("error in checking arraySchema: %w", a.context.LastError())
 	}
 	return nil
 }
@@ -369,7 +369,7 @@ func LoadArraySchema(context *Context, path string) (*ArraySchema, error) {
 	a := ArraySchema{context: context}
 	ret := C.tiledb_array_schema_load(a.context.tiledbContext, cpath, &a.tiledbArraySchema)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error in loading arraySchema from %s: %s", path, a.context.LastError())
+		return nil, fmt.Errorf("error in loading arraySchema from %s: %w", path, a.context.LastError())
 	}
 	freeOnGC(&a)
 	return &a, nil
@@ -379,7 +379,7 @@ func LoadArraySchema(context *Context, path string) (*ArraySchema, error) {
 func (a *ArraySchema) DumpSTDOUT() error {
 	ret := C.tiledb_array_schema_dump(a.context.tiledbContext, a.tiledbArraySchema, C.stdout)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error dumping array schema to stdout: %s", a.context.LastError())
+		return fmt.Errorf("error dumping array schema to stdout: %w", a.context.LastError())
 	}
 	return nil
 }
@@ -388,7 +388,7 @@ func (a *ArraySchema) DumpSTDOUT() error {
 func (a *ArraySchema) Dump(path string) error {
 
 	if _, err := os.Stat(path); err == nil {
-		return fmt.Errorf("Error path already %s exists", path)
+		return fmt.Errorf("error path already %s exists", path)
 	}
 
 	// Convert to char *
@@ -406,7 +406,7 @@ func (a *ArraySchema) Dump(path string) error {
 	// Dump array schema to file
 	ret := C.tiledb_array_schema_dump(a.context.tiledbContext, a.tiledbArraySchema, cFile)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error dumping array schema to file %s: %s", path, a.context.LastError())
+		return fmt.Errorf("error dumping array schema to file %s: %w", path, a.context.LastError())
 	}
 	return nil
 }
@@ -416,7 +416,7 @@ func (a *ArraySchema) Type() (ArrayType, error) {
 	var arrayType C.tiledb_array_type_t
 	ret := C.tiledb_array_schema_get_array_type(a.context.tiledbContext, a.tiledbArraySchema, &arrayType)
 	if ret != C.TILEDB_OK {
-		return TILEDB_DENSE, fmt.Errorf("Error fetching array schema type: %s", a.context.LastError())
+		return TILEDB_DENSE, fmt.Errorf("error fetching array schema type: %w", a.context.LastError())
 	}
 
 	return ArrayType(arrayType), nil

--- a/array_schema_evolution_experimental.go
+++ b/array_schema_evolution_experimental.go
@@ -24,7 +24,7 @@ func NewArraySchemaEvolution(tdbCtx *Context) (*ArraySchemaEvolution, error) {
 		arraySchemaEvolution.context.tiledbContext,
 		&arraySchemaEvolution.tiledbArraySchemaEvolution)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error creating tiledb arraySchemaEvolution: %s",
+		return nil, fmt.Errorf("error creating tiledb arraySchemaEvolution: %w",
 			arraySchemaEvolution.context.LastError())
 	}
 	freeOnGC(&arraySchemaEvolution)
@@ -60,7 +60,7 @@ func (ase *ArraySchemaEvolution) AddAttribute(attribute *Attribute) error {
 		attribute.tiledbAttribute)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf(
-			"error adding attribute %s to tiledb arraySchemaEvolution: %s",
+			"error adding attribute %s to tiledb arraySchemaEvolution: %w",
 			name, ase.context.LastError())
 	}
 
@@ -75,7 +75,7 @@ func (ase *ArraySchemaEvolution) DropAttribute(name string) error {
 	ret := C.tiledb_array_schema_evolution_drop_attribute(
 		ase.context.tiledbContext, ase.tiledbArraySchemaEvolution, cname)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error dropping tiledb attribute: %s",
+		return fmt.Errorf("error dropping tiledb attribute: %w",
 			ase.context.LastError())
 	}
 
@@ -90,7 +90,7 @@ func (ase *ArraySchemaEvolution) Evolve(uri string) error {
 	ret := C.tiledb_array_evolve(ase.context.tiledbContext, curi,
 		ase.tiledbArraySchemaEvolution)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error evolving schema for array %s: %s", uri,
+		return fmt.Errorf("error evolving schema for array %s: %w", uri,
 			ase.context.LastError())
 	}
 

--- a/attribute.go
+++ b/attribute.go
@@ -34,7 +34,7 @@ func NewAttribute(context *Context, name string, datatype Datatype) (*Attribute,
 
 	ret := C.tiledb_attribute_alloc(context.tiledbContext, cname, C.tiledb_datatype_t(datatype), &attribute.tiledbAttribute)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error creating tiledb attribute: %s", context.LastError())
+		return nil, fmt.Errorf("error creating tiledb attribute: %w", context.LastError())
 	}
 	freeOnGC(&attribute)
 
@@ -61,7 +61,7 @@ func (a *Attribute) Context() *Context {
 func (a *Attribute) SetFilterList(filterlist *FilterList) error {
 	ret := C.tiledb_attribute_set_filter_list(a.context.tiledbContext, a.tiledbAttribute, filterlist.tiledbFilterList)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting tiledb attribute filter list: %s", a.context.LastError())
+		return fmt.Errorf("error setting tiledb attribute filter list: %w", a.context.LastError())
 	}
 	return nil
 }
@@ -71,7 +71,7 @@ func (a *Attribute) FilterList() (*FilterList, error) {
 	filterList := FilterList{context: a.context}
 	ret := C.tiledb_attribute_get_filter_list(a.context.tiledbContext, a.tiledbAttribute, &filterList.tiledbFilterList)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting tiledb attribute filter list: %s", a.context.LastError())
+		return nil, fmt.Errorf("error getting tiledb attribute filter list: %w", a.context.LastError())
 	}
 	freeOnGC(&filterList)
 
@@ -85,7 +85,7 @@ func (a *Attribute) SetCellValNum(val uint32) error {
 	ret := C.tiledb_attribute_set_cell_val_num(a.context.tiledbContext,
 		a.tiledbAttribute, C.uint32_t(val))
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting tiledb attribute cell val num: %s", a.context.LastError())
+		return fmt.Errorf("error setting tiledb attribute cell val num: %w", a.context.LastError())
 	}
 	return nil
 }
@@ -96,7 +96,7 @@ func (a *Attribute) CellValNum() (uint32, error) {
 	var cellValNum C.uint32_t
 	ret := C.tiledb_attribute_get_cell_val_num(a.context.tiledbContext, a.tiledbAttribute, &cellValNum)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting tiledb attribute cell val num: %s", a.context.LastError())
+		return 0, fmt.Errorf("error getting tiledb attribute cell val num: %w", a.context.LastError())
 	}
 
 	return uint32(cellValNum), nil
@@ -107,7 +107,7 @@ func (a *Attribute) CellSize() (uint64, error) {
 	var cellSize C.uint64_t
 	ret := C.tiledb_attribute_get_cell_size(a.context.tiledbContext, a.tiledbAttribute, &cellSize)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting tiledb attribute cell size: %s", a.context.LastError())
+		return 0, fmt.Errorf("error getting tiledb attribute cell size: %w", a.context.LastError())
 	}
 
 	return uint64(cellSize), nil
@@ -290,17 +290,17 @@ func (a *Attribute) GetFillValue() (interface{}, uint64, error) {
 
 	ret := C.tiledb_attribute_get_fill_value(a.context.tiledbContext, a.tiledbAttribute, &cvalue, &fillValueSize)
 	if ret != C.TILEDB_OK {
-		return nil, 0, fmt.Errorf("Error getting tiledb attribute fill value: %s", a.context.LastError())
+		return nil, 0, fmt.Errorf("error getting tiledb attribute fill value: %w", a.context.LastError())
 	}
 
 	attrDataType, err := a.Type()
 	if err != nil {
-		return nil, 0, fmt.Errorf("Error getting tiledb attribute fill value: %s", a.context.LastError())
+		return nil, 0, fmt.Errorf("error getting tiledb attribute fill value: %w", a.context.LastError())
 	}
 
 	value, err := attrDataType.GetValue(1, cvalue)
 	if err != nil {
-		return nil, 0, fmt.Errorf("Error getting tiledb attribute fill value: %s", a.context.LastError())
+		return nil, 0, fmt.Errorf("error getting tiledb attribute fill value: %w", a.context.LastError())
 	}
 
 	return value, uint64(fillValueSize), nil
@@ -319,17 +319,17 @@ func (a *Attribute) GetFillValueNullable() (interface{}, uint64, bool, error) {
 
 	ret := C.tiledb_attribute_get_fill_value_nullable(a.context.tiledbContext, a.tiledbAttribute, &cvalue, &fillValueSize, &cvalid)
 	if ret != C.TILEDB_OK {
-		return nil, 0, false, fmt.Errorf("Error getting tiledb attribute fill value: %s", a.context.LastError())
+		return nil, 0, false, fmt.Errorf("error getting tiledb attribute fill value: %w", a.context.LastError())
 	}
 
 	attrDataType, err := a.Type()
 	if err != nil {
-		return nil, 0, false, fmt.Errorf("Error getting tiledb attribute fill value: %s", a.context.LastError())
+		return nil, 0, false, fmt.Errorf("error getting tiledb attribute fill value: %w", a.context.LastError())
 	}
 
 	value, err := attrDataType.GetValue(1, cvalue)
 	if err != nil {
-		return nil, 0, false, fmt.Errorf("Error getting tiledb attribute fill value: %s", a.context.LastError())
+		return nil, 0, false, fmt.Errorf("error getting tiledb attribute fill value: %w", a.context.LastError())
 	}
 
 	return value, uint64(fillValueSize), cvalid == 1, nil
@@ -340,7 +340,7 @@ func (a *Attribute) Name() (string, error) {
 	var cName *C.char
 	ret := C.tiledb_attribute_get_name(a.context.tiledbContext, a.tiledbAttribute, &cName)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error getting tiledb attribute name: %s", a.context.LastError())
+		return "", fmt.Errorf("error getting tiledb attribute name: %w", a.context.LastError())
 	}
 
 	return C.GoString(cName), nil
@@ -351,7 +351,7 @@ func (a *Attribute) Type() (Datatype, error) {
 	var attrType C.tiledb_datatype_t
 	ret := C.tiledb_attribute_get_type(a.context.tiledbContext, a.tiledbAttribute, &attrType)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting tiledb attribute type: %s", a.context.LastError())
+		return 0, fmt.Errorf("error getting tiledb attribute type: %w", a.context.LastError())
 	}
 	return Datatype(attrType), nil
 }
@@ -360,7 +360,7 @@ func (a *Attribute) Type() (Datatype, error) {
 func (a *Attribute) DumpSTDOUT() error {
 	ret := C.tiledb_attribute_dump(a.context.tiledbContext, a.tiledbAttribute, C.stdout)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error dumping attribute to stdout: %s", a.context.LastError())
+		return fmt.Errorf("error dumping attribute to stdout: %w", a.context.LastError())
 	}
 	return nil
 }
@@ -369,7 +369,7 @@ func (a *Attribute) DumpSTDOUT() error {
 func (a *Attribute) Dump(path string) error {
 
 	if _, err := os.Stat(path); err == nil {
-		return fmt.Errorf("Error path already %s exists", path)
+		return fmt.Errorf("error path already %s exists", path)
 	}
 
 	// Convert to char *
@@ -387,7 +387,7 @@ func (a *Attribute) Dump(path string) error {
 	// Dump attribute to file
 	ret := C.tiledb_attribute_dump(a.context.tiledbContext, a.tiledbAttribute, cFile)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error dumping attribute to file %s: %s", path, a.context.LastError())
+		return fmt.Errorf("error dumping attribute to file %s: %w", path, a.context.LastError())
 	}
 	return nil
 }
@@ -401,7 +401,7 @@ func (a *Attribute) SetNullable(nullable bool) error {
 	ret := C.tiledb_attribute_set_nullable(a.context.tiledbContext,
 		a.tiledbAttribute, cNullable)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting tiledb attribute nullable: %s", a.context.LastError())
+		return fmt.Errorf("error setting tiledb attribute nullable: %w", a.context.LastError())
 	}
 	return nil
 }
@@ -411,7 +411,7 @@ func (a *Attribute) Nullable() (bool, error) {
 	var nullable C.uint8_t
 	ret := C.tiledb_attribute_get_nullable(a.context.tiledbContext, a.tiledbAttribute, &nullable)
 	if ret != C.TILEDB_OK {
-		return false, fmt.Errorf("Error getting tiledb attribute nullable: %s", a.context.LastError())
+		return false, fmt.Errorf("error getting tiledb attribute nullable: %w", a.context.LastError())
 	}
 
 	return nullable == 1, nil

--- a/buffer.go
+++ b/buffer.go
@@ -45,12 +45,12 @@ func NewBuffer(context *Context) (*Buffer, error) {
 	buffer := Buffer{context: context}
 
 	if buffer.context == nil {
-		return nil, fmt.Errorf("Error creating tiledb buffer, context is nil")
+		return nil, errors.New("error creating tiledb buffer, context is nil")
 	}
 
 	ret := C.tiledb_buffer_alloc(buffer.context.tiledbContext, &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error creating tiledb buffer: %s", buffer.context.LastError())
+		return nil, fmt.Errorf("error creating tiledb buffer: %w", buffer.context.LastError())
 	}
 	freeOnGC(&buffer)
 
@@ -78,7 +78,7 @@ func (b *Buffer) Context() *Context {
 func (b *Buffer) SetType(datatype Datatype) error {
 	ret := C.tiledb_buffer_set_type(b.context.tiledbContext, b.tiledbBuffer, C.tiledb_datatype_t(datatype))
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting datatype for tiledb buffer: %s", b.context.LastError())
+		return fmt.Errorf("error setting datatype for tiledb buffer: %w", b.context.LastError())
 	}
 	return nil
 }
@@ -89,7 +89,7 @@ func (b *Buffer) Type() (Datatype, error) {
 	ret := C.tiledb_buffer_get_type(b.context.tiledbContext, b.tiledbBuffer, &bufferType)
 
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting tiledb buffer type: %s", b.context.LastError())
+		return 0, fmt.Errorf("error getting tiledb buffer type: %w", b.context.LastError())
 	}
 
 	return Datatype(bufferType), nil
@@ -202,7 +202,7 @@ func (b *Buffer) SetBuffer(buffer []byte) error {
 
 	ret := C.tiledb_buffer_set_data(b.context.tiledbContext, b.tiledbBuffer, b.data.start(), C.uint64_t(b.data.lenBytes()))
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting tiledb buffer: %s", b.context.LastError())
+		return fmt.Errorf("error setting tiledb buffer: %w", b.context.LastError())
 	}
 
 	return nil
@@ -215,7 +215,7 @@ func (b *Buffer) dataCopy() ([]byte, error) {
 
 	ret := C.tiledb_buffer_get_data(b.context.tiledbContext, b.tiledbBuffer, &cbuffer, &csize)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting tiledb buffer data: %s", b.context.LastError())
+		return nil, fmt.Errorf("error getting tiledb buffer data: %w", b.context.LastError())
 	}
 
 	if cbuffer == nil {
@@ -253,7 +253,7 @@ func (b *Buffer) Len() (uint64, error) {
 
 	ret := C.tiledb_buffer_get_data(b.context.tiledbContext, b.tiledbBuffer, &cbuffer, &csize)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting tiledb buffer data: %s", b.context.LastError())
+		return 0, fmt.Errorf("error getting tiledb buffer data: %w", b.context.LastError())
 	}
 
 	return uint64(csize), nil

--- a/buffer_list.go
+++ b/buffer_list.go
@@ -22,7 +22,7 @@ func NewBufferList(context *Context) (*BufferList, error) {
 
 	ret := C.tiledb_buffer_list_alloc(bufferList.context.tiledbContext, &bufferList.tiledbBufferList)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error creating tiledb buffer list: %s", bufferList.context.LastError())
+		return nil, fmt.Errorf("error creating tiledb buffer list: %w", bufferList.context.LastError())
 	}
 	freeOnGC(&bufferList)
 
@@ -81,7 +81,7 @@ func (b *BufferList) NumBuffers() (uint64, error) {
 	ret := C.tiledb_buffer_list_get_num_buffers(b.context.tiledbContext, b.tiledbBufferList, &numBuffers)
 
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting tiledb bufferList num buffers: %s", b.context.LastError())
+		return 0, fmt.Errorf("error getting tiledb bufferList num buffers: %w", b.context.LastError())
 	}
 
 	return uint64(numBuffers), nil
@@ -94,7 +94,7 @@ func (b *BufferList) GetBuffer(bufferIndex uint) (*Buffer, error) {
 
 	ret := C.tiledb_buffer_list_get_buffer(b.context.tiledbContext, b.tiledbBufferList, C.uint64_t(bufferIndex), &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting tiledb buffer index %d from buffer list: %s", bufferIndex, b.context.LastError())
+		return nil, fmt.Errorf("error getting tiledb buffer index %d from buffer list: %w", bufferIndex, b.context.LastError())
 	}
 
 	return &buffer, nil
@@ -106,7 +106,7 @@ func (b *BufferList) TotalSize() (uint64, error) {
 	ret := C.tiledb_buffer_list_get_total_size(b.context.tiledbContext, b.tiledbBufferList, &totalSize)
 
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting tiledb bufferList num buffers: %s", b.context.LastError())
+		return 0, fmt.Errorf("error getting tiledb bufferList num buffers: %w", b.context.LastError())
 	}
 
 	return uint64(totalSize), nil
@@ -122,7 +122,7 @@ func (b *BufferList) Flatten() (*Buffer, error) {
 	ret := C.tiledb_buffer_list_flatten(b.context.tiledbContext, b.tiledbBufferList, &buffer.tiledbBuffer)
 
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting tiledb bufferList num buffers: %s", b.context.LastError())
+		return nil, fmt.Errorf("error getting tiledb bufferList num buffers: %w", b.context.LastError())
 	}
 
 	return &buffer, nil

--- a/common.go
+++ b/common.go
@@ -1,10 +1,12 @@
 package tiledb
 
 /*
+#include <tiledb/tiledb.h>
 #include <stdlib.h>
 */
 import "C"
 import (
+	"errors"
 	"unsafe"
 )
 
@@ -36,4 +38,20 @@ func cStringArray(stringList []string) ([]*C.char, func()) {
 			C.free(unsafe.Pointer(str))
 		}
 	}
+}
+
+// cError creates an error value from a TileDB error.
+func cError(err *C.tiledb_error_t) error {
+	var str *C.char
+	var msg string
+
+	switch C.tiledb_error_message(err, &str) {
+	case C.TILEDB_OK:
+		msg = C.GoString(str)
+	case C.TILEDB_OOM:
+		msg = "out of memory error while retrieving message"
+	default:
+		msg = "could not retrieve error"
+	}
+	return errors.New(msg)
 }

--- a/common.go
+++ b/common.go
@@ -49,7 +49,7 @@ func cError(err *C.tiledb_error_t) error {
 	case C.TILEDB_OK:
 		msg = C.GoString(str)
 	case C.TILEDB_OOM:
-		msg = "out of memory error while retrieving message"
+		msg = "out of memory error while retrieving TileDB error message"
 	default:
 		msg = "could not retrieve error"
 	}

--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ package tiledb
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 )
@@ -109,7 +110,7 @@ func (c *Config) SaveToFile(file string) error {
 func LoadConfig(uri string) (*Config, error) {
 
 	if uri == "" {
-		return nil, fmt.Errorf("error loading tiledb config: passed uri is empty")
+		return nil, errors.New("error loading tiledb config: passed uri is empty")
 	}
 
 	var config Config

--- a/config.go
+++ b/config.go
@@ -23,10 +23,8 @@ func NewConfig() (*Config, error) {
 	var err *C.tiledb_error_t
 	C.tiledb_config_alloc(&config.tiledbConfig, &err)
 	if err != nil {
-		var msg *C.char
-		C.tiledb_error_message(err, &msg)
 		defer C.tiledb_error_free(&err)
-		return nil, fmt.Errorf("error creating tiledb config: %s", C.GoString(msg))
+		return nil, fmt.Errorf("error creating tiledb config: %w", cError(err))
 	}
 	freeOnGC(&config)
 
@@ -43,10 +41,8 @@ func (c *Config) Set(param string, value string) error {
 	C.tiledb_config_set(c.tiledbConfig, cparam, cvalue, &err)
 
 	if err != nil {
-		var msg *C.char
-		C.tiledb_error_message(err, &msg)
 		defer C.tiledb_error_free(&err)
-		return fmt.Errorf("error setting %s:%s in config: %s", param, value, C.GoString(msg))
+		return fmt.Errorf("error setting %s:%s in config: %w", param, value, cError(err))
 	}
 
 	return nil
@@ -61,10 +57,8 @@ func (c *Config) Get(param string) (string, error) {
 	C.tiledb_config_get(c.tiledbConfig, cparam, &val, &err)
 
 	if err != nil {
-		var msg *C.char
-		C.tiledb_error_message(err, &msg)
 		defer C.tiledb_error_free(&err)
-		return "", fmt.Errorf("error getting %s in config: %s", param, C.GoString(msg))
+		return "", fmt.Errorf("error getting %s in config: %w", param, cError(err))
 	}
 
 	value := C.GoString(val)
@@ -80,10 +74,8 @@ func (c *Config) Unset(param string) error {
 	C.tiledb_config_unset(c.tiledbConfig, cparam, &err)
 
 	if err != nil {
-		var msg *C.char
-		C.tiledb_error_message(err, &msg)
 		defer C.tiledb_error_free(&err)
-		return fmt.Errorf("error unsetting %s in config: %s", param, C.GoString(msg))
+		return fmt.Errorf("error unsetting %s in config: %w", param, cError(err))
 	}
 
 	return nil
@@ -97,10 +89,8 @@ func (c *Config) SaveToFile(file string) error {
 	C.tiledb_config_save_to_file(c.tiledbConfig, cfile, &err)
 
 	if err != nil {
-		var msg *C.char
-		C.tiledb_error_message(err, &msg)
 		defer C.tiledb_error_free(&err)
-		return fmt.Errorf("error saving config from file %s: %s", file, C.GoString(msg))
+		return fmt.Errorf("error saving config from file %s: %w", file, cError(err))
 	}
 
 	return nil
@@ -117,20 +107,16 @@ func LoadConfig(uri string) (*Config, error) {
 	var err *C.tiledb_error_t
 	C.tiledb_config_alloc(&config.tiledbConfig, &err)
 	if err != nil {
-		var msg *C.char
-		C.tiledb_error_message(err, &msg)
 		defer C.tiledb_error_free(&err)
-		return nil, fmt.Errorf("error loading tiledb config: %s", C.GoString(msg))
+		return nil, fmt.Errorf("error loading tiledb config: %w", cError(err))
 	}
 
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	C.tiledb_config_load_from_file(config.tiledbConfig, curi, &err)
 	if err != nil {
-		var msg *C.char
-		C.tiledb_error_message(err, &msg)
 		defer C.tiledb_error_free(&err)
-		return nil, fmt.Errorf("error loading config from file %s: %s", uri, C.GoString(msg))
+		return nil, fmt.Errorf("error loading config from file %s: %w", uri, cError(err))
 	}
 	freeOnGC(&config)
 

--- a/config_iter.go
+++ b/config_iter.go
@@ -53,7 +53,7 @@ func (ci *ConfigIter) Here() (*string, *string, error) {
 	C.tiledb_config_iter_here(ci.tiledbConfigIter, &cparam, &cvalue, &err)
 	if err != nil {
 		defer C.tiledb_error_free(&err)
-		return nil, nil, fmt.Errorf("error getting param, vakue from config iter: %w", cError(err))
+		return nil, nil, fmt.Errorf("error getting param, value from config iter: %w", cError(err))
 	}
 	param := C.GoString(cparam)
 	value := C.GoString(cvalue)

--- a/config_iter.go
+++ b/config_iter.go
@@ -26,10 +26,8 @@ func NewConfigIter(config *Config, prefix string) (*ConfigIter, error) {
 	defer C.free(unsafe.Pointer(cprefix))
 	C.tiledb_config_iter_alloc(config.tiledbConfig, cprefix, &ci.tiledbConfigIter, &err)
 	if err != nil {
-		var msg *C.char
-		C.tiledb_error_message(err, &msg)
 		defer C.tiledb_error_free(&err)
-		return nil, fmt.Errorf("error creating tiledb config iter: %s", C.GoString(msg))
+		return nil, fmt.Errorf("error creating tiledb config iter: %w", cError(err))
 	}
 	freeOnGC(&ci)
 
@@ -54,10 +52,8 @@ func (ci *ConfigIter) Here() (*string, *string, error) {
 	var cparam, cvalue *C.char
 	C.tiledb_config_iter_here(ci.tiledbConfigIter, &cparam, &cvalue, &err)
 	if err != nil {
-		var msg *C.char
-		C.tiledb_error_message(err, &msg)
 		defer C.tiledb_error_free(&err)
-		return nil, nil, fmt.Errorf("error getting param, vakue from config iter: %s", C.GoString(msg))
+		return nil, nil, fmt.Errorf("error getting param, vakue from config iter: %w", cError(err))
 	}
 	param := C.GoString(cparam)
 	value := C.GoString(cvalue)
@@ -69,10 +65,8 @@ func (ci *ConfigIter) Next() error {
 	var err *C.tiledb_error_t
 	C.tiledb_config_iter_next(ci.tiledbConfigIter, &err)
 	if err != nil {
-		var msg *C.char
-		C.tiledb_error_message(err, &msg)
 		defer C.tiledb_error_free(&err)
-		return fmt.Errorf("error moving to next ConfigItem from iter: %s", C.GoString(msg))
+		return fmt.Errorf("error moving to next ConfigItem from iter: %w", cError(err))
 	}
 	return nil
 }
@@ -83,10 +77,8 @@ func (ci *ConfigIter) Done() (bool, error) {
 	var cDone C.int32_t
 	C.tiledb_config_iter_done(ci.tiledbConfigIter, &cDone, &err)
 	if err != nil {
-		var msg *C.char
-		C.tiledb_error_message(err, &msg)
 		defer C.tiledb_error_free(&err)
-		return false, fmt.Errorf("error moving to next ConfigItem from iter: %s", C.GoString(msg))
+		return false, fmt.Errorf("error moving to next ConfigItem from iter: %w", cError(err))
 	}
 	return int(cDone) == 1, nil
 }
@@ -97,9 +89,7 @@ func (ci *ConfigIter) IsDone() bool {
 	var cDone C.int32_t
 	C.tiledb_config_iter_done(ci.tiledbConfigIter, &cDone, &err)
 	if err != nil {
-		var msg *C.char
-		C.tiledb_error_message(err, &msg)
-		defer C.tiledb_error_free(&err)
+		C.tiledb_error_free(&err)
 		return false
 	}
 	return int(cDone) == 1
@@ -112,10 +102,8 @@ func (ci *ConfigIter) Reset(prefix string) error {
 	defer C.free(unsafe.Pointer(cprefix))
 	C.tiledb_config_iter_reset(ci.config.tiledbConfig, ci.tiledbConfigIter, cprefix, &err)
 	if err != nil {
-		var msg *C.char
-		C.tiledb_error_message(err, &msg)
 		defer C.tiledb_error_free(&err)
-		return fmt.Errorf("error creating tiledb config iter: %s", C.GoString(msg))
+		return fmt.Errorf("error creating tiledb config iter: %w", cError(err))
 	}
 	return nil
 }

--- a/context.go
+++ b/context.go
@@ -116,16 +116,8 @@ func (c *Context) LastError() error {
 	}
 
 	if err != nil {
-		var msg *C.char
 		defer C.tiledb_error_free(&err)
-		ret := C.tiledb_error_message(err, &msg)
-		if ret == C.TILEDB_OOM {
-			return errors.New("out of Memory error in tiledb_error_message")
-		} else if ret != C.TILEDB_OK {
-			return errors.New("unknown error in tiledb_error_message")
-		}
-
-		return errors.New(C.GoString(msg))
+		return cError(err)
 	}
 	return nil
 }

--- a/context.go
+++ b/context.go
@@ -96,9 +96,9 @@ func (c *Context) Config() (*Config, error) {
 	ret := C.tiledb_ctx_get_config(c.tiledbContext, &config.tiledbConfig)
 
 	if ret == C.TILEDB_OOM {
-		return nil, fmt.Errorf("Out of Memory error in GetConfig")
+		return nil, errors.New("out of Memory error in GetConfig")
 	} else if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Unknown error in GetConfig")
+		return nil, errors.New("unknown error in GetConfig")
 	}
 	freeOnGC(&config)
 
@@ -110,9 +110,9 @@ func (c *Context) LastError() error {
 	var err *C.tiledb_error_t
 	ret := C.tiledb_ctx_get_last_error(c.tiledbContext, &err)
 	if ret == C.TILEDB_OOM {
-		return fmt.Errorf("Out of Memory error in tiledb_ctx_get_last_error")
+		return errors.New("out of Memory error in tiledb_ctx_get_last_error")
 	} else if ret != C.TILEDB_OK {
-		return fmt.Errorf("Unknown error in tiledb_ctx_get_last_error")
+		return errors.New("unknown error in tiledb_ctx_get_last_error")
 	}
 
 	if err != nil {
@@ -120,12 +120,12 @@ func (c *Context) LastError() error {
 		defer C.tiledb_error_free(&err)
 		ret := C.tiledb_error_message(err, &msg)
 		if ret == C.TILEDB_OOM {
-			return fmt.Errorf("Out of Memory error in tiledb_error_message")
+			return errors.New("out of Memory error in tiledb_error_message")
 		} else if ret != C.TILEDB_OK {
-			return fmt.Errorf("Unknown error in tiledb_error_message")
+			return errors.New("unknown error in tiledb_error_message")
 		}
 
-		return fmt.Errorf("%s", C.GoString(msg))
+		return errors.New(C.GoString(msg))
 	}
 	return nil
 }
@@ -136,7 +136,7 @@ func (c *Context) IsSupportedFS(fs FS) (bool, error) {
 	ret := C.tiledb_ctx_is_supported_fs(c.tiledbContext, C.tiledb_filesystem_t(fs), &isSupported)
 
 	if ret != C.TILEDB_OK {
-		return false, fmt.Errorf("Error in checking FS support")
+		return false, errors.New("error in checking FS support")
 	}
 
 	if isSupported == 0 {
@@ -156,7 +156,7 @@ func (c *Context) SetTag(key string, value string) error {
 	ret := C.tiledb_ctx_set_tag(c.tiledbContext, ckey, cvalue)
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error in setting tag")
+		return fmt.Errorf("error in setting tag: %w", c.LastError())
 	}
 
 	return nil
@@ -185,12 +185,12 @@ func (c *Context) setDefaultTags() error {
 func (c *Context) Stats() ([]byte, error) {
 	var stats *C.char
 	if ret := C.tiledb_ctx_get_stats(c.tiledbContext, &stats); ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting stats from context: %w", c.LastError())
+		return nil, fmt.Errorf("error getting stats from context: %w", c.LastError())
 	}
 
 	s := C.GoString(stats)
 	if ret := C.tiledb_stats_free_str(&stats); ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error freeing string from dumping stats to string")
+		return nil, errors.New("error freeing string from dumping stats to string")
 	}
 
 	if s == "" {

--- a/dimension.go
+++ b/dimension.go
@@ -30,12 +30,12 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 	defer C.free(unsafe.Pointer(cname))
 
 	if reflect.TypeOf(domain).Kind() != reflect.Slice {
-		return nil, fmt.Errorf("Domain passed must be a slice of two integers or two floats, type passed was: %s", reflect.TypeOf(domain).Kind().String())
+		return nil, fmt.Errorf("domain passed must be a slice of two integers or two floats, type passed was: %s", reflect.TypeOf(domain).Kind().String())
 	}
 	domainInterfaceVal := reflect.ValueOf(domain)
 
 	if domainInterfaceVal.Len() != 2 {
-		return nil, fmt.Errorf("Domain passed must be a slice of two integers or two floats, size of slice is: %d", domainInterfaceVal.Len())
+		return nil, fmt.Errorf("domain passed must be a slice of two integers or two floats, size of slice is: %d", domainInterfaceVal.Len())
 	}
 
 	domainType := reflect.TypeOf(domain).Elem().Kind()
@@ -225,7 +225,7 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 		extentPtr = &tmpExtent
 		cextent = unsafe.Pointer(&tmpExtent)
 	default:
-		return nil, fmt.Errorf("Unrecognized datatype passed: %s", datatype.String())
+		return nil, fmt.Errorf("unrecognized datatype passed: %s", datatype.String())
 	}
 
 	if !domainTypeMatchDatatype {
@@ -235,7 +235,7 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 	ret = C.tiledb_dimension_alloc(context.tiledbContext, cname, C.tiledb_datatype_t(datatype), cdomain, cextent, &dimension.tiledbDimension)
 
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error creating tiledb dimension: %s", context.LastError())
+		return nil, fmt.Errorf("error creating tiledb dimension: %w", context.LastError())
 	}
 	freeOnGC(&dimension)
 
@@ -255,7 +255,7 @@ func NewStringDimension(context *Context, name string) (*Dimension, error) {
 	ret = C.tiledb_dimension_alloc(context.tiledbContext, cname, C.tiledb_datatype_t(datatype), nil, nil, &dimension.tiledbDimension)
 
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error creating tiledb dimension: %s", context.LastError())
+		return nil, fmt.Errorf("error creating tiledb dimension: %w", context.LastError())
 	}
 	freeOnGC(&dimension)
 
@@ -282,7 +282,7 @@ func (d *Dimension) Context() *Context {
 func (d *Dimension) SetFilterList(filterlist *FilterList) error {
 	ret := C.tiledb_dimension_set_filter_list(d.context.tiledbContext, d.tiledbDimension, filterlist.tiledbFilterList)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting tiledb dimension filter list: %s", d.context.LastError())
+		return fmt.Errorf("error setting tiledb dimension filter list: %w", d.context.LastError())
 	}
 	return nil
 }
@@ -292,7 +292,7 @@ func (d *Dimension) FilterList() (*FilterList, error) {
 	filterList := FilterList{context: d.context}
 	ret := C.tiledb_dimension_get_filter_list(d.context.tiledbContext, d.tiledbDimension, &filterList.tiledbFilterList)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting tiledb dimension filter list: %s", d.context.LastError())
+		return nil, fmt.Errorf("error getting tiledb dimension filter list: %w", d.context.LastError())
 	}
 	freeOnGC(&filterList)
 
@@ -307,7 +307,7 @@ func (d *Dimension) SetCellValNum(val uint32) error {
 	ret := C.tiledb_dimension_set_cell_val_num(d.context.tiledbContext,
 		d.tiledbDimension, C.uint32_t(val))
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting tiledb dimension cell val num: %s", d.context.LastError())
+		return fmt.Errorf("error setting tiledb dimension cell val num: %w", d.context.LastError())
 	}
 	return nil
 }
@@ -318,7 +318,7 @@ func (d *Dimension) CellValNum() (uint32, error) {
 	var cellValNum C.uint32_t
 	ret := C.tiledb_dimension_get_cell_val_num(d.context.tiledbContext, d.tiledbDimension, &cellValNum)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting tiledb dimension cell val num: %s", d.context.LastError())
+		return 0, fmt.Errorf("error getting tiledb dimension cell val num: %w", d.context.LastError())
 	}
 
 	return uint32(cellValNum), nil
@@ -329,7 +329,7 @@ func (d *Dimension) Name() (string, error) {
 	var cName *C.char
 	ret := C.tiledb_dimension_get_name(d.context.tiledbContext, d.tiledbDimension, &cName)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error getting tiledb dimension name: %s", d.context.LastError())
+		return "", fmt.Errorf("error getting tiledb dimension name: %w", d.context.LastError())
 	}
 
 	return C.GoString(cName), nil
@@ -340,7 +340,7 @@ func (d *Dimension) Type() (Datatype, error) {
 	var cType C.tiledb_datatype_t
 	ret := C.tiledb_dimension_get_type(d.context.tiledbContext, d.tiledbDimension, &cType)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting tiledb dimension type: %s", d.context.LastError())
+		return 0, fmt.Errorf("error getting tiledb dimension type: %w", d.context.LastError())
 	}
 
 	return Datatype(cType), nil
@@ -396,7 +396,7 @@ func domainInternal[T any](d *Dimension) ([]T, error) {
 	var cDomain unsafe.Pointer
 	ret := C.tiledb_dimension_get_domain(d.context.tiledbContext, d.tiledbDimension, &cDomain)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("could not get tiledb dimension's domain: %w", d.context.LastError())
+		return nil, fmt.Errorf("error getting tiledb dimension's domain: %w", d.context.LastError())
 	}
 	asArray := (*[2]T)(cDomain)
 	return []T{asArray[0], asArray[1]}, nil
@@ -456,7 +456,7 @@ func extentInternal[T any](d *Dimension) (T, error) {
 func (d *Dimension) DumpSTDOUT() error {
 	ret := C.tiledb_dimension_dump(d.context.tiledbContext, d.tiledbDimension, C.stdout)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error dumping dimension to stdout: %s", d.context.LastError())
+		return fmt.Errorf("error dumping dimension to stdout: %w", d.context.LastError())
 	}
 	return nil
 }
@@ -465,7 +465,7 @@ func (d *Dimension) DumpSTDOUT() error {
 func (d *Dimension) Dump(path string) error {
 
 	if _, err := os.Stat(path); err == nil {
-		return fmt.Errorf("Error path already %s exists", path)
+		return fmt.Errorf("error path already %s exists", path)
 	}
 
 	// Convert to char *
@@ -483,7 +483,7 @@ func (d *Dimension) Dump(path string) error {
 	// Dump dimension to file
 	ret := C.tiledb_dimension_dump(d.context.tiledbContext, d.tiledbDimension, cFile)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error dumping dimension to file %s: %s", path, d.context.LastError())
+		return fmt.Errorf("error dumping dimension to file %s: %w", path, d.context.LastError())
 	}
 	return nil
 }

--- a/dimension_label_experimental.go
+++ b/dimension_label_experimental.go
@@ -34,7 +34,7 @@ func (d *DimensionLabel) DimensionIndex() (uint32, error) {
 	var dimensionIndex C.uint32_t
 	ret := C.tiledb_dimension_label_get_dimension_index(d.context.tiledbContext, d.tiledbDimensionLabel, &dimensionIndex)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error fetching dimension index for dimension label: %s", d.context.LastError())
+		return 0, fmt.Errorf("error fetching dimension index for dimension label: %w", d.context.LastError())
 	}
 
 	return uint32(dimensionIndex), nil
@@ -45,7 +45,7 @@ func (d *DimensionLabel) AttributeName() (string, error) {
 	var labelAttrName *C.char
 	ret := C.tiledb_dimension_label_get_label_attr_name(d.context.tiledbContext, d.tiledbDimensionLabel, &labelAttrName)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error getting dimension label attribute name: %s", d.context.LastError())
+		return "", fmt.Errorf("error getting dimension label attribute name: %w", d.context.LastError())
 	}
 
 	return C.GoString(labelAttrName), nil // copies labelAttrName which is memory owned by core
@@ -57,7 +57,7 @@ func (d *DimensionLabel) CellValNum() (uint32, error) {
 	var labelCellValNum C.uint32_t
 	ret := C.tiledb_dimension_label_get_label_cell_val_num(d.context.tiledbContext, d.tiledbDimensionLabel, &labelCellValNum)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error fetching cell val num for dimension label: %s", d.context.LastError())
+		return 0, fmt.Errorf("error fetching cell val num for dimension label: %w", d.context.LastError())
 	}
 
 	return uint32(labelCellValNum), nil
@@ -68,7 +68,7 @@ func (d *DimensionLabel) Order() (DataOrder, error) {
 	var labelOrder C.tiledb_data_order_t
 	ret := C.tiledb_dimension_label_get_label_order(d.context.tiledbContext, d.tiledbDimensionLabel, &labelOrder)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error fetching label order for dimension label: %s", d.context.LastError())
+		return 0, fmt.Errorf("error fetching label order for dimension label: %w", d.context.LastError())
 	}
 
 	return DataOrder(labelOrder), nil
@@ -79,7 +79,7 @@ func (d *DimensionLabel) Type() (Datatype, error) {
 	var dataType C.tiledb_datatype_t
 	ret := C.tiledb_dimension_label_get_label_type(d.context.tiledbContext, d.tiledbDimensionLabel, &dataType)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error fetching dimension label type: %s", d.context.LastError())
+		return 0, fmt.Errorf("error fetching dimension label type: %w", d.context.LastError())
 	}
 
 	return Datatype(dataType), nil
@@ -90,7 +90,7 @@ func (d *DimensionLabel) Name() (string, error) {
 	var labelName *C.char
 	ret := C.tiledb_dimension_label_get_name(d.context.tiledbContext, d.tiledbDimensionLabel, &labelName)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error getting dimension label name: %s", d.context.LastError())
+		return "", fmt.Errorf("error getting dimension label name: %w", d.context.LastError())
 	}
 
 	return C.GoString(labelName), nil // copies labelName which is memory owned by core
@@ -101,7 +101,7 @@ func (d *DimensionLabel) URI() (string, error) {
 	var labelUri *C.char
 	ret := C.tiledb_dimension_label_get_uri(d.context.tiledbContext, d.tiledbDimensionLabel, &labelUri)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error getting dimension label URI: %s", d.context.LastError())
+		return "", fmt.Errorf("error getting dimension label URI: %w", d.context.LastError())
 	}
 
 	return C.GoString(labelUri), nil // copies labelUri which is memory owned by core
@@ -113,7 +113,7 @@ func (a *ArraySchema) AddDimensionLabel(dimIndex uint32, name string, order Data
 	ret := C.tiledb_array_schema_add_dimension_label(a.context.tiledbContext, a.tiledbArraySchema,
 		C.uint32_t(dimIndex), cLabelName, C.tiledb_data_order_t(order), C.tiledb_datatype_t(labelType))
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error adding dimension label to ArraySchema: %s", a.context.LastError())
+		return fmt.Errorf("error adding dimension label to ArraySchema: %w", a.context.LastError())
 	}
 
 	return nil
@@ -125,7 +125,7 @@ func (a *ArraySchema) DimensionLabelFromIndex(labelIdx uint64) (*DimensionLabel,
 	ret := C.tiledb_array_schema_get_dimension_label_from_index(a.context.tiledbContext, a.tiledbArraySchema,
 		C.uint64_t(labelIdx), &dimLabel.tiledbDimensionLabel)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting dimension label '%d' for ArraySchema: %s", labelIdx, a.context.LastError())
+		return nil, fmt.Errorf("error getting dimension label '%d' for ArraySchema: %w", labelIdx, a.context.LastError())
 	}
 
 	freeOnGC(&dimLabel)
@@ -140,7 +140,7 @@ func (a *ArraySchema) DimensionLabelFromName(name string) (*DimensionLabel, erro
 	ret := C.tiledb_array_schema_get_dimension_label_from_name(a.context.tiledbContext, a.tiledbArraySchema,
 		cAttrName, &dimLabel.tiledbDimensionLabel)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting dimension label '%s' for ArraySchema: %s", name, a.context.LastError())
+		return nil, fmt.Errorf("error getting dimension label '%s' for ArraySchema: %w", name, a.context.LastError())
 	}
 
 	freeOnGC(&dimLabel)
@@ -156,7 +156,7 @@ func (a *ArraySchema) HasDimensionLabel(name string) (bool, error) {
 	ret := C.tiledb_array_schema_has_dimension_label(a.context.tiledbContext, a.tiledbArraySchema,
 		cLabelName, &hasLabel)
 	if ret != C.TILEDB_OK {
-		return false, fmt.Errorf("Error checking ArraySchema for dimension label '%s': %s", name, a.context.LastError())
+		return false, fmt.Errorf("error checking ArraySchema for dimension label '%s': %w", name, a.context.LastError())
 	}
 
 	return hasLabel != 0, nil
@@ -168,7 +168,7 @@ func (a *ArraySchema) DimensionLabelsNum() (uint64, error) {
 
 	ret := C.tiledb_array_schema_get_dimension_label_num(a.context.tiledbContext, a.tiledbArraySchema, &labelNum)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error fetching dimension label number: %s", a.context.LastError())
+		return 0, fmt.Errorf("error fetching dimension label number: %w", a.context.LastError())
 	}
 
 	return uint64(labelNum), nil
@@ -182,7 +182,7 @@ func (a *ArraySchema) SetDimensionLabelFilterList(name string, filterList Filter
 	ret := C.tiledb_array_schema_set_dimension_label_filter_list(a.context.tiledbContext, a.tiledbArraySchema,
 		cName, filterList.tiledbFilterList)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting dimension label filter list on ArraySchema: %s", a.context.LastError())
+		return fmt.Errorf("error setting dimension label filter list on ArraySchema: %w", a.context.LastError())
 	}
 
 	return nil
@@ -195,7 +195,7 @@ func (a *ArraySchema) SetDimensionLabelTileExtent(labelName string, dimType Data
 
 	extentType := reflect.TypeOf(extent).Kind()
 	if extentType != dimType.ReflectKind() {
-		return fmt.Errorf("Dimension and extent do not have the same data types. Dimension: %s, Extent: %s",
+		return fmt.Errorf("dimension and extent do not have the same data types. Dimension: %s, Extent: %s",
 			dimType.ReflectKind(), extentType)
 	}
 
@@ -239,14 +239,14 @@ func (a *ArraySchema) SetDimensionLabelTileExtent(labelName string, dimType Data
 		extentPtr = &tmpExtent
 		cExtent = unsafe.Pointer(&tmpExtent)
 	default:
-		return fmt.Errorf("Unrecognized dimension datatype passed to SetDimensionLabelTileExtent: %s",
+		return fmt.Errorf("unrecognized dimension datatype passed to SetDimensionLabelTileExtent: %s",
 			dimType.String())
 	}
 
 	ret := C.tiledb_array_schema_set_dimension_label_tile_extent(a.context.tiledbContext, a.tiledbArraySchema,
 		cName, C.tiledb_datatype_t(dimType), cExtent)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting dimension label tile extent on ArraySchema: %s", a.context.LastError())
+		return fmt.Errorf("error setting dimension label tile extent on ArraySchema: %w", a.context.LastError())
 	}
 
 	return nil
@@ -256,19 +256,19 @@ func (a *ArraySchema) SetDimensionLabelTileExtent(labelName string, dimType Data
 func (q *Query) getDimensionLabelDataType(labelName string) (Datatype, error) {
 	schema, err := q.array.Schema()
 	if err != nil {
-		return 0, fmt.Errorf("Could not get schema for getDimensionLabelDatatype: %s", err)
+		return 0, fmt.Errorf("could not get schema for getDimensionLabelDatatype: %w", err)
 	}
 	defer schema.Free()
 
 	dimLabel, err := schema.DimensionLabelFromName(labelName)
 	if err != nil {
-		return 0, fmt.Errorf("Could not get dimension label %s for getDimensionLabelDatatype: %s", labelName, err)
+		return 0, fmt.Errorf("could not get dimension label %s for getDimensionLabelDatatype: %w", labelName, err)
 	}
 	defer dimLabel.Free()
 
 	datatype, err := dimLabel.Type()
 	if err != nil {
-		return 0, fmt.Errorf("Could not get dimension label type for getDimensionLabelDatatype: %s", err)
+		return 0, fmt.Errorf("could not get dimension label type for getDimensionLabelDatatype: %w", err)
 	}
 
 	return datatype, nil
@@ -283,7 +283,7 @@ func (sa *Subarray) GetDimensionLabelRangeNum(labelName string) (uint64, error) 
 
 	ret := C.tiledb_subarray_get_label_range_num(sa.context.tiledbContext, sa.subarray, cLabelName, &rangeNum)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error retrieving subarray label range num: %s", sa.context.LastError())
+		return 0, fmt.Errorf("error retrieving subarray label range num: %w", sa.context.LastError())
 	}
 
 	return uint64(rangeNum), nil
@@ -320,7 +320,7 @@ func (sa *Subarray) AddDimensionLabelRange(labelName string, r Range) error {
 		runtime.KeepAlive(endValue)
 	}
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error adding subarray label range: %s", sa.context.LastError())
+		return fmt.Errorf("error adding subarray label range: %w", sa.context.LastError())
 	}
 
 	return nil
@@ -371,7 +371,7 @@ func (sa *Subarray) GetDimensionLabelRange(labelName string, rangeNum uint64) (R
 		}
 	}
 	if ret != C.TILEDB_OK {
-		return Range{}, fmt.Errorf("Error retrieving subarray range for label %s and range num %d: %s", labelName, rangeNum, sa.context.LastError())
+		return Range{}, fmt.Errorf("error retrieving subarray range for label %s and range num %d: %w", labelName, rangeNum, sa.context.LastError())
 	}
 
 	return r, err

--- a/domain.go
+++ b/domain.go
@@ -26,7 +26,7 @@ func NewDomain(tdbCtx *Context) (*Domain, error) {
 	domain := Domain{context: tdbCtx}
 	ret := C.tiledb_domain_alloc(domain.context.tiledbContext, &domain.tiledbDomain)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error creating tiledb domain: %s", domain.context.LastError())
+		return nil, fmt.Errorf("error creating tiledb domain: %w", domain.context.LastError())
 	}
 	freeOnGC(&domain)
 
@@ -54,7 +54,7 @@ func (d *Domain) Type() (Datatype, error) {
 	var datatype C.tiledb_datatype_t
 	ret := C.tiledb_domain_get_type(d.context.tiledbContext, d.tiledbDomain, &datatype)
 	if ret != C.TILEDB_OK {
-		return -1, fmt.Errorf("Error getting tiledb domain type: %s", d.context.LastError())
+		return -1, fmt.Errorf("error getting tiledb domain type: %w", d.context.LastError())
 	}
 	return Datatype(datatype), nil
 }
@@ -64,7 +64,7 @@ func (d *Domain) NDim() (uint, error) {
 	var ndim C.uint32_t
 	ret := C.tiledb_domain_get_ndim(d.context.tiledbContext, d.tiledbDomain, &ndim)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting tiledb domain number of dimensions: %s", d.context.LastError())
+		return 0, fmt.Errorf("error getting tiledb domain number of dimensions: %w", d.context.LastError())
 	}
 	return uint(ndim), nil
 }
@@ -75,7 +75,7 @@ func (d *Domain) DimensionFromIndex(index uint) (*Dimension, error) {
 	ret := C.tiledb_domain_get_dimension_from_index(d.context.tiledbContext,
 		d.tiledbDomain, C.uint32_t(index), &dim)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting tiledb dimension by index for domain: %s", d.context.LastError())
+		return nil, fmt.Errorf("error getting tiledb dimension by index for domain: %w", d.context.LastError())
 	}
 
 	dimension := Dimension{tiledbDimension: dim, context: d.context}
@@ -91,7 +91,7 @@ func (d *Domain) DimensionFromName(name string) (*Dimension, error) {
 	var dim *C.tiledb_dimension_t
 	ret := C.tiledb_domain_get_dimension_from_name(d.context.tiledbContext, d.tiledbDomain, cname, &dim)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting tiledb dimension by name for domain: %s", d.context.LastError())
+		return nil, fmt.Errorf("error getting tiledb dimension by name for domain: %w", d.context.LastError())
 	}
 	dimension := Dimension{tiledbDimension: dim, context: d.context}
 	freeOnGC(&dimension)
@@ -103,7 +103,7 @@ func (d *Domain) AddDimensions(dimensions ...*Dimension) error {
 	for _, dimension := range dimensions {
 		ret := C.tiledb_domain_add_dimension(d.context.tiledbContext, d.tiledbDomain, dimension.tiledbDimension)
 		if ret != C.TILEDB_OK {
-			return fmt.Errorf("Error adding dimension to domain: %s", d.context.LastError())
+			return fmt.Errorf("error adding dimension to domain: %w", d.context.LastError())
 		}
 	}
 	return nil
@@ -116,7 +116,7 @@ func (d *Domain) HasDimension(dimName string) (bool, error) {
 	defer C.free(unsafe.Pointer(cDimName))
 	ret := C.tiledb_domain_has_dimension(d.context.tiledbContext, d.tiledbDomain, cDimName, &hasDim)
 	if ret != C.TILEDB_OK {
-		return false, fmt.Errorf("Error finding dimension %s in domain: %s", dimName, d.context.LastError())
+		return false, fmt.Errorf("error finding dimension %s in domain: %w", dimName, d.context.LastError())
 	}
 
 	if hasDim == 0 {
@@ -130,7 +130,7 @@ func (d *Domain) HasDimension(dimName string) (bool, error) {
 func (d *Domain) DumpSTDOUT() error {
 	ret := C.tiledb_domain_dump(d.context.tiledbContext, d.tiledbDomain, C.stdout)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error dumping domain to stdout: %s", d.context.LastError())
+		return fmt.Errorf("error dumping domain to stdout: %w", d.context.LastError())
 	}
 	return nil
 }
@@ -139,7 +139,7 @@ func (d *Domain) DumpSTDOUT() error {
 func (d *Domain) Dump(path string) error {
 
 	if _, err := os.Stat(path); err == nil {
-		return fmt.Errorf("Error path already %s exists", path)
+		return fmt.Errorf("error path already %s exists", path)
 	}
 
 	// Convert to char *
@@ -157,7 +157,7 @@ func (d *Domain) Dump(path string) error {
 	// Dump domain to file
 	ret := C.tiledb_domain_dump(d.context.tiledbContext, d.tiledbDomain, cFile)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error dumping domain to file %s: %s", path, d.context.LastError())
+		return fmt.Errorf("error dumping domain to file %s: %w", path, d.context.LastError())
 	}
 	return nil
 }

--- a/enumeration_experimental.go
+++ b/enumeration_experimental.go
@@ -289,7 +289,7 @@ func (e *Enumeration) Values() (interface{}, error) {
 	}
 
 	if int(cOffsetsSize)%8 > 0 {
-		return nil, errors.New("error getting data offsets: returned size does not contains an integer size of items")
+		return nil, errors.New("error getting data offsets: returned size does not contain an integer size of items")
 	}
 
 	var strs []string

--- a/enumeration_experimental.go
+++ b/enumeration_experimental.go
@@ -9,6 +9,7 @@ package tiledb
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -125,7 +126,7 @@ func newEnumeration[T EnumerationType](tdbCtx *Context, name string, ordered boo
 	ret := C.tiledb_enumeration_alloc(tdbCtx.tiledbContext, cName, C.tiledb_datatype_t(tiledbType), cCellNum, cOrdered,
 		cData, cDataLen, cOffsets, cOffsetsLen, &tiledbEnum)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error creating enumeration: %s", tdbCtx.LastError())
+		return nil, fmt.Errorf("error creating enumeration: %w", tdbCtx.LastError())
 	}
 
 	e := &Enumeration{context: tdbCtx, tiledbEnum: tiledbEnum}
@@ -153,7 +154,7 @@ func (e *Enumeration) Name() (string, error) {
 
 	ret := C.tiledb_enumeration_get_name(e.context.tiledbContext, e.tiledbEnum, &str)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error getting name: %s", e.context.LastError())
+		return "", fmt.Errorf("error getting name: %w", e.context.LastError())
 	}
 	defer C.tiledb_string_free(&str)
 
@@ -161,7 +162,7 @@ func (e *Enumeration) Name() (string, error) {
 	var cNameSize C.size_t
 	ret = C.tiledb_string_view(str, &cName, &cNameSize)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error getting name: %s", e.context.LastError())
+		return "", fmt.Errorf("error getting name: %w", e.context.LastError())
 	}
 
 	return C.GoStringN(cName, C.int(cNameSize)), nil
@@ -173,7 +174,7 @@ func (e *Enumeration) Type() (Datatype, error) {
 
 	ret := C.tiledb_enumeration_get_type(e.context.tiledbContext, e.tiledbEnum, &attrType)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting tiledb enumeration type: %s", e.context.LastError())
+		return 0, fmt.Errorf("error getting tiledb enumeration type: %w", e.context.LastError())
 	}
 
 	return Datatype(attrType), nil
@@ -185,7 +186,7 @@ func (e *Enumeration) CellValNum() (uint32, error) {
 
 	ret := C.tiledb_enumeration_get_cell_val_num(e.context.tiledbContext, e.tiledbEnum, &cellValNum)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting enumeration cell val num: %s", e.context.LastError())
+		return 0, fmt.Errorf("error getting enumeration cell val num: %w", e.context.LastError())
 	}
 
 	return uint32(cellValNum), nil
@@ -198,7 +199,7 @@ func (e *Enumeration) IsOrdered() (bool, error) {
 
 	ret := C.tiledb_enumeration_get_ordered(e.context.tiledbContext, e.tiledbEnum, &ordered)
 	if ret != C.TILEDB_OK {
-		return false, fmt.Errorf("Error getting ordered: %s", e.context.LastError())
+		return false, fmt.Errorf("error getting ordered: %w", e.context.LastError())
 	}
 
 	return ordered > 0, nil
@@ -208,7 +209,7 @@ func (e *Enumeration) IsOrdered() (bool, error) {
 func (e *Enumeration) DumpSTDOUT() error {
 	ret := C.tiledb_enumeration_dump(e.context.tiledbContext, e.tiledbEnum, C.stdout)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error dumping enumeration to stdout: %s", e.context.LastError())
+		return fmt.Errorf("error dumping enumeration to stdout: %w", e.context.LastError())
 	}
 
 	return nil
@@ -217,7 +218,7 @@ func (e *Enumeration) DumpSTDOUT() error {
 // Dump creates the file at path (must not exist) and writes a human-readable description of the enumeration.
 func (e *Enumeration) Dump(path string) error {
 	if _, err := os.Stat(path); err == nil {
-		return fmt.Errorf("Error path already %s exists", path)
+		return fmt.Errorf("error path already %s exists", path)
 	}
 
 	cPath := C.CString(path)
@@ -231,7 +232,7 @@ func (e *Enumeration) Dump(path string) error {
 
 	ret := C.tiledb_enumeration_dump(e.context.tiledbContext, e.tiledbEnum, cFile)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error dumping enumeration to file %s: %s", path, e.context.LastError())
+		return fmt.Errorf("error dumping enumeration to file %s: %w", path, e.context.LastError())
 	}
 
 	return nil
@@ -248,7 +249,7 @@ func (e *Enumeration) Values() (interface{}, error) {
 	var cDataSize C.uint64_t
 	ret := C.tiledb_enumeration_get_data(e.context.tiledbContext, e.tiledbEnum, &cData, &cDataSize)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting data: %s", e.context.LastError())
+		return nil, fmt.Errorf("error getting data: %w", e.context.LastError())
 	}
 
 	if typ != TILEDB_STRING_ASCII {
@@ -284,11 +285,11 @@ func (e *Enumeration) Values() (interface{}, error) {
 	var cOffsetsSize C.uint64_t
 	ret = C.tiledb_enumeration_get_offsets(e.context.tiledbContext, e.tiledbEnum, &cOffsets, &cOffsetsSize)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting data offsets: %s", e.context.LastError())
+		return nil, fmt.Errorf("error getting data offsets: %w", e.context.LastError())
 	}
 
 	if int(cOffsetsSize)%8 > 0 {
-		return nil, fmt.Errorf("Error getting data offsets: returned size does not contains an integer size of items")
+		return nil, errors.New("error getting data offsets: returned size does not contains an integer size of items")
 	}
 
 	var strs []string
@@ -313,22 +314,22 @@ func (e *Enumeration) Values() (interface{}, error) {
 // used with ArraySchemaEvolution.ApplyExtendedEnumeration to make changes persistent.
 func ExtendEnumeration[T EnumerationType](tdbCtx *Context, e *Enumeration, values []T) (*Enumeration, error) {
 	if len(values) == 0 {
-		return nil, fmt.Errorf("Error extending enumeration: empty values")
+		return nil, errors.New("error extending enumeration: empty values")
 	}
 
 	eName, err := e.Name()
 	if err != nil {
-		return nil, fmt.Errorf("Error extending enumeration: failed to get name of enumeration: %s", tdbCtx.LastError())
+		return nil, fmt.Errorf("error extending enumeration: failed to get name of enumeration: %w", tdbCtx.LastError())
 	}
 
 	eType, err := e.Type()
 	if err != nil {
-		return nil, fmt.Errorf("Error extending enumeration: failed to get type of enumeration %s: %s", eName, tdbCtx.LastError())
+		return nil, fmt.Errorf("error extending enumeration: failed to get type of enumeration %s: %w", eName, tdbCtx.LastError())
 	}
 
 	tiledbType := enumerationTypeToTileDB[T]()
 	if eType != tiledbType {
-		return nil, fmt.Errorf("Error extending enumeration: type mismatch: enumeration type %v, values type %v", eType, tiledbType)
+		return nil, fmt.Errorf("error extending enumeration: type mismatch: enumeration type %v, values type %v", eType, tiledbType)
 	}
 
 	var cData unsafe.Pointer
@@ -365,7 +366,7 @@ func ExtendEnumeration[T EnumerationType](tdbCtx *Context, e *Enumeration, value
 
 	ret := C.tiledb_enumeration_extend(tdbCtx.tiledbContext, e.tiledbEnum, cData, cDataLen, cOffsets, cOffsetsLen, &extEnum)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error extending enumeration: %s", tdbCtx.LastError())
+		return nil, fmt.Errorf("error extending enumeration: %w", tdbCtx.LastError())
 	}
 
 	ext := &Enumeration{context: tdbCtx, tiledbEnum: extEnum}
@@ -380,7 +381,7 @@ func ExtendEnumeration[T EnumerationType](tdbCtx *Context, e *Enumeration, value
 func (a *ArraySchema) AddEnumeration(e *Enumeration) error {
 	ret := C.tiledb_array_schema_add_enumeration(a.context.tiledbContext, a.tiledbArraySchema, e.tiledbEnum)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error adding enumeration: %s", a.context.LastError())
+		return fmt.Errorf("error adding enumeration: %w", a.context.LastError())
 	}
 
 	return nil
@@ -417,7 +418,7 @@ func (a *ArraySchema) EnumerationFromAttributeName(name string) (*Enumeration, e
 func (a *Array) LoadAllEnumerations() error {
 	ret := C.tiledb_array_load_all_enumerations(a.context.tiledbContext, a.tiledbArray)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error loading all enumerations: %s", a.context.LastError())
+		return fmt.Errorf("error loading all enumerations: %w", a.context.LastError())
 	}
 
 	return nil
@@ -441,7 +442,7 @@ func (a *Array) GetEnumeration(name string) (*Enumeration, error) {
 	var tiledbEnum *C.tiledb_enumeration_t
 	ret := C.tiledb_array_get_enumeration(a.context.tiledbContext, a.tiledbArray, cName, &tiledbEnum)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting enumeration %s: %s", name, a.context.LastError())
+		return nil, fmt.Errorf("error getting enumeration %s: %w", name, a.context.LastError())
 	}
 
 	return &Enumeration{context: a.context, tiledbEnum: tiledbEnum}, nil
@@ -455,7 +456,7 @@ func (a *Attribute) SetEnumerationName(name string) error {
 
 	ret := C.tiledb_attribute_set_enumeration_name(a.context.tiledbContext, a.tiledbAttribute, cName)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting enumeration name: %s", a.context.LastError())
+		return fmt.Errorf("error setting enumeration name: %w", a.context.LastError())
 	}
 
 	return nil
@@ -467,7 +468,7 @@ func (a *Attribute) GetEnumerationName() (string, error) {
 
 	ret := C.tiledb_attribute_get_enumeration_name(a.context.tiledbContext, a.tiledbAttribute, &str)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error getting enumeration name: %s", a.context.LastError())
+		return "", fmt.Errorf("error getting enumeration name: %w", a.context.LastError())
 	}
 	defer C.tiledb_string_free(&str)
 
@@ -475,7 +476,7 @@ func (a *Attribute) GetEnumerationName() (string, error) {
 	var cNameSize C.size_t
 	ret = C.tiledb_string_view(str, &cName, &cNameSize)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error getting name: %s", a.context.LastError())
+		return "", fmt.Errorf("error getting name: %w", a.context.LastError())
 	}
 
 	return C.GoStringN(cName, C.int(cNameSize)), nil
@@ -490,7 +491,7 @@ func (qc *QueryCondition) UseEnumeration(useEnum bool) error {
 
 	ret := C.tiledb_query_condition_set_use_enumeration(qc.context.tiledbContext, qc.cond, cUseEnum)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error toggling enumerations use: %s", qc.context.LastError())
+		return fmt.Errorf("error toggling enumerations use: %w", qc.context.LastError())
 	}
 
 	return nil
@@ -500,12 +501,12 @@ func (qc *QueryCondition) UseEnumeration(useEnum bool) error {
 func (ase *ArraySchemaEvolution) AddEnumeration(e *Enumeration) error {
 	name, err := e.Name()
 	if err != nil {
-		return fmt.Errorf("Error getting enumeration name: %s", e.context.LastError())
+		return fmt.Errorf("error getting enumeration name: %w", e.context.LastError())
 	}
 
 	ret := C.tiledb_array_schema_evolution_add_enumeration(ase.context.tiledbContext, ase.tiledbArraySchemaEvolution, e.tiledbEnum)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error adding enumeration %s to tiledb arraySchemaEvolution: %s", name, ase.context.LastError())
+		return fmt.Errorf("error adding enumeration %s to tiledb arraySchemaEvolution: %w", name, ase.context.LastError())
 	}
 
 	return nil
@@ -518,7 +519,7 @@ func (ase *ArraySchemaEvolution) DropEnumeration(name string) error {
 
 	ret := C.tiledb_array_schema_evolution_drop_enumeration(ase.context.tiledbContext, ase.tiledbArraySchemaEvolution, cName)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error dropping enumeration %s from tiledb arraySchemaEvolution: %s", name, ase.context.LastError())
+		return fmt.Errorf("error dropping enumeration %s from tiledb arraySchemaEvolution: %w", name, ase.context.LastError())
 	}
 
 	return nil
@@ -528,7 +529,7 @@ func (ase *ArraySchemaEvolution) DropEnumeration(name string) error {
 func (ase *ArraySchemaEvolution) ApplyExtendedEnumeration(e *Enumeration) error {
 	ret := C.tiledb_array_schema_evolution_extend_enumeration(ase.context.tiledbContext, ase.tiledbArraySchemaEvolution, e.tiledbEnum)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error applying extended enumeration to arraySchemaEvolution: %s", ase.context.LastError())
+		return fmt.Errorf("error applying extended enumeration to arraySchemaEvolution: %w", ase.context.LastError())
 	}
 
 	return nil
@@ -542,7 +543,7 @@ func copyUnsafeSliceOfEnumerationValues[T any](data unsafe.Pointer, dataSize int
 	var zero T
 	factor := int(unsafe.Sizeof(zero))
 	if dataSize%factor > 0 {
-		return nil, fmt.Errorf("Error getting data values: returned size does not contains an integer size of items")
+		return nil, errors.New("error getting data values: returned size does not contains an integer size of items")
 	}
 
 	retLen := dataSize / factor

--- a/enums.go
+++ b/enums.go
@@ -356,7 +356,7 @@ func (d Datatype) GetValue(valueNum uint, cvalue unsafe.Pointer) (interface{}, e
 		}
 		return bools, nil
 	default:
-		return nil, fmt.Errorf("Unrecognized value type: %d", d)
+		return nil, fmt.Errorf("unrecognized value type: %d", d)
 	}
 }
 
@@ -690,7 +690,7 @@ func (d DataOrder) String() (string, error) {
 	var dataOrderStr *C.char
 	ret := C.tiledb_data_order_to_str(C.tiledb_data_order_t(d), &dataOrderStr)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error converting DataOrder to string: %d", d)
+		return "", fmt.Errorf("error converting DataOrder to string: %d", d)
 	}
 
 	return C.GoString(dataOrderStr), nil
@@ -704,7 +704,7 @@ func DataOrderFromString(name string) (DataOrder, error) {
 	var cDataOrder C.tiledb_data_order_t
 	ret := C.tiledb_data_order_from_str(cName, &cDataOrder)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error converting '%s' to tiledb_data_order_t", name)
+		return 0, fmt.Errorf("error converting '%s' to tiledb_data_order_t", name)
 	}
 	return DataOrder(cDataOrder), nil
 }

--- a/examples_lib/vfs.go
+++ b/examples_lib/vfs.go
@@ -107,7 +107,7 @@ func write(dir string) {
 	fh1, err := vfs.Open(file, tiledb.TILEDB_VFS_WRITE)
 	defer vfs.Close(fh1)
 	if err != nil {
-		fmt.Printf("Error opening file '%s'\n", file)
+		fmt.Printf("error opening file '%s'\n", file)
 	}
 
 	var f1 float32 = 153.0
@@ -121,7 +121,7 @@ func write(dir string) {
 	fh2, err := vfs.Open(file, tiledb.TILEDB_VFS_WRITE)
 	defer vfs.Close(fh2)
 	if err != nil {
-		fmt.Printf("Error opening file '%s' for write.\n", file)
+		fmt.Printf("error opening file '%s' for write.\n", file)
 	}
 
 	var f2 float32 = 153.1
@@ -135,7 +135,7 @@ func write(dir string) {
 	fh3, err := vfs.Open(file, tiledb.TILEDB_VFS_APPEND)
 	defer vfs.Close(fh3)
 	if err != nil {
-		fmt.Printf("Error opening file '%s' for append.\n", file)
+		fmt.Printf("error opening file '%s' for append.\n", file)
 	}
 
 	s3 := "ghijkl"
@@ -165,7 +165,7 @@ func read(dir string) {
 	fh, err := vfs.Open(file, tiledb.TILEDB_VFS_READ)
 	defer vfs.Close(fh)
 	if err != nil {
-		fmt.Printf("Error opening file '%s'\n", file)
+		fmt.Printf("error opening file '%s'\n", file)
 	}
 
 	sizefFile, err := vfs.FileSize(file)

--- a/filestore_experimental.go
+++ b/filestore_experimental.go
@@ -21,7 +21,7 @@ func FileSize(tdbCtx *Context, arrayURI string) (int64, error) {
 	var size C.size_t
 	ret := C.tiledb_filestore_size(tdbCtx.tiledbContext, cArrayURI, &size)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting file size: %s", tdbCtx.LastError())
+		return 0, fmt.Errorf("error getting file size: %w", tdbCtx.LastError())
 	}
 
 	return int64(size), nil
@@ -37,7 +37,7 @@ func ExportFile(tdbCtx *Context, filePath, arrayURI string) error {
 
 	ret := C.tiledb_filestore_uri_export(tdbCtx.tiledbContext, cFileURI, cArrayURI)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error exporting file: %s", tdbCtx.LastError())
+		return fmt.Errorf("error exporting file: %w", tdbCtx.LastError())
 	}
 
 	return nil
@@ -52,7 +52,7 @@ func ImportFile(tdbCtx *Context, arrayURI, filePath string, mimeType FileStoreMi
 
 	ret := C.tiledb_filestore_uri_import(tdbCtx.tiledbContext, cArrayURI, cFileURI, C.tiledb_mime_type_t(mimeType))
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error importing file: %s", tdbCtx.LastError())
+		return fmt.Errorf("error importing file: %w", tdbCtx.LastError())
 	}
 
 	return nil
@@ -163,7 +163,7 @@ func NewArraySchemaForFile(tdbCtx *Context, filePath string) (*ArraySchema, erro
 	arraySchema := ArraySchema{context: tdbCtx}
 	ret := C.tiledb_filestore_schema_create(tdbCtx.tiledbContext, fileURI, &arraySchema.tiledbArraySchema)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error creating schema: %s", tdbCtx.LastError())
+		return nil, fmt.Errorf("error creating schema: %w", tdbCtx.LastError())
 	}
 	freeOnGC(&arraySchema)
 
@@ -180,7 +180,7 @@ func bufferExport(tdbCtx *Context, uri *C.char, off int64, p []byte) error {
 
 	ret := C.tiledb_filestore_buffer_export(tdbCtx.tiledbContext, uri, C.size_t(off), slicePtr(p), C.size_t(len(p)))
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error exporting buffer data: %s", tdbCtx.LastError())
+		return fmt.Errorf("error exporting buffer data: %w", tdbCtx.LastError())
 	}
 
 	return nil
@@ -190,12 +190,12 @@ func bufferExport(tdbCtx *Context, uri *C.char, off int64, p []byte) error {
 // Uri is the uri of an existing array with the filestore schema (see ArraySchemaForFile)
 func bufferImport(tdbCtx *Context, uri *C.char, data []byte, mimeType FileStoreMimeType) error {
 	if len(data) == 0 {
-		return errors.New("Error importing buffer data: empty data")
+		return errors.New("error importing buffer data: empty data")
 	}
 
 	ret := C.tiledb_filestore_buffer_import(tdbCtx.tiledbContext, uri, slicePtr(data), C.size_t(len(data)), C.tiledb_mime_type_t(mimeType))
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error importing buffer data: %s", tdbCtx.LastError())
+		return fmt.Errorf("error importing buffer data: %w", tdbCtx.LastError())
 	}
 
 	return nil

--- a/filter.go
+++ b/filter.go
@@ -7,6 +7,7 @@ package tiledb
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 )
@@ -23,7 +24,7 @@ func NewFilter(context *Context, filterType FilterType) (*Filter, error) {
 
 	ret := C.tiledb_filter_alloc(filter.context.tiledbContext, C.tiledb_filter_type_t(filterType), &filter.tiledbFilter)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error creating tiledb filter: %s", filter.context.LastError())
+		return nil, fmt.Errorf("error creating tiledb filter: %w", filter.context.LastError())
 	}
 	freeOnGC(&filter)
 
@@ -52,7 +53,7 @@ func (f *Filter) Type() (FilterType, error) {
 	ret := C.tiledb_filter_get_type(f.context.tiledbContext, f.tiledbFilter, &filterType)
 
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting tiledb filter type: %s", f.context.LastError())
+		return 0, fmt.Errorf("error getting tiledb filter type: %w", f.context.LastError())
 	}
 
 	return FilterType(filterType), nil
@@ -68,32 +69,32 @@ func (f *Filter) SetOption(filterOption FilterOption, valueInterface interface{}
 	case TILEDB_COMPRESSION_LEVEL:
 		value, ok := valueInterface.(int32)
 		if !ok {
-			return fmt.Errorf("Error setting tiledb filter option TILEDB_COMPRESSION_LEVEL, passed data is not int32")
+			return errors.New("error setting tiledb filter option TILEDB_COMPRESSION_LEVEL, passed data is not int32")
 		}
 		cvalue = unsafe.Pointer(&value)
 		ret := C.tiledb_filter_set_option(f.context.tiledbContext, f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
 		if ret != C.TILEDB_OK {
-			return fmt.Errorf("Error setting tiledb filter option: %s", f.context.LastError())
+			return fmt.Errorf("error setting tiledb filter option: %w", f.context.LastError())
 		}
 	case TILEDB_BIT_WIDTH_MAX_WINDOW:
 		value, ok := valueInterface.(uint32)
 		if !ok {
-			return fmt.Errorf("Error setting tiledb filter option TILEDB_BIT_WIDTH_MAX_WINDOW, passed data is not uint32")
+			return errors.New("error setting tiledb filter option TILEDB_BIT_WIDTH_MAX_WINDOW, passed data is not uint32")
 		}
 		cvalue = unsafe.Pointer(&value)
 		ret := C.tiledb_filter_set_option(f.context.tiledbContext, f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
 		if ret != C.TILEDB_OK {
-			return fmt.Errorf("Error setting tiledb filter option: %s", f.context.LastError())
+			return fmt.Errorf("error setting tiledb filter option: %w", f.context.LastError())
 		}
 	case TILEDB_POSITIVE_DELTA_MAX_WINDOW:
 		value, ok := valueInterface.(uint32)
 		if !ok {
-			return fmt.Errorf("Error setting tiledb filter option TILEDB_POSITIVE_DELTA_MAX_WINDOW, passed data is not uint32")
+			return errors.New("error setting tiledb filter option TILEDB_POSITIVE_DELTA_MAX_WINDOW, passed data is not uint32")
 		}
 		cvalue = unsafe.Pointer(&value)
 		ret := C.tiledb_filter_set_option(f.context.tiledbContext, f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
 		if ret != C.TILEDB_OK {
-			return fmt.Errorf("Error setting tiledb filter option: %s", f.context.LastError())
+			return fmt.Errorf("error setting tiledb filter option: %w", f.context.LastError())
 		}
 	}
 
@@ -115,7 +116,7 @@ func (f *Filter) Option(filterOption FilterOption) (interface{}, error) {
 		cvalue = unsafe.Pointer(&val)
 		ret := C.tiledb_filter_get_option(f.context.tiledbContext, f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
 		if ret != C.TILEDB_OK {
-			return nil, fmt.Errorf("Error getting tiledb filter option: %s", f.context.LastError())
+			return nil, fmt.Errorf("error getting tiledb filter option: %w", f.context.LastError())
 		}
 		return val, nil
 	case TILEDB_BIT_WIDTH_MAX_WINDOW:
@@ -123,7 +124,7 @@ func (f *Filter) Option(filterOption FilterOption) (interface{}, error) {
 		cvalue = unsafe.Pointer(&val)
 		ret := C.tiledb_filter_get_option(f.context.tiledbContext, f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
 		if ret != C.TILEDB_OK {
-			return nil, fmt.Errorf("Error getting tiledb filter option: %s", f.context.LastError())
+			return nil, fmt.Errorf("error getting tiledb filter option: %w", f.context.LastError())
 		}
 		return val, nil
 	case TILEDB_POSITIVE_DELTA_MAX_WINDOW:
@@ -131,7 +132,7 @@ func (f *Filter) Option(filterOption FilterOption) (interface{}, error) {
 		cvalue = unsafe.Pointer(&val)
 		ret := C.tiledb_filter_get_option(f.context.tiledbContext, f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
 		if ret != C.TILEDB_OK {
-			return nil, fmt.Errorf("Error getting tiledb filter option: %s", f.context.LastError())
+			return nil, fmt.Errorf("error getting tiledb filter option: %w", f.context.LastError())
 		}
 		return val, nil
 	}

--- a/filter_list.go
+++ b/filter_list.go
@@ -22,7 +22,7 @@ func NewFilterList(context *Context) (*FilterList, error) {
 
 	ret := C.tiledb_filter_list_alloc(filterList.context.tiledbContext, &filterList.tiledbFilterList)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error creating tiledb FilterList: %s", filterList.context.LastError())
+		return nil, fmt.Errorf("error creating tiledb FilterList: %w", filterList.context.LastError())
 	}
 	freeOnGC(&filterList)
 
@@ -50,7 +50,7 @@ func (f *FilterList) Context() *Context {
 func (f *FilterList) AddFilter(filter *Filter) error {
 	ret := C.tiledb_filter_list_add_filter(f.context.tiledbContext, f.tiledbFilterList, filter.tiledbFilter)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error adding filter to tiledb FilterList: %s", f.context.LastError())
+		return fmt.Errorf("error adding filter to tiledb FilterList: %w", f.context.LastError())
 	}
 	return nil
 }
@@ -59,7 +59,7 @@ func (f *FilterList) AddFilter(filter *Filter) error {
 func (f *FilterList) SetMaxChunkSize(maxChunkSize uint32) error {
 	ret := C.tiledb_filter_list_set_max_chunk_size(f.context.tiledbContext, f.tiledbFilterList, C.uint32_t(maxChunkSize))
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting max chunk size on tiledb FilterList: %s", f.context.LastError())
+		return fmt.Errorf("error setting max chunk size on tiledb FilterList: %w", f.context.LastError())
 	}
 	return nil
 }
@@ -69,7 +69,7 @@ func (f *FilterList) MaxChunkSize() (uint32, error) {
 	var cMaxChunkSize C.uint32_t
 	ret := C.tiledb_filter_list_get_max_chunk_size(f.context.tiledbContext, f.tiledbFilterList, &cMaxChunkSize)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error fetching max chunk size from tiledb FilterList: %s", f.context.LastError())
+		return 0, fmt.Errorf("error fetching max chunk size from tiledb FilterList: %w", f.context.LastError())
 	}
 	return uint32(cMaxChunkSize), nil
 }
@@ -79,7 +79,7 @@ func (f *FilterList) NFilters() (uint32, error) {
 	var cNFilters C.uint32_t
 	ret := C.tiledb_filter_list_get_nfilters(f.context.tiledbContext, f.tiledbFilterList, &cNFilters)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting number of filter for tiledb FilterList: %s", f.context.LastError())
+		return 0, fmt.Errorf("error getting number of filter for tiledb FilterList: %w", f.context.LastError())
 	}
 	return uint32(cNFilters), nil
 }
@@ -89,7 +89,7 @@ func (f *FilterList) FilterFromIndex(index uint32) (*Filter, error) {
 	filter := Filter{context: f.context}
 	ret := C.tiledb_filter_list_get_filter_from_index(f.context.tiledbContext, f.tiledbFilterList, C.uint32_t(index), &filter.tiledbFilter)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error fetching filter for index %d from tiledb FilterList: %s", index, f.context.LastError())
+		return nil, fmt.Errorf("error fetching filter for index %d from tiledb FilterList: %w", index, f.context.LastError())
 	}
 	freeOnGC(&filter)
 	return &filter, nil

--- a/fragment_info.go
+++ b/fragment_info.go
@@ -34,7 +34,7 @@ func NewFragmentInfo(tdbCtx *Context, uri string) (*FragmentInfo, error) {
 	ret := C.tiledb_fragment_info_alloc(fI.context.tiledbContext,
 		curi, &fI.tiledbFragmentInfo)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error creating tiledb fragment info: %s", fI.context.LastError())
+		return nil, fmt.Errorf("error creating tiledb fragment info: %w", fI.context.LastError())
 	}
 	freeOnGC(&fI)
 
@@ -61,7 +61,7 @@ func (fI *FragmentInfo) Context() *Context {
 func (fI *FragmentInfo) Load() error {
 	ret := C.tiledb_fragment_info_load(fI.context.tiledbContext, fI.tiledbFragmentInfo)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error loading tiledb fragment info: %s", fI.context.LastError())
+		return fmt.Errorf("error loading tiledb fragment info: %w", fI.context.LastError())
 	}
 	return nil
 }
@@ -72,7 +72,7 @@ func (fI *FragmentInfo) GetFragmentNum() (uint32, error) {
 
 	ret := C.tiledb_fragment_info_get_fragment_num(fI.context.tiledbContext, fI.tiledbFragmentInfo, &cNum)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting number of fragments from fragment info: %s", fI.context.LastError())
+		return 0, fmt.Errorf("error getting number of fragments from fragment info: %w", fI.context.LastError())
 	}
 
 	return uint32(cNum), nil
@@ -86,7 +86,7 @@ func (fI *FragmentInfo) GetFragmentURI(fid uint32) (string, error) {
 		fI.tiledbFragmentInfo, C.uint32_t(fid), &curi)
 	uri := C.GoString(curi)
 	if uri == "" {
-		return uri, fmt.Errorf("Error getting URI for fragment %d: uri is empty", fid)
+		return uri, fmt.Errorf("error getting URI for fragment %d: uri is empty", fid)
 	}
 	return uri, nil
 }
@@ -98,7 +98,7 @@ func (fI *FragmentInfo) GetFragmentSize(fid uint32) (uint64, error) {
 	ret := C.tiledb_fragment_info_get_fragment_size(fI.context.tiledbContext,
 		fI.tiledbFragmentInfo, C.uint32_t(fid), &cSize)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting fragment size for fragment %d: %s", fid, fI.context.LastError())
+		return 0, fmt.Errorf("error getting fragment size for fragment %d: %w", fid, fI.context.LastError())
 	}
 
 	return uint64(cSize), nil
@@ -111,7 +111,7 @@ func (fI *FragmentInfo) GetDense(fid uint32) (bool, error) {
 	ret := C.tiledb_fragment_info_get_dense(fI.context.tiledbContext,
 		fI.tiledbFragmentInfo, C.uint32_t(fid), &cDense)
 	if ret != C.TILEDB_OK {
-		return false, fmt.Errorf("Error finding if fragment %d is dense: %s", fid, fI.context.LastError())
+		return false, fmt.Errorf("error finding if fragment %d is dense: %w", fid, fI.context.LastError())
 	}
 
 	return cDense == 1, nil
@@ -124,7 +124,7 @@ func (fI *FragmentInfo) GetSparse(fid uint32) (bool, error) {
 	ret := C.tiledb_fragment_info_get_sparse(fI.context.tiledbContext,
 		fI.tiledbFragmentInfo, C.uint32_t(fid), &cSparse)
 	if ret != C.TILEDB_OK {
-		return false, fmt.Errorf("Error finding if fragment %d is dense: %s", fid, fI.context.LastError())
+		return false, fmt.Errorf("error finding if fragment %d is dense: %w", fid, fI.context.LastError())
 	}
 
 	return cSparse == 1, nil
@@ -138,7 +138,7 @@ func (fI *FragmentInfo) GetTimestampRange(fid uint32) (uint64, uint64, error) {
 	ret := C.tiledb_fragment_info_get_timestamp_range(fI.context.tiledbContext,
 		fI.tiledbFragmentInfo, C.uint32_t(fid), &cStart, &cEnd)
 	if ret != C.TILEDB_OK {
-		return 0, 0, fmt.Errorf("Error getting the timestamp range for fragment %d: %s", fid, fI.context.LastError())
+		return 0, 0, fmt.Errorf("error getting the timestamp range for fragment %d: %w", fid, fI.context.LastError())
 	}
 
 	return uint64(cStart), uint64(cEnd), nil
@@ -227,7 +227,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainFromIndex(fid uint32, did uint32) (*Non
 		(C.uint32_t)(did),
 		tmpDimensionPtr)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error in getting non empty domain from fragment %d for a given dimension index %d: %s", fid, did, fI.context.LastError())
+		return nil, fmt.Errorf("error in getting non empty domain from fragment %d for a given dimension index %d: %w", fid, did, fI.context.LastError())
 	}
 
 	if isEmpty == 1 {
@@ -261,7 +261,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainFromName(fid uint32, did string) (*NonE
 		cDid,
 		tmpDimensionPtr)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error in getting non empty domain from fragment %d for a given dimension name %s: %s", fid, did, fI.context.LastError())
+		return nil, fmt.Errorf("error in getting non empty domain from fragment %d for a given dimension name %s: %w", fid, did, fI.context.LastError())
 	}
 
 	// If at least one domain for a dimension is empty the union of domains is non-empty
@@ -284,7 +284,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainVarSizeFromIndex(fid uint32, did uint32
 	ret := C.tiledb_fragment_info_get_non_empty_domain_var_size_from_index(fI.context.tiledbContext,
 		fI.tiledbFragmentInfo, C.uint32_t(fid), C.uint32_t(did), &cStart, &cEnd)
 	if ret != C.TILEDB_OK {
-		return 0, 0, fmt.Errorf("Error retrieving the non-empty domain range sizes from fragment %d for a given dimension index %d: %s", fid, did, fI.context.LastError())
+		return 0, 0, fmt.Errorf("error retrieving the non-empty domain range sizes from fragment %d for a given dimension index %d: %w", fid, did, fI.context.LastError())
 	}
 
 	return uint64(cStart), uint64(cEnd), nil
@@ -302,7 +302,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainVarSizeFromName(fid uint32, did string)
 	ret := C.tiledb_fragment_info_get_non_empty_domain_var_size_from_name(fI.context.tiledbContext,
 		fI.tiledbFragmentInfo, C.uint32_t(fid), cDid, &cStart, &cEnd)
 	if ret != C.TILEDB_OK {
-		return 0, 0, fmt.Errorf("Error retrieving the non-empty domain range sizes from fragment %d for a given dimension name %s: %s", fid, did, fI.context.LastError())
+		return 0, 0, fmt.Errorf("error retrieving the non-empty domain range sizes from fragment %d for a given dimension name %s: %w", fid, did, fI.context.LastError())
 	}
 
 	return uint64(cStart), uint64(cEnd), nil
@@ -317,7 +317,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainVarFromIndex(fid uint32, did uint32) (*
 	ret := C.tiledb_fragment_info_get_non_empty_domain_var_size_from_index(fI.context.tiledbContext,
 		fI.tiledbFragmentInfo, C.uint32_t(fid), C.uint32_t(did), &cStartSize, &cEndSize)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error retrieving the non-empty domain range sizes from fragment %d for a given dimension index %d: %s", fid, did, fI.context.LastError())
+		return nil, fmt.Errorf("error retrieving the non-empty domain range sizes from fragment %d for a given dimension index %d: %w", fid, did, fI.context.LastError())
 	}
 
 	err := fI.useArrayFromCache()
@@ -342,7 +342,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainVarFromIndex(fid uint32, did uint32) (*
 
 	dimension, err := domain.DimensionFromIndex(uint(did))
 	if err != nil {
-		return nil, fmt.Errorf("Could not get dimension having index: %d", did)
+		return nil, fmt.Errorf("could not get dimension having index: %d", did)
 	}
 
 	dimType, err := dimension.Type()
@@ -373,7 +373,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainVarFromIndex(fid uint32, did uint32) (*
 		cend)
 
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error in getting non empty domain for dimension index %d for fragment info %d: %s",
+		return nil, fmt.Errorf("error in getting non empty domain for dimension index %d for fragment info %d: %w",
 			did, fid, fI.context.LastError())
 	}
 
@@ -402,7 +402,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainVarFromName(fid uint32, did string) (*N
 	ret := C.tiledb_fragment_info_get_non_empty_domain_var_size_from_name(fI.context.tiledbContext,
 		fI.tiledbFragmentInfo, C.uint32_t(fid), cDid, &cStartSize, &cEndSize)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error retrieving the non-empty domain range sizes from fragment %d for a given dimension name %s: %s", fid, did, fI.context.LastError())
+		return nil, fmt.Errorf("error retrieving the non-empty domain range sizes from fragment %d for a given dimension name %s: %w", fid, did, fI.context.LastError())
 	}
 
 	err := fI.useArrayFromCache()
@@ -427,7 +427,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainVarFromName(fid uint32, did string) (*N
 
 	dimension, err := domain.DimensionFromName(did)
 	if err != nil {
-		return nil, fmt.Errorf("Could not get dimension having name: %s", did)
+		return nil, fmt.Errorf("could not get dimension having name: %s", did)
 	}
 
 	dimType, err := dimension.Type()
@@ -458,7 +458,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainVarFromName(fid uint32, did string) (*N
 		cend)
 
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error in getting non empty domain for dimension name %s for fragment info %d: %s",
+		return nil, fmt.Errorf("error in getting non empty domain for dimension name %s for fragment info %d: %w",
 			did, fid, fI.context.LastError())
 	}
 
@@ -489,7 +489,7 @@ func (fI *FragmentInfo) GetCellNum(fid uint32) (uint64, error) {
 	ret := C.tiledb_fragment_info_get_cell_num(fI.context.tiledbContext,
 		fI.tiledbFragmentInfo, C.uint32_t(fid), &cCellNum)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error retrieving number of cells written to the fragment %d by the user: %s", fid, fI.context.LastError())
+		return 0, fmt.Errorf("error retrieving number of cells written to the fragment %d by the user: %w", fid, fI.context.LastError())
 	}
 
 	return uint64(cCellNum), nil
@@ -502,7 +502,7 @@ func (fI *FragmentInfo) GetVersion(fid uint32) (uint32, error) {
 	ret := C.tiledb_fragment_info_get_version(fI.context.tiledbContext,
 		fI.tiledbFragmentInfo, C.uint32_t(fid), &cVersion)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error finding version of fragment %d: %s", fid, fI.context.LastError())
+		return 0, fmt.Errorf("error finding version of fragment %d: %w", fid, fI.context.LastError())
 	}
 
 	return uint32(cVersion), nil
@@ -515,7 +515,7 @@ func (fI *FragmentInfo) HasConsolidatedMetadata(fid uint32) (bool, error) {
 	ret := C.tiledb_fragment_info_has_consolidated_metadata(fI.context.tiledbContext,
 		fI.tiledbFragmentInfo, C.uint32_t(fid), &cHas)
 	if ret != C.TILEDB_OK {
-		return false, fmt.Errorf("Error finding if fragment %d has consolidated metadata: %s", fid, fI.context.LastError())
+		return false, fmt.Errorf("error finding if fragment %d has consolidated metadata: %w", fid, fI.context.LastError())
 	}
 
 	return cHas == 1, nil
@@ -528,7 +528,7 @@ func (fI *FragmentInfo) GetUnconsolidatedMetadataNum() (uint32, error) {
 
 	ret := C.tiledb_fragment_info_get_unconsolidated_metadata_num(fI.context.tiledbContext, fI.tiledbFragmentInfo, &cNum)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting number of fragments with unconsolidated metadata: %s", fI.context.LastError())
+		return 0, fmt.Errorf("error getting number of fragments with unconsolidated metadata: %w", fI.context.LastError())
 	}
 
 	return uint32(cNum), nil
@@ -540,7 +540,7 @@ func (fI *FragmentInfo) GetToVacuumNum() (uint32, error) {
 
 	ret := C.tiledb_fragment_info_get_to_vacuum_num(fI.context.tiledbContext, fI.tiledbFragmentInfo, &cNum)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting number of fragments to vacuum: %s", fI.context.LastError())
+		return 0, fmt.Errorf("error getting number of fragments to vacuum: %w", fI.context.LastError())
 	}
 
 	return uint32(cNum), nil
@@ -552,11 +552,11 @@ func (fI *FragmentInfo) GetToVacuumURI(fid uint32) (string, error) {
 	var curi *C.char
 	ret := C.tiledb_fragment_info_get_to_vacuum_uri(fI.context.tiledbContext, fI.tiledbFragmentInfo, C.uint32_t(fid), &curi)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error getting URI uri for fragment to vacuum: %s", fI.context.LastError())
+		return "", fmt.Errorf("error getting URI uri for fragment to vacuum: %w", fI.context.LastError())
 	}
 	uri := C.GoString(curi)
 	if uri == "" {
-		return "", fmt.Errorf("Error getting URI for fragment %d to vacuum: uri is empty", fid)
+		return "", fmt.Errorf("error getting URI for fragment %d to vacuum: uri is empty", fid)
 	}
 	return uri, nil
 }
@@ -565,7 +565,7 @@ func (fI *FragmentInfo) GetToVacuumURI(fid uint32) (string, error) {
 func (fI *FragmentInfo) DumpSTDOUT() error {
 	ret := C.tiledb_fragment_info_dump(fI.context.tiledbContext, fI.tiledbFragmentInfo, C.stdout)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error dumping fragment info to stdout: %s", fI.context.LastError())
+		return fmt.Errorf("error dumping fragment info to stdout: %w", fI.context.LastError())
 	}
 	return nil
 }
@@ -591,7 +591,7 @@ func (fI *FragmentInfo) String() (string, error) {
 func (fI *FragmentInfo) SetConfig(config *Config) error {
 	ret := C.tiledb_fragment_info_set_config(fI.context.tiledbContext, fI.tiledbFragmentInfo, config.tiledbConfig)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting config on group: %s", fI.context.LastError())
+		return fmt.Errorf("error setting config on group: %w", fI.context.LastError())
 	}
 	fI.config = config
 	return nil
@@ -602,7 +602,7 @@ func (fI *FragmentInfo) Config() (*Config, error) {
 	var config Config
 	ret := C.tiledb_fragment_info_get_config(fI.context.tiledbContext, fI.tiledbFragmentInfo, &config.tiledbConfig)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting config from fragment info: %s", fI.context.LastError())
+		return nil, fmt.Errorf("error getting config from fragment info: %w", fI.context.LastError())
 	}
 	freeOnGC(&config)
 

--- a/group.go
+++ b/group.go
@@ -28,7 +28,7 @@ func NewGroup(tdbCtx *Context, uri string) (*Group, error) {
 	group := Group{context: tdbCtx, uri: uri}
 	ret := C.tiledb_group_alloc(group.context.tiledbContext, curi, &group.group)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error creating tiledb group: %s", group.context.LastError())
+		return nil, fmt.Errorf("error creating tiledb group: %w", group.context.LastError())
 	}
 	freeOnGC(&group)
 
@@ -42,7 +42,7 @@ func (g *Group) Create() error {
 
 	ret := C.tiledb_group_create(g.context.tiledbContext, curi)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error in creating group: %s", g.context.LastError())
+		return fmt.Errorf("error in creating group: %w", g.context.LastError())
 	}
 	return nil
 }
@@ -50,7 +50,7 @@ func (g *Group) Create() error {
 func (g *Group) Open(queryType QueryType) error {
 	ret := C.tiledb_group_open(g.context.tiledbContext, g.group, C.tiledb_query_type_t(queryType))
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error opening tiledb group for querying: %s", g.context.LastError())
+		return fmt.Errorf("error opening tiledb group for querying: %w", g.context.LastError())
 	}
 	return nil
 }
@@ -65,7 +65,7 @@ func (g *Group) Free() {
 func (g *Group) Close() error {
 	ret := C.tiledb_group_close(g.context.tiledbContext, g.group)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error closing tiledb group: %s", g.context.LastError())
+		return fmt.Errorf("error closing tiledb group: %w", g.context.LastError())
 	}
 	return nil
 }
@@ -73,7 +73,7 @@ func (g *Group) Close() error {
 func (g *Group) SetConfig(config *Config) error {
 	ret := C.tiledb_group_set_config(g.context.tiledbContext, g.group, config.tiledbConfig)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting config on group: %s", g.context.LastError())
+		return fmt.Errorf("error setting config on group: %w", g.context.LastError())
 	}
 	g.config = config
 	return nil
@@ -83,7 +83,7 @@ func (g *Group) Config() (*Config, error) {
 	var config Config
 	ret := C.tiledb_group_get_config(g.context.tiledbContext, g.group, &config.tiledbConfig)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting config from query: %s", g.context.LastError())
+		return nil, fmt.Errorf("error getting config from query: %w", g.context.LastError())
 	}
 	freeOnGC(&config)
 
@@ -108,7 +108,7 @@ func (g *Group) AddMember(uri, name string, isRelativeURI bool) error {
 
 	ret := C.tiledb_group_add_member(g.context.tiledbContext, g.group, curi, cRelative, cname)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error adding member to group: %s", g.context.LastError())
+		return fmt.Errorf("error adding member to group: %w", g.context.LastError())
 	}
 	return nil
 }
@@ -229,7 +229,7 @@ func (g *Group) RemoveMember(uri string) error {
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_group_remove_member(g.context.tiledbContext, g.group, curi)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error removing member from group: %s", g.context.LastError())
+		return fmt.Errorf("error removing member from group: %w", g.context.LastError())
 	}
 	return nil
 }
@@ -238,7 +238,7 @@ func (g *Group) GetMemberCount() (uint64, error) {
 	var count C.uint64_t
 	ret := C.tiledb_group_get_member_count(g.context.tiledbContext, g.group, &count)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error retrieving member count in group: %s", g.context.LastError())
+		return 0, fmt.Errorf("error retrieving member count in group: %w", g.context.LastError())
 	}
 	return uint64(count), nil
 }
@@ -251,7 +251,7 @@ func (g *Group) GetMemberFromIndex(index uint64) (string, string, ObjectTypeEnum
 	var objectTypeEnum C.tiledb_object_t
 	ret := C.tiledb_group_get_member_by_index_v2(g.context.tiledbContext, g.group, C.uint64_t(index), &curi, &objectTypeEnum, &cname)
 	if ret != C.TILEDB_OK {
-		return "", "", TILEDB_INVALID, fmt.Errorf("Error getting member by index for group: %s", g.context.LastError())
+		return "", "", TILEDB_INVALID, fmt.Errorf("error getting member by index for group: %w", g.context.LastError())
 	}
 	defer C.tiledb_string_free(&curi)
 	defer C.tiledb_string_free(&cname)
@@ -278,7 +278,7 @@ func (g *Group) GetMemberByName(name string) (string, string, ObjectTypeEnum, er
 	var objectTypeEnum C.tiledb_object_t
 	ret := C.tiledb_group_get_member_by_name_v2(g.context.tiledbContext, g.group, cname, &curi, &objectTypeEnum)
 	if ret != C.TILEDB_OK {
-		return "", "", TILEDB_INVALID, fmt.Errorf("Error getting member by index for group: %s", g.context.LastError())
+		return "", "", TILEDB_INVALID, fmt.Errorf("error getting member by index for group: %w", g.context.LastError())
 	}
 	defer C.tiledb_string_free(&curi)
 
@@ -288,7 +288,7 @@ func (g *Group) GetMemberByName(name string) (string, string, ObjectTypeEnum, er
 	}
 
 	if name == "" {
-		return "", "", TILEDB_INVALID, fmt.Errorf("Error getting name for member %s: name is empty", name)
+		return "", "", TILEDB_INVALID, fmt.Errorf("error getting name for member %s: name is empty", name)
 	}
 
 	name = C.GoString(cname)
@@ -306,18 +306,18 @@ func (g *Group) GetMetadata(key string) (Datatype, uint, interface{}, error) {
 
 	ret := C.tiledb_group_get_metadata(g.context.tiledbContext, g.group, ckey, &cType, &cValueNum, &cvalue)
 	if ret != C.TILEDB_OK {
-		return 0, 0, nil, fmt.Errorf("Error getting metadata from group: %s, key: %s", g.context.LastError(), key)
+		return 0, 0, nil, fmt.Errorf("error getting metadata from group: %w, key: %s", g.context.LastError(), key)
 	}
 
 	valueNum := uint(cValueNum)
 	if valueNum == 0 {
-		return 0, 0, nil, fmt.Errorf("Error getting metadata from group, key: %s does not exist", key)
+		return 0, 0, nil, fmt.Errorf("error getting metadata from group, key: %s does not exist", key)
 	}
 
 	datatype := Datatype(cType)
 	value, err := datatype.GetValue(valueNum, cvalue)
 	if err != nil {
-		return 0, 0, nil, fmt.Errorf("%s, key: %s", err.Error(), key)
+		return 0, 0, nil, fmt.Errorf("%w, key: %s", err, key)
 	}
 
 	return datatype, valueNum, value, nil
@@ -329,7 +329,7 @@ func (g *Group) DeleteMetadata(key string) error {
 
 	ret := C.tiledb_group_delete_metadata(g.context.tiledbContext, g.group, ckey)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error deleting metadata from group: %s", g.context.LastError())
+		return fmt.Errorf("error deleting metadata from group: %w", g.context.LastError())
 	}
 	return nil
 }
@@ -339,7 +339,7 @@ func (g *Group) GetMetadataNum() (uint64, error) {
 
 	ret := C.tiledb_group_get_metadata_num(g.context.tiledbContext, g.group, &cNum)
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting number of metadata from group: %s", g.context.LastError())
+		return 0, fmt.Errorf("error getting number of metadata from group: %w", g.context.LastError())
 	}
 
 	return uint64(cNum), nil
@@ -361,12 +361,12 @@ func (g *Group) GetMetadataFromIndexWithValueLimit(index uint64, limit *uint) (*
 	ret := C.tiledb_group_get_metadata_from_index(g.context.tiledbContext,
 		g.group, cIndex, &cKey, &cKeyLen, &cType, &cValueNum, &cvalue)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error getting metadata from group: %s, index: %d", g.context.LastError(), index)
+		return nil, fmt.Errorf("error getting metadata from group: %s, index: %d", g.context.LastError(), index)
 	}
 
 	valueNum := uint(cValueNum)
 	if valueNum == 0 {
-		return nil, fmt.Errorf("Error getting metadata from group, Index: %d does not exist", index)
+		return nil, fmt.Errorf("error getting metadata from group, Index: %d does not exist", index)
 	}
 
 	datatype := Datatype(cType)
@@ -427,7 +427,7 @@ func (g *Group) GetIsRelativeURIByName(name string) (bool, error) {
 	var isRelative C.uint8_t
 	ret := C.tiledb_group_get_is_relative_uri_by_name(g.context.tiledbContext, g.group, cName, &isRelative)
 	if ret != C.TILEDB_OK {
-		return false, fmt.Errorf("Error getting if member %s has a relative uri: %s", name, g.context.LastError())
+		return false, fmt.Errorf("error getting if member %s has a relative uri: %w", name, g.context.LastError())
 	}
 	return isRelative > 0, nil
 }
@@ -446,7 +446,7 @@ func (g *Group) Delete(recursive bool) error {
 
 	ret := C.tiledb_group_delete_group(g.context.tiledbContext, g.group, curi, cRecursive)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error deleting group: %s", g.context.LastError())
+		return fmt.Errorf("error deleting group: %w", g.context.LastError())
 	}
 	return nil
 }

--- a/group_test.go
+++ b/group_test.go
@@ -281,7 +281,7 @@ func TestGetIsRelativeURIByName(t *testing.T) {
 	// check that non-existing members return error
 	_, err = group.GetIsRelativeURIByName("array3")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Error getting")
+	require.Contains(t, err.Error(), "error getting")
 
 	require.NoError(t, group.Close())
 }

--- a/object.go
+++ b/object.go
@@ -7,6 +7,7 @@ package tiledb
 */
 import "C"
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 
@@ -17,7 +18,7 @@ import (
 // A TileDB "object" is currently either a TileDB array or a TileDB group.
 func ObjectType(tdbCtx *Context, path string) (ObjectTypeEnum, error) {
 	if tdbCtx == nil {
-		return TILEDB_INVALID, fmt.Errorf("error getting object type, context is nil")
+		return TILEDB_INVALID, errors.New("error getting object type, context is nil")
 	}
 
 	var objectTypeEnum C.tiledb_object_t
@@ -25,7 +26,7 @@ func ObjectType(tdbCtx *Context, path string) (ObjectTypeEnum, error) {
 	defer C.free(unsafe.Pointer(cpath))
 	ret := C.tiledb_object_type(tdbCtx.tiledbContext, cpath, &objectTypeEnum)
 	if ret != C.TILEDB_OK {
-		return TILEDB_INVALID, fmt.Errorf("Cannot get object type from path %s: %s",
+		return TILEDB_INVALID, fmt.Errorf("cannot get object type from path %s: %w",
 			path, tdbCtx.LastError())
 	}
 
@@ -64,7 +65,7 @@ func objectsInPath(path *C.cchar_t, objectTypeEnum C.tiledb_object_t, data unsaf
 // (e.g., file or directory) that is not TileDB-related.
 func ObjectWalk(tdbCtx *Context, path string, walkOrder WalkOrder) (*ObjectList, error) {
 	if tdbCtx == nil {
-		return nil, fmt.Errorf("error walking object, context is nil")
+		return nil, errors.New("error walking object, context is nil")
 	}
 
 	cpath := C.CString(path)
@@ -81,7 +82,7 @@ func ObjectWalk(tdbCtx *Context, path string, walkOrder WalkOrder) (*ObjectList,
 	fmt.Println(objectList)
 
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Cannot walk in path %s: %s", path,
+		return nil, fmt.Errorf("cannot walk in path %s: %w", path,
 			tdbCtx.LastError())
 	}
 	return &objectList, nil
@@ -91,7 +92,7 @@ func ObjectWalk(tdbCtx *Context, path string, walkOrder WalkOrder) (*ObjectList,
 // of `path` (it does not recursively continue to the children directories).
 func ObjectLs(tdbCtx *Context, path string) (*ObjectList, error) {
 	if tdbCtx == nil {
-		return nil, fmt.Errorf("error listing object, context is nil")
+		return nil, errors.New("error listing object, context is nil")
 	}
 
 	cpath := C.CString(path)
@@ -106,7 +107,7 @@ func ObjectLs(tdbCtx *Context, path string) (*ObjectList, error) {
 		unsafe.Pointer(data))
 
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Cannot walk in path %s: %s", path,
+		return nil, fmt.Errorf("cannot walk in path %s: %w", path,
 			tdbCtx.LastError())
 	}
 	return &objectList, nil
@@ -116,7 +117,7 @@ func ObjectLs(tdbCtx *Context, path string) (*ObjectList, error) {
 // Param path is the new path to move to
 func ObjectMove(tdbCtx *Context, path string, newPath string) error {
 	if tdbCtx == nil {
-		return fmt.Errorf("error moving object, context is nil")
+		return errors.New("error moving object, context is nil")
 	}
 
 	cpath := C.CString(path)
@@ -125,7 +126,7 @@ func ObjectMove(tdbCtx *Context, path string, newPath string) error {
 	defer C.free(unsafe.Pointer(cnewPath))
 	ret := C.tiledb_object_move(tdbCtx.tiledbContext, cpath, cnewPath)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Cannot move object from %s to %s: %s", path,
+		return fmt.Errorf("cannot move object from %s to %s: %w", path,
 			newPath, tdbCtx.LastError())
 	}
 
@@ -135,14 +136,14 @@ func ObjectMove(tdbCtx *Context, path string, newPath string) error {
 // ObjectRemove deletes a TileDB resource (group, array, key-value).
 func ObjectRemove(tdbCtx *Context, path string) error {
 	if tdbCtx == nil {
-		return fmt.Errorf("error removing object, context is nil")
+		return errors.New("error removing object, context is nil")
 	}
 
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
 	ret := C.tiledb_object_remove(tdbCtx.tiledbContext, cpath)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Cannot delete object %s: %s", path, tdbCtx.LastError())
+		return fmt.Errorf("cannot delete object %s: %w", path, tdbCtx.LastError())
 	}
 	return nil
 }

--- a/query_condition.go
+++ b/query_condition.go
@@ -21,7 +21,7 @@ type QueryCondition struct {
 func NewQueryCondition(tdbCtx *Context, attributeName string, op QueryConditionOp, value interface{}) (*QueryCondition, error) {
 	qc := QueryCondition{context: tdbCtx}
 	if ret := C.tiledb_query_condition_alloc(qc.context.tiledbContext, &qc.cond); ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error allocating tiledb query condition: %s", qc.context.LastError())
+		return nil, fmt.Errorf("error allocating tiledb query condition: %w", qc.context.LastError())
 	}
 	freeOnGC(&qc)
 
@@ -37,7 +37,7 @@ func NewQueryCondition(tdbCtx *Context, attributeName string, op QueryConditionO
 func NewQueryConditionCombination(tdbCtx *Context, left *QueryCondition, op QueryConditionCombinationOp, right *QueryCondition) (*QueryCondition, error) {
 	qc := QueryCondition{context: tdbCtx}
 	if ret := C.tiledb_query_condition_combine(qc.context.tiledbContext, left.cond, right.cond, C.tiledb_query_condition_combination_op_t(op), &qc.cond); ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error allocating tiledb query condition: %s", qc.context.LastError())
+		return nil, fmt.Errorf("error allocating tiledb query condition: %w", qc.context.LastError())
 	}
 	freeOnGC(&qc)
 
@@ -49,7 +49,7 @@ func NewQueryConditionCombination(tdbCtx *Context, left *QueryCondition, op Quer
 func NewQueryConditionNegated(tdbCtx *Context, qc *QueryCondition) (*QueryCondition, error) {
 	nqc := QueryCondition{context: tdbCtx}
 	if ret := C.tiledb_query_condition_negate(qc.context.tiledbContext, qc.cond, &nqc.cond); ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error allocating tiledb query condition: %s", qc.context.LastError())
+		return nil, fmt.Errorf("error allocating tiledb query condition: %w", qc.context.LastError())
 	}
 	freeOnGC(&nqc)
 

--- a/query_condition_test.go
+++ b/query_condition_test.go
@@ -28,7 +28,7 @@ var testAttributeValues = struct {
 }
 
 func TestQueryCondition(t *testing.T) {
-	array, err := createBasicTestArray(t, "test_query_condition")
+	array, err := createBasicTestArray(t)
 	if err != nil {
 		t.Errorf("failed to create basic test array: %s", err)
 	}
@@ -273,7 +273,7 @@ func testQueryConditionBytes(t *testing.T, array *Array) {
 	}
 }
 
-func createBasicTestArray(t testing.TB, identifier string) (*Array, error) {
+func createBasicTestArray(t testing.TB) (*Array, error) {
 	// Create configuration
 	config, err := NewConfig()
 	if err != nil {

--- a/query_experimental.go
+++ b/query_experimental.go
@@ -19,7 +19,7 @@ type QueryStatusDetails struct {
 func (q *Query) RelevantFragmentNum() (uint64, error) {
 	var num C.uint64_t
 	if ret := C.tiledb_query_get_relevant_fragment_num(q.context.tiledbContext, q.tiledbQuery, &num); ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error getting relevant fragment num from query: %s", q.context.LastError())
+		return 0, fmt.Errorf("error getting relevant fragment num from query: %w", q.context.LastError())
 	}
 
 	return uint64(num), nil
@@ -30,7 +30,7 @@ func (q *Query) StatusDetails() (QueryStatusDetails, error) {
 	var details QueryStatusDetails
 	var cDetails C.tiledb_query_status_details_t
 	if ret := C.tiledb_query_get_status_details(q.context.tiledbContext, q.tiledbQuery, &cDetails); ret != C.TILEDB_OK {
-		return details, fmt.Errorf("Error getting query status details: %s", q.context.LastError())
+		return details, fmt.Errorf("error getting query status details: %w", q.context.LastError())
 	}
 	details.IncompleteReason = QueryStatusDetailsReason(cDetails.incomplete_reason)
 	return details, nil
@@ -63,7 +63,7 @@ func (q *Query) GetPlan() (string, error) {
 
 	ret := C.tiledb_query_get_plan(q.context.tiledbContext, q.tiledbQuery, &plan)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error getting query plan: %s", q.context.LastError())
+		return "", fmt.Errorf("error getting query plan: %w", q.context.LastError())
 	}
 	defer C.tiledb_string_free(&plan)
 
@@ -71,7 +71,7 @@ func (q *Query) GetPlan() (string, error) {
 	var sPlanSize C.size_t
 	ret = C.tiledb_string_view(plan, &sPlan, &sPlanSize)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error extracting query query: %s", q.context.LastError())
+		return "", fmt.Errorf("error extracting query query: %w", q.context.LastError())
 	}
 
 	return C.GoStringN(sPlan, C.int(sPlanSize)), nil

--- a/query_experimental_test.go
+++ b/query_experimental_test.go
@@ -188,7 +188,7 @@ const templateQueryPlan = `{
 }`
 
 // requirePlanAsExpected checks if a query plan conforms to the query plan template
-func requirePlanAsExpected(t *testing.T, arrayPath, actualPlan string, diffs map[string]interface{}) {
+func requirePlanAsExpected(t *testing.T, actualPlan string, diffs map[string]interface{}) {
 	var expectedPlan bytes.Buffer
 	require.NoError(t, template.Must(template.New("plan").Parse(templateQueryPlan)).Execute(&expectedPlan, diffs))
 
@@ -320,7 +320,7 @@ func TestQueryPlan(t *testing.T) {
 	actualPlan, err := query.GetPlan()
 	require.NoError(t, err)
 
-	requirePlanAsExpected(t, tmpArrayPath, actualPlan, map[string]interface{}{
+	requirePlanAsExpected(t, actualPlan, map[string]interface{}{
 		"uri":      "file://" + tmpArrayPath,
 		"layout":   "row-major",
 		"strategy": "DenseReader",

--- a/serialize.go
+++ b/serialize.go
@@ -29,7 +29,7 @@ func SerializeArraySchemaToBuffer(schema *ArraySchema, serializationType Seriali
 
 	ret := C.tiledb_serialize_array_schema(schema.context.tiledbContext, schema.tiledbArraySchema, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error serializing array schema: %s", schema.context.LastError())
+		return nil, fmt.Errorf("error serializing array schema: %w", schema.context.LastError())
 	}
 
 	return &buffer, nil
@@ -60,7 +60,7 @@ func DeserializeArraySchema(buffer *Buffer, serializationType SerializationType,
 
 	ret := C.tiledb_deserialize_array_schema(schema.context.tiledbContext, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, &schema.tiledbArraySchema)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error deserializing array schema: %s", schema.context.LastError())
+		return nil, fmt.Errorf("error deserializing array schema: %w", schema.context.LastError())
 	}
 
 	// This needs to happen *after* the tiledb_deserialize_array_schema call
@@ -89,7 +89,7 @@ func SerializeArraySchemaEvolutionToBuffer(arraySchemaEvolution *ArraySchemaEvol
 		C.tiledb_serialization_type_t(serializationType),
 		cClientSide, &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error serializing array schem evolution: %s",
+		return nil, fmt.Errorf("error serializing array schem evolution: %w",
 			arraySchemaEvolution.context.LastError())
 	}
 
@@ -124,7 +124,7 @@ func DeserializeArraySchemaEvolution(buffer *Buffer, serializationType Serializa
 		C.tiledb_serialization_type_t(serializationType),
 		cClientSide, &arraySchemaEvolution.tiledbArraySchemaEvolution)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error deserializing array schema evolution: %s", arraySchemaEvolution.context.LastError())
+		return nil, fmt.Errorf("error deserializing array schema evolution: %w", arraySchemaEvolution.context.LastError())
 	}
 
 	// This needs to happen *after* the tiledb_deserialize_array_schema_evolution
@@ -159,7 +159,7 @@ func SerializeArrayNonEmptyDomainToBuffer(a *Array, serializationType Serializat
 	tmpDomain := make([]uint8, subarraySize)
 	ret := C.tiledb_array_get_non_empty_domain(a.context.tiledbContext, a.tiledbArray, slicePtr(tmpDomain), &isEmpty)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error serializing array nonempty domain: %s", a.context.LastError())
+		return nil, fmt.Errorf("error serializing array nonempty domain: %w", a.context.LastError())
 	}
 
 	buffer := Buffer{context: schema.context}
@@ -168,7 +168,7 @@ func SerializeArrayNonEmptyDomainToBuffer(a *Array, serializationType Serializat
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
 	ret = C.tiledb_serialize_array_nonempty_domain(a.context.tiledbContext, a.tiledbArray, slicePtr(tmpDomain), isEmpty, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error serializing array nonempty domain: %s", a.context.LastError())
+		return nil, fmt.Errorf("error serializing array nonempty domain: %w", a.context.LastError())
 	}
 
 	return &buffer, nil
@@ -214,7 +214,7 @@ func DeserializeArrayNonEmptyDomain(a *Array, buffer *Buffer, serializationType 
 	var isEmpty C.int32_t
 	ret := C.tiledb_deserialize_array_nonempty_domain(a.context.tiledbContext, a.tiledbArray, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, tmpDomainPtr, &isEmpty)
 	if ret != C.TILEDB_OK {
-		return nil, false, fmt.Errorf("error serializing array nonempty domain: %s", a.context.LastError())
+		return nil, false, fmt.Errorf("error serializing array nonempty domain: %w", a.context.LastError())
 	}
 
 	if isEmpty == 1 {
@@ -277,7 +277,7 @@ func SerializeArrayNonEmptyDomainAllDimensionsToBuffer(a *Array, serializationTy
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
 	ret := C.tiledb_serialize_array_non_empty_domain_all_dimensions(a.context.tiledbContext, a.tiledbArray, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error serializing array nonempty domain: %s", a.context.LastError())
+		return nil, fmt.Errorf("error serializing array nonempty domain: %w", a.context.LastError())
 	}
 
 	return &buffer, nil
@@ -301,7 +301,7 @@ func DeserializeArrayNonEmptyDomainAllDimensions(a *Array, buffer *Buffer, seria
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
 	ret := C.tiledb_deserialize_array_non_empty_domain_all_dimensions(a.context.tiledbContext, a.tiledbArray, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error deserializing array nonempty domain: %s", a.context.LastError())
+		return fmt.Errorf("error deserializing array nonempty domain: %w", a.context.LastError())
 	}
 
 	return nil
@@ -321,7 +321,7 @@ func SerializeQuery(query *Query, serializationType SerializationType, clientSid
 
 	ret := C.tiledb_serialize_query(query.context.tiledbContext, query.tiledbQuery, C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferList.tiledbBufferList)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error serializing query: %s", query.context.LastError())
+		return nil, fmt.Errorf("error serializing query: %w", query.context.LastError())
 	}
 
 	return &bufferList, nil
@@ -338,7 +338,7 @@ func DeserializeQuery(query *Query, buffer *Buffer, serializationType Serializat
 
 	ret := C.tiledb_deserialize_query(query.context.tiledbContext, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, query.tiledbQuery)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error deserializing query: %s", query.context.LastError())
+		return fmt.Errorf("error deserializing query: %w", query.context.LastError())
 	}
 
 	return nil
@@ -351,7 +351,7 @@ func SerializeArrayMetadataToBuffer(a *Array, serializationType SerializationTyp
 
 	ret := C.tiledb_serialize_array_metadata(a.context.tiledbContext, a.tiledbArray, C.tiledb_serialization_type_t(serializationType), &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error serializing array metadata: %s", a.context.LastError())
+		return nil, fmt.Errorf("error serializing array metadata: %w", a.context.LastError())
 	}
 
 	return &buffer, nil
@@ -373,7 +373,7 @@ func SerializeArrayMetadata(a *Array, serializationType SerializationType) ([]by
 func DeserializeArrayMetadata(a *Array, buffer *Buffer, serializationType SerializationType) error {
 	ret := C.tiledb_deserialize_array_metadata(a.context.tiledbContext, a.tiledbArray, C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error deserializing array metadata: %s", a.context.LastError())
+		return fmt.Errorf("error deserializing array metadata: %w", a.context.LastError())
 	}
 	return nil
 }
@@ -392,7 +392,7 @@ func SerializeQueryEstResultSizesToBuffer(q *Query, serializationType Serializat
 
 	ret := C.tiledb_serialize_query_est_result_sizes(q.context.tiledbContext, q.tiledbQuery, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error serializing query est buffer sizes: %s", q.context.LastError())
+		return nil, fmt.Errorf("error serializing query est buffer sizes: %w", q.context.LastError())
 	}
 
 	return &buffer, nil
@@ -421,7 +421,7 @@ func DeserializeQueryEstResultSizes(q *Query, buffer *Buffer, serializationType 
 
 	ret := C.tiledb_deserialize_query_est_result_sizes(q.context.tiledbContext, q.tiledbQuery, C.tiledb_serialization_type_t(serializationType), cClientSide, buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error deserializing query est buffer sizes: %s", q.context.LastError())
+		return fmt.Errorf("error deserializing query est buffer sizes: %w", q.context.LastError())
 	}
 	return nil
 }
@@ -441,7 +441,7 @@ func SerializeArrayToBuffer(array *Array, serializationType SerializationType, c
 
 	ret := C.tiledb_serialize_array(array.context.tiledbContext, array.tiledbArray, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error serializing array: %s", array.context.LastError())
+		return nil, fmt.Errorf("error serializing array: %w", array.context.LastError())
 	}
 
 	return &buffer, nil
@@ -475,7 +475,7 @@ func DeserializeArray(buffer *Buffer, serializationType SerializationType, clien
 
 	ret := C.tiledb_deserialize_array(array.context.tiledbContext, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, cArrayURI, &array.tiledbArray)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error deserializing array: %s", array.context.LastError())
+		return nil, fmt.Errorf("error deserializing array: %w", array.context.LastError())
 	}
 
 	// Set finalizer for free C pointer on gc
@@ -502,7 +502,7 @@ func SerializeFragmentInfoToBuffer(fragmentInfo *FragmentInfo, serializationType
 
 	ret := C.tiledb_serialize_fragment_info(fragmentInfo.context.tiledbContext, fragmentInfo.tiledbFragmentInfo, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error serializing array: %s", fragmentInfo.context.LastError())
+		return nil, fmt.Errorf("error serializing array: %w", fragmentInfo.context.LastError())
 	}
 
 	return &buffer, nil
@@ -534,7 +534,7 @@ func DeserializeFragmentInfo(fragmentInfo FragmentInfo, buffer *Buffer, arrayURI
 
 	ret := C.tiledb_deserialize_fragment_info(fragmentInfo.context.tiledbContext, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cArrayURI, cClientSide, fragmentInfo.tiledbFragmentInfo)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error deserializing array: %s", fragmentInfo.context.LastError())
+		return fmt.Errorf("error deserializing array: %w", fragmentInfo.context.LastError())
 	}
 
 	return nil
@@ -555,7 +555,7 @@ func SerializeFragmentInfoRequestToBuffer(fragmentInfo *FragmentInfo, serializat
 
 	ret := C.tiledb_serialize_fragment_info_request(fragmentInfo.context.tiledbContext, fragmentInfo.tiledbFragmentInfo, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error serializing array: %s", fragmentInfo.context.LastError())
+		return nil, fmt.Errorf("error serializing array: %w", fragmentInfo.context.LastError())
 	}
 
 	return &buffer, nil
@@ -584,7 +584,7 @@ func DeserializeFragmentInfoRequest(fragmentInfo FragmentInfo, buffer *Buffer, s
 
 	ret := C.tiledb_deserialize_fragment_info_request(fragmentInfo.context.tiledbContext, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, fragmentInfo.tiledbFragmentInfo)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error deserializing array: %s", fragmentInfo.context.LastError())
+		return fmt.Errorf("error deserializing array: %w", fragmentInfo.context.LastError())
 	}
 
 	return nil
@@ -612,7 +612,7 @@ func DeserializeQueryAndArray(context *Context, buffer *Buffer, serializationTyp
 
 	ret := C.tiledb_deserialize_query_and_array(context.tiledbContext, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, cArrayURI, &query.tiledbQuery, &array.tiledbArray)
 	if ret != C.TILEDB_OK {
-		return nil, nil, fmt.Errorf("error deserializing query: %s", context.LastError())
+		return nil, nil, fmt.Errorf("error deserializing query: %w", context.LastError())
 	}
 
 	freeOnGC(array)
@@ -632,7 +632,7 @@ func SerializeGroupMetadataToBuffer(g *Group, serializationType SerializationTyp
 
 	ret := C.tiledb_serialize_group_metadata(g.context.tiledbContext, g.group, C.tiledb_serialization_type_t(serializationType), &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error serializing group metadata: %s", g.context.LastError())
+		return nil, fmt.Errorf("error serializing group metadata: %w", g.context.LastError())
 	}
 
 	return &buffer, nil
@@ -663,7 +663,7 @@ func DeserializeGroupMetadata(g *Group, buffer *Buffer, serializationType Serial
 
 	ret := C.tiledb_deserialize_group_metadata(g.context.tiledbContext, g.group, C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error deserializing group metadata: %s", g.context.LastError())
+		return fmt.Errorf("error deserializing group metadata: %w", g.context.LastError())
 	}
 
 	return nil
@@ -690,7 +690,7 @@ func (g *Group) Deserialize(buffer *Buffer, serializationType SerializationType,
 
 	ret := C.tiledb_deserialize_group(g.context.tiledbContext, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, g.group)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error deserializing group: %s", g.context.LastError())
+		return fmt.Errorf("error deserializing group: %w", g.context.LastError())
 	}
 
 	return nil
@@ -702,12 +702,12 @@ func (g *Group) Deserialize(buffer *Buffer, serializationType SerializationType,
 func HandleLoadArraySchemaRequest(array *Array, request *Buffer, serializationType SerializationType) (*Buffer, error) {
 	response, err := NewBuffer(array.context)
 	if err != nil {
-		return nil, fmt.Errorf("error creating LoadArraySchemaResponse buffer: %s", array.context.LastError())
+		return nil, fmt.Errorf("error creating LoadArraySchemaResponse buffer: %w", array.context.LastError())
 	}
 
 	ret := C.tiledb_handle_load_array_schema_request(array.context.tiledbContext, array.tiledbArray, C.tiledb_serialization_type_t(serializationType), request.tiledbBuffer, response.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error handling LoadArraySchemaRequset: %s", array.context.LastError())
+		return nil, fmt.Errorf("error handling LoadArraySchemaRequset: %w", array.context.LastError())
 	}
 
 	runtime.KeepAlive(request)
@@ -719,7 +719,7 @@ func HandleArrayDeleteFragmentsTimestampsRequest(context *Context, array *Array,
 	ret := C.tiledb_handle_array_delete_fragments_timestamps_request(context.tiledbContext, array.tiledbArray,
 		C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error deserializing delete fragments timestamps: %s", context.LastError())
+		return fmt.Errorf("error deserializing delete fragments timestamps: %w", context.LastError())
 	}
 
 	runtime.KeepAlive(buffer)
@@ -731,7 +731,7 @@ func HandleArrayDeleteFragmentsListRequest(context *Context, array *Array, buffe
 	ret := C.tiledb_handle_array_delete_fragments_list_request(context.tiledbContext, array.tiledbArray,
 		C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error deserializing delete fragments list: %s", context.LastError())
+		return fmt.Errorf("error deserializing delete fragments list: %w", context.LastError())
 	}
 
 	runtime.KeepAlive(buffer)
@@ -745,13 +745,13 @@ func HandleQueryPlanRequest(array *Array, serializationType SerializationType, r
 
 	response, err := NewBuffer(opContext)
 	if err != nil {
-		return nil, fmt.Errorf("error allocating tiledb buffer: %s", opContext.LastError())
+		return nil, fmt.Errorf("error allocating tiledb buffer: %w", opContext.LastError())
 	}
 
 	ret := C.tiledb_handle_query_plan_request(opContext.tiledbContext, array.tiledbArray, C.tiledb_serialization_type_t(serializationType),
 		request.tiledbBuffer, response.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error handling query plan request: %s", opContext.LastError())
+		return nil, fmt.Errorf("error handling query plan request: %w", opContext.LastError())
 	}
 
 	runtime.KeepAlive(request)
@@ -767,13 +767,13 @@ func HandleConsolidationPlanRequest(array *Array, serializationType Serializatio
 
 	response, err := NewBuffer(opContext)
 	if err != nil {
-		return nil, fmt.Errorf("error allocating tiledb buffer: %s", opContext.LastError())
+		return nil, fmt.Errorf("error allocating tiledb buffer: %w", opContext.LastError())
 	}
 
 	ret := C.tiledb_handle_consolidation_plan_request(opContext.tiledbContext, array.tiledbArray, C.tiledb_serialization_type_t(serializationType),
 		request.tiledbBuffer, response.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error handling consolidation plan request: %s", opContext.LastError())
+		return nil, fmt.Errorf("error handling consolidation plan request: %w", opContext.LastError())
 	}
 
 	runtime.KeepAlive(request)
@@ -786,13 +786,13 @@ func HandleConsolidationPlanRequest(array *Array, serializationType Serializatio
 func DeserializeLoadEnumerationsRequest(array *Array, serializationType SerializationType, request *Buffer) (*Buffer, error) {
 	response, err := NewBuffer(array.context)
 	if err != nil {
-		return nil, fmt.Errorf("error deserializing load enumerations request: %s", array.context.LastError())
+		return nil, fmt.Errorf("error deserializing load enumerations request: %w", array.context.LastError())
 	}
 
 	ret := C.tiledb_handle_load_enumerations_request(array.context.tiledbContext, array.tiledbArray, C.tiledb_serialization_type_t(serializationType),
 		request.tiledbBuffer, response.tiledbBuffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error deserializing load enumerations request: %s", array.context.LastError())
+		return nil, fmt.Errorf("error deserializing load enumerations request: %w", array.context.LastError())
 	}
 
 	runtime.KeepAlive(request)

--- a/stats.go
+++ b/stats.go
@@ -8,6 +8,7 @@ package tiledb
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"unsafe"
@@ -17,7 +18,7 @@ import (
 func StatsEnable() error {
 	ret := C.tiledb_stats_enable()
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error enabling stats")
+		return errors.New("error enabling stats")
 	}
 	return nil
 }
@@ -26,7 +27,7 @@ func StatsEnable() error {
 func StatsDisable() error {
 	ret := C.tiledb_stats_disable()
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error disabling stats")
+		return errors.New("error disabling stats")
 	}
 	return nil
 }
@@ -35,7 +36,7 @@ func StatsDisable() error {
 func StatsReset() error {
 	ret := C.tiledb_stats_reset()
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error resetting stats")
+		return errors.New("error resetting stats")
 	}
 	return nil
 }
@@ -44,7 +45,7 @@ func StatsReset() error {
 func StatsDumpSTDOUT() error {
 	ret := C.tiledb_stats_dump(C.stdout)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error dumping stats to stdout")
+		return errors.New("error dumping stats to stdout")
 	}
 	return nil
 }
@@ -53,7 +54,7 @@ func StatsDumpSTDOUT() error {
 func StatsDump(path string) error {
 
 	if _, err := os.Stat(path); err == nil {
-		return fmt.Errorf("Error path already %s exists", path)
+		return fmt.Errorf("error path already %s exists", path)
 	}
 
 	// Convert to char *
@@ -71,7 +72,7 @@ func StatsDump(path string) error {
 	// Dump stats to file
 	ret := C.tiledb_stats_dump(cFile)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error dumping stats to file %s", path)
+		return fmt.Errorf("error dumping stats to file %s", path)
 	}
 	return nil
 }
@@ -83,13 +84,13 @@ func Stats() (string, error) {
 	// Dump stats to string
 	ret := C.tiledb_stats_dump_str(&msg)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error dumping stats to string")
+		return "", errors.New("error dumping stats to string")
 	}
 	s := C.GoString(msg)
 
 	ret = C.tiledb_stats_free_str(&msg)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error freeing string from dumping stats to string")
+		return "", errors.New("error freeing string from dumping stats to string")
 	}
 
 	return s, nil
@@ -99,7 +100,7 @@ func Stats() (string, error) {
 func StatsRawDumpSTDOUT() error {
 	ret := C.tiledb_stats_raw_dump(C.stdout)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error dumping stats to stdout")
+		return errors.New("error dumping stats to stdout")
 	}
 	return nil
 }
@@ -108,7 +109,7 @@ func StatsRawDumpSTDOUT() error {
 func StatsRawDump(path string) error {
 
 	if _, err := os.Stat(path); err == nil {
-		return fmt.Errorf("Error path already %s exists", path)
+		return fmt.Errorf("error path already %s exists", path)
 	}
 
 	// Convert to char *
@@ -126,7 +127,7 @@ func StatsRawDump(path string) error {
 	// Dump stats to file
 	ret := C.tiledb_stats_raw_dump(cFile)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error dumping stats to file %s", path)
+		return fmt.Errorf("error dumping stats to file %s", path)
 	}
 	return nil
 }
@@ -138,13 +139,13 @@ func StatsRaw() (string, error) {
 	// Dump stats to string
 	ret := C.tiledb_stats_raw_dump_str(&msg)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error dumping raw stats to string")
+		return "", errors.New("error dumping raw stats to string")
 	}
 	s := C.GoString(msg)
 
 	ret = C.tiledb_stats_free_str(&msg)
 	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("Error freeing string from dumping raw stats to string")
+		return "", errors.New("error freeing string from dumping raw stats to string")
 	}
 
 	return s, nil

--- a/subarray.go
+++ b/subarray.go
@@ -25,7 +25,7 @@ func (a *Array) NewSubarray() (*Subarray, error) {
 
 	ret := C.tiledb_subarray_alloc(a.context.tiledbContext, a.tiledbArray, &sa)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("Error creating Subarray: %s", a.context.LastError())
+		return nil, fmt.Errorf("error creating Subarray: %w", a.context.LastError())
 	}
 
 	subarray := &Subarray{array: a, subarray: sa, context: a.context}
@@ -38,7 +38,7 @@ func (a *Array) NewSubarray() (*Subarray, error) {
 func (sa *Subarray) SetConfig(cfg *Config) error {
 	ret := C.tiledb_subarray_set_config(sa.context.tiledbContext, sa.subarray, cfg.tiledbConfig)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting Config: %s", sa.context.LastError())
+		return fmt.Errorf("error setting Config: %w", sa.context.LastError())
 	}
 	return nil
 }
@@ -58,30 +58,30 @@ func (sa *Subarray) Free() {
 func (sa *Subarray) SetSubArray(subArray interface{}) error {
 
 	if reflect.TypeOf(subArray).Kind() != reflect.Slice {
-		return fmt.Errorf("Subarray passed must be a slice, type passed was: %s", reflect.TypeOf(subArray).Kind().String())
+		return fmt.Errorf("subarray passed must be a slice, type passed was: %s", reflect.TypeOf(subArray).Kind().String())
 	}
 
 	subArrayType := reflect.TypeOf(subArray).Elem().Kind()
 
 	schema, err := sa.array.Schema()
 	if err != nil {
-		return fmt.Errorf("Could not get array schema from array: %s", err)
+		return fmt.Errorf("could not get array schema from array: %w", err)
 	}
 	defer schema.Free()
 
 	domain, err := schema.Domain()
 	if err != nil {
-		return fmt.Errorf("Could not get domain from array schema: %s", err)
+		return fmt.Errorf("could not get domain from array schema: %w", err)
 	}
 	defer domain.Free()
 
 	domainType, err := domain.Type()
 	if err != nil {
-		return fmt.Errorf("Could not get domain type: %s", err)
+		return fmt.Errorf("could not get domain type: %w", err)
 	}
 
 	if subArrayType != domainType.ReflectKind() {
-		return fmt.Errorf("Domain and subarray do not have the same data types. Domain: %s, Extent: %s", domainType.ReflectKind().String(), subArrayType.String())
+		return fmt.Errorf("domain and subarray do not have the same data types. Domain: %s, Extent: %s", domainType.ReflectKind().String(), subArrayType.String())
 	}
 
 	var csubArray unsafe.Pointer
@@ -139,12 +139,12 @@ func (sa *Subarray) SetSubArray(subArray interface{}) error {
 		tmpSubArray := subArray.([]bool)
 		csubArray = slicePtr(tmpSubArray)
 	default:
-		return fmt.Errorf("Unrecognized subArray type passed: %s", subArrayType.String())
+		return fmt.Errorf("unrecognized subArray type passed: %s", subArrayType.String())
 	}
 
 	ret := C.tiledb_subarray_set_subarray(sa.context.tiledbContext, sa.subarray, csubArray)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting subarray: %s", sa.context.LastError())
+		return fmt.Errorf("error setting subarray: %w", sa.context.LastError())
 	}
 	return nil
 }
@@ -159,7 +159,7 @@ func (sa *Subarray) SetCoalesceRanges(b bool) error {
 
 	ret := C.tiledb_subarray_set_coalesce_ranges(sa.context.tiledbContext, sa.subarray, coalesce)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error setting coalesce ranges on subarray: %s", sa.context.LastError())
+		return fmt.Errorf("error setting coalesce ranges on subarray: %w", sa.context.LastError())
 	}
 
 	return nil
@@ -193,7 +193,7 @@ func (sa *Subarray) AddRange(dimIdx uint32, r Range) error {
 		runtime.KeepAlive(endValue)
 	}
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error adding subarray range: %s", sa.context.LastError())
+		return fmt.Errorf("error adding subarray range: %w", sa.context.LastError())
 	}
 
 	return nil
@@ -230,7 +230,7 @@ func (sa *Subarray) AddRangeByName(dimName string, r Range) error {
 		runtime.KeepAlive(endValue)
 	}
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("Error adding subarray range: %s", sa.context.LastError())
+		return fmt.Errorf("error adding subarray range: %w", sa.context.LastError())
 	}
 
 	return nil
@@ -242,7 +242,7 @@ func (sa *Subarray) GetRangeNum(dimIdx uint32) (uint64, error) {
 
 	ret := C.tiledb_subarray_get_range_num(sa.context.tiledbContext, sa.subarray, C.uint32_t(dimIdx), (*C.uint64_t)(unsafe.Pointer(&rangeNum)))
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error retrieving subarray range num: %s", sa.context.LastError())
+		return 0, fmt.Errorf("error retrieving subarray range num: %w", sa.context.LastError())
 	}
 
 	return rangeNum, nil
@@ -257,7 +257,7 @@ func (sa *Subarray) GetRangeNumFromName(dimName string) (uint64, error) {
 
 	ret := C.tiledb_subarray_get_range_num_from_name(sa.context.tiledbContext, sa.subarray, cDimName, (*C.uint64_t)(unsafe.Pointer(&rangeNum)))
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("Error retrieving subarray range num: %s", sa.context.LastError())
+		return 0, fmt.Errorf("error retrieving subarray range num: %w", sa.context.LastError())
 	}
 
 	return rangeNum, nil
@@ -377,7 +377,7 @@ func (sa *Subarray) GetRange(dimIdx uint32, rangeNum uint64) (Range, error) {
 		}
 	}
 	if ret != C.TILEDB_OK {
-		return Range{}, fmt.Errorf("Error retrieving subarray range for dimension %d and range num %d: %s", dimIdx, rangeNum, sa.context.LastError())
+		return Range{}, fmt.Errorf("error retrieving subarray range for dimension %d and range num %d: %w", dimIdx, rangeNum, sa.context.LastError())
 	}
 
 	return r, err
@@ -426,7 +426,7 @@ func (sa *Subarray) GetRangeFromName(dimName string, rangeNum uint64) (Range, er
 		}
 	}
 	if ret != C.TILEDB_OK {
-		return Range{}, fmt.Errorf("Error retrieving subarray range for dimension %s and range num %d: %s", dimName, rangeNum, sa.context.LastError())
+		return Range{}, fmt.Errorf("error retrieving subarray range for dimension %s and range num %d: %w", dimName, rangeNum, sa.context.LastError())
 	}
 
 	return r, err

--- a/vfs.go
+++ b/vfs.go
@@ -8,6 +8,7 @@ package tiledb
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -54,7 +55,7 @@ func (v *VFSfh) IsClosed() (bool, error) {
 	ret := C.tiledb_vfs_fh_is_closed(v.context.tiledbContext, v.tiledbVFSfh, &isClosed)
 
 	if ret != C.TILEDB_OK {
-		return false, fmt.Errorf("error in checking if vfs file handler is closed")
+		return false, errors.New("error in checking if vfs file handler is closed")
 	}
 
 	if isClosed == 1 {
@@ -113,9 +114,9 @@ func (v *VFS) Config() (*Config, error) {
 		&config.tiledbConfig)
 
 	if ret == C.TILEDB_OOM {
-		return nil, fmt.Errorf("out of Memory error in GetConfig")
+		return nil, errors.New("out of Memory error in GetConfig")
 	} else if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("unknown error in GetConfig")
+		return nil, errors.New("unknown error in GetConfig")
 	}
 	freeOnGC(&config)
 
@@ -129,7 +130,7 @@ func (v *VFS) CreateBucket(uri string) error {
 	ret := C.tiledb_vfs_create_bucket(v.context.tiledbContext, v.tiledbVFS, curi)
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error in creating s3 bucket %s: %s", uri, v.context.LastError())
+		return fmt.Errorf("error in creating s3 bucket %s: %w", uri, v.context.LastError())
 	}
 
 	return nil
@@ -142,7 +143,7 @@ func (v *VFS) RemoveBucket(uri string) error {
 	ret := C.tiledb_vfs_remove_bucket(v.context.tiledbContext, v.tiledbVFS, curi)
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error in removing s3 bucket %s: %s", uri, v.context.LastError())
+		return fmt.Errorf("error in removing s3 bucket %s: %w", uri, v.context.LastError())
 	}
 
 	return nil
@@ -155,7 +156,7 @@ func (v *VFS) EmptyBucket(uri string) error {
 	ret := C.tiledb_vfs_empty_bucket(v.context.tiledbContext, v.tiledbVFS, curi)
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error in emptying s3 bucket %s: %s", uri, v.context.LastError())
+		return fmt.Errorf("error in emptying s3 bucket %s: %w", uri, v.context.LastError())
 	}
 
 	return nil
@@ -169,7 +170,7 @@ func (v *VFS) IsEmptyBucket(uri string) (bool, error) {
 	ret := C.tiledb_vfs_is_empty_bucket(v.context.tiledbContext, v.tiledbVFS, curi, &isEmpty)
 
 	if ret != C.TILEDB_OK {
-		return false, fmt.Errorf("error in checking if s3 bucket %s is empty: %s", uri, v.context.LastError())
+		return false, fmt.Errorf("error in checking if s3 bucket %s is empty: %w", uri, v.context.LastError())
 	}
 
 	if isEmpty == 1 {
@@ -187,7 +188,7 @@ func (v *VFS) IsBucket(uri string) (bool, error) {
 	ret := C.tiledb_vfs_is_bucket(v.context.tiledbContext, v.tiledbVFS, curi, &isBucket)
 
 	if ret != C.TILEDB_OK {
-		return false, fmt.Errorf("error in checking if %s is a s3 bucket: %s", uri, v.context.LastError())
+		return false, fmt.Errorf("error in checking if %s is a s3 bucket: %w", uri, v.context.LastError())
 	}
 
 	if isBucket == 1 {
@@ -204,7 +205,7 @@ func (v *VFS) CreateDir(uri string) error {
 	ret := C.tiledb_vfs_create_dir(v.context.tiledbContext, v.tiledbVFS, curi)
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error in creating directory %s: %s", uri, v.context.LastError())
+		return fmt.Errorf("error in creating directory %s: %w", uri, v.context.LastError())
 	}
 
 	return nil
@@ -218,7 +219,7 @@ func (v *VFS) IsDir(uri string) (bool, error) {
 	ret := C.tiledb_vfs_is_dir(v.context.tiledbContext, v.tiledbVFS, curi, &isDir)
 
 	if ret != C.TILEDB_OK {
-		return false, fmt.Errorf("error in checking if %s is a directory: %s", uri, v.context.LastError())
+		return false, fmt.Errorf("error in checking if %s is a directory: %w", uri, v.context.LastError())
 	}
 
 	if isDir == 1 {
@@ -235,7 +236,7 @@ func (v *VFS) RemoveDir(uri string) error {
 	ret := C.tiledb_vfs_remove_dir(v.context.tiledbContext, v.tiledbVFS, curi)
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error in removing directory %s: %s", uri, v.context.LastError())
+		return fmt.Errorf("error in removing directory %s: %w", uri, v.context.LastError())
 	}
 
 	return nil
@@ -249,7 +250,7 @@ func (v *VFS) IsFile(uri string) (bool, error) {
 	ret := C.tiledb_vfs_is_file(v.context.tiledbContext, v.tiledbVFS, curi, &isFile)
 
 	if ret != C.TILEDB_OK {
-		return false, fmt.Errorf("Error in checking if %s is a file: %s", uri, v.context.LastError())
+		return false, fmt.Errorf("error in checking if %s is a file: %w", uri, v.context.LastError())
 	}
 
 	if isFile == 1 {
@@ -266,7 +267,7 @@ func (v *VFS) RemoveFile(uri string) error {
 	ret := C.tiledb_vfs_remove_file(v.context.tiledbContext, v.tiledbVFS, curi)
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error in removing file %s: %s", uri, v.context.LastError())
+		return fmt.Errorf("error in removing file %s: %w", uri, v.context.LastError())
 	}
 
 	return nil
@@ -280,7 +281,7 @@ func (v *VFS) FileSize(uri string) (uint64, error) {
 	ret := C.tiledb_vfs_file_size(v.context.tiledbContext, v.tiledbVFS, curi, &cfsize)
 
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("error in getting file size %s: %s", uri, v.context.LastError())
+		return 0, fmt.Errorf("error in getting file size %s: %w", uri, v.context.LastError())
 	}
 
 	return uint64(cfsize), nil
@@ -296,7 +297,7 @@ func (v *VFS) MoveFile(oldURI string, newURI string) error {
 	ret := C.tiledb_vfs_move_file(v.context.tiledbContext, v.tiledbVFS, cOldURI, cNewURI)
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error in moving file %s to %s: %s", oldURI, newURI, v.context.LastError())
+		return fmt.Errorf("error in moving file %s to %s: %w", oldURI, newURI, v.context.LastError())
 	}
 
 	return nil
@@ -312,7 +313,7 @@ func (v *VFS) CopyFile(oldURI string, newURI string) error {
 	ret := C.tiledb_vfs_copy_file(v.context.tiledbContext, v.tiledbVFS, cOldURI, cNewURI)
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error in copying file %s to %s: %s", oldURI, newURI, v.context.LastError())
+		return fmt.Errorf("error in copying file %s to %s: %w", oldURI, newURI, v.context.LastError())
 	}
 
 	return nil
@@ -328,7 +329,7 @@ func (v *VFS) MoveDir(oldURI string, newURI string) error {
 	ret := C.tiledb_vfs_move_dir(v.context.tiledbContext, v.tiledbVFS, cOldURI, cNewURI)
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error in moving directory %s to %s: %s", oldURI, newURI, v.context.LastError())
+		return fmt.Errorf("error in moving directory %s to %s: %w", oldURI, newURI, v.context.LastError())
 	}
 
 	return nil
@@ -344,9 +345,9 @@ func (v *VFS) Open(uri string, mode VFSMode) (*VFSfh, error) {
 	ret := C.tiledb_vfs_open(v.context.tiledbContext, v.tiledbVFS, curi, C.tiledb_vfs_mode_t(mode), &fh.tiledbVFSfh)
 
 	if ret == C.TILEDB_OOM {
-		return nil, fmt.Errorf("out of Memory error in VFS.Open: %s", v.context.LastError())
+		return nil, fmt.Errorf("out of Memory error in VFS.Open: %w", v.context.LastError())
 	} else if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("unknown error in VFS.Open: %s", v.context.LastError())
+		return nil, fmt.Errorf("unknown error in VFS.Open: %w", v.context.LastError())
 	}
 
 	return fh, nil
@@ -360,7 +361,7 @@ func (v *VFS) Close(fh *VFSfh) error {
 	ret := C.tiledb_vfs_close(v.context.tiledbContext, fh.tiledbVFSfh)
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("unknown error in VFS.Close: %s", v.context.LastError())
+		return fmt.Errorf("unknown error in VFS.Close: %w", v.context.LastError())
 	}
 
 	fh.Free()
@@ -374,7 +375,7 @@ func (v *VFS) Read(fh *VFSfh, offset uint64, nbytes uint64) ([]byte, error) {
 	ret := C.tiledb_vfs_read(v.context.tiledbContext, fh.tiledbVFSfh, C.uint64_t(offset), cbuffer, C.uint64_t(nbytes))
 
 	if ret != C.TILEDB_OK {
-		return []byte{}, fmt.Errorf("unknown error in VFS.Read: %s", v.context.LastError())
+		return []byte{}, fmt.Errorf("unknown error in VFS.Read: %w", v.context.LastError())
 	}
 
 	return bytes, nil
@@ -389,7 +390,7 @@ func (v *VFS) Write(fh *VFSfh, bytes []byte) error {
 	ret := C.tiledb_vfs_write(v.context.tiledbContext, fh.tiledbVFSfh, cbuffer, C.uint64_t(len(bytes)))
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("unknown error in VFS.Write: %s", v.context.LastError())
+		return fmt.Errorf("unknown error in VFS.Write: %w", v.context.LastError())
 	}
 
 	return nil
@@ -400,7 +401,7 @@ func (v *VFS) Sync(fh *VFSfh) error {
 	ret := C.tiledb_vfs_sync(v.context.tiledbContext, fh.tiledbVFSfh)
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("unknown error in VFS.Sync: %s", v.context.LastError())
+		return fmt.Errorf("unknown error in VFS.Sync: %w", v.context.LastError())
 	}
 
 	return nil
@@ -413,7 +414,7 @@ func (v *VFS) Touch(uri string) error {
 	ret := C.tiledb_vfs_touch(v.context.tiledbContext, v.tiledbVFS, curi)
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error in touching %s: %s", uri, v.context.LastError())
+		return fmt.Errorf("error in touching %s: %w", uri, v.context.LastError())
 	}
 
 	return nil
@@ -427,7 +428,7 @@ func (v *VFS) DirSize(uri string) (uint64, error) {
 	ret := C.tiledb_vfs_dir_size(v.context.tiledbContext, v.tiledbVFS, curi, &cfsize)
 
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("error in getting dir size %s: %s", uri, v.context.LastError())
+		return 0, fmt.Errorf("error in getting dir size %s: %w", uri, v.context.LastError())
 	}
 
 	return uint64(cfsize), nil
@@ -472,7 +473,7 @@ func (v *VFS) NumOfFragmentsInPath(path string) (int, error) {
 	ret := C._num_of_folders_in_path(v.context.tiledbContext, v.tiledbVFS, cpath, data)
 
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("error in getting dir list %s: %s", path, v.context.LastError())
+		return 0, fmt.Errorf("error in getting dir list %s: %w", path, v.context.LastError())
 	}
 
 	return numOfFragmentsData.NumOfFolders, nil
@@ -486,7 +487,7 @@ func (v *VFSfh) Close() error {
 	ret := C.tiledb_vfs_close(v.context.tiledbContext, v.tiledbVFSfh)
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("unknown error in VFS.Close: %s", v.context.LastError())
+		return fmt.Errorf("unknown error in VFS.Close: %w", v.context.LastError())
 	}
 
 	v.Free()
@@ -518,7 +519,7 @@ func (v *VFSfh) Read(p []byte) (int, error) {
 	ret := C.tiledb_vfs_read(v.context.tiledbContext, v.tiledbVFSfh, C.uint64_t(v.offset), cbuffer, C.uint64_t(nbytes))
 
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("unknown error in VFS.Read: %s", v.context.LastError())
+		return 0, fmt.Errorf("unknown error in VFS.Read: %w", v.context.LastError())
 	}
 
 	v.offset += nbytes
@@ -536,7 +537,7 @@ func (v *VFSfh) Write(bytes []byte) (int, error) {
 	ret := C.tiledb_vfs_write(v.context.tiledbContext, v.tiledbVFSfh, cbuffer, C.uint64_t(len(bytes)))
 
 	if ret != C.TILEDB_OK {
-		return 0, fmt.Errorf("unknown error in VFS.Write: %s", v.context.LastError())
+		return 0, fmt.Errorf("unknown error in VFS.Write: %w", v.context.LastError())
 	}
 
 	return len(bytes), nil
@@ -547,7 +548,7 @@ func (v *VFSfh) Sync() error {
 	ret := C.tiledb_vfs_sync(v.context.tiledbContext, v.tiledbVFSfh)
 
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("unknown error in VFS.Sync: %s", v.context.LastError())
+		return fmt.Errorf("unknown error in VFS.Sync: %w", v.context.LastError())
 	}
 
 	return nil
@@ -570,18 +571,18 @@ func (v *VFSfh) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekEnd:
 		origin = *v.size
 	default:
-		return -1, fmt.Errorf("unknown seek whence")
+		return -1, errors.New("unknown seek whence")
 	}
 
 	var newOffset uint64
 	if offset >= 0 {
 		newOffset = origin + uint64(offset)
 		if newOffset > *v.size {
-			return -1, fmt.Errorf("invalid offset, attempt to move beyond end of file")
+			return -1, errors.New("invalid offset, attempt to move beyond end of file")
 		}
 	} else {
 		if offset == math.MinInt64 || uint64(-offset) > origin {
-			return -1, fmt.Errorf("invalid offset, attempt to move before start of file")
+			return -1, errors.New("invalid offset, attempt to move before start of file")
 		}
 		newOffset = origin - uint64(-offset)
 	}
@@ -641,7 +642,7 @@ func (v *VFS) List(path string) ([]string, []string, error) {
 
 	ret := C._vfs_ls(v.context.tiledbContext, v.tiledbVFS, cpath, data)
 	if ret != C.TILEDB_OK {
-		return nil, nil, fmt.Errorf("error in getting path listing %s: %s", path, v.context.LastError())
+		return nil, nil, fmt.Errorf("error in getting path listing %s: %w", path, v.context.LastError())
 	}
 
 	return folderData.Folders, folderData.Files, nil

--- a/vfs.go
+++ b/vfs.go
@@ -78,13 +78,9 @@ type VFS struct {
 // garbage collection
 func NewVFS(context *Context, config *Config) (*VFS, error) {
 	vfs := VFS{context: context}
-	var err *C.tiledb_error_t
-	C.tiledb_vfs_alloc(context.tiledbContext, config.tiledbConfig, &vfs.tiledbVFS)
-	if err != nil {
-		var msg *C.char
-		C.tiledb_error_message(err, &msg)
-		defer C.tiledb_error_free(&err)
-		return nil, fmt.Errorf("error creating tiledb context: %s", C.GoString(msg))
+	ret := C.tiledb_vfs_alloc(context.tiledbContext, config.tiledbConfig, &vfs.tiledbVFS)
+	if ret != C.TILEDB_OK {
+		return nil, fmt.Errorf("error creating tiledb VFS %w", context.LastError())
 	}
 	freeOnGC(&vfs)
 

--- a/vfs.go
+++ b/vfs.go
@@ -80,7 +80,7 @@ func NewVFS(context *Context, config *Config) (*VFS, error) {
 	vfs := VFS{context: context}
 	ret := C.tiledb_vfs_alloc(context.tiledbContext, config.tiledbConfig, &vfs.tiledbVFS)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error creating tiledb VFS %w", context.LastError())
+		return nil, fmt.Errorf("error creating tiledb VFS: %w", context.LastError())
 	}
 	freeOnGC(&vfs)
 


### PR DESCRIPTION
* All error messages start with a lower-case letter.
* Errors are formatted with the `%w` specifier, which wraps them.
* All other warnings are fixed.
* Functions that wrap APIs that report errors in a `tiledb_error_t*` were refactored to use a common function for formatting the error, and wrapping the C API message inside the Go API message.
* Fixed error handling of `NewVFS`.