### PR TITLE
Update to Go 1.22.

### DIFF
--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.20", "1.21", "1.22", "1.23"]
+        go: ["1.22", "1.23"]
     steps:
 
     # Checks out repository
@@ -72,7 +72,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.20", "1.21", "1.22", "1.23"]
+        go: ["1.22", "1.23"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v4
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.20", "1.21", "1.22", "1.23"]
+        go: ["1.22", "1.23"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v4

--- a/buffer.go
+++ b/buffer.go
@@ -135,12 +135,7 @@ func (b *Buffer) ReadAt(p []byte, off int64) (int, error) {
 	}
 
 	availableBytes := uint64(csize) - uint64(off)
-	var sizeToRead int
-	if availableBytes > math.MaxInt {
-		sizeToRead = math.MaxInt
-	} else {
-		sizeToRead = int(availableBytes)
-	}
+	sizeToRead := min(math.MaxInt, int(availableBytes))
 
 	readSize := copy(p, unsafe.Slice((*byte)(unsafe.Pointer(uintptr(cbuffer)+uintptr(off))), sizeToRead))
 
@@ -171,13 +166,7 @@ func (b *Buffer) WriteTo(w io.Writer) (int64, error) {
 	// Because io.Writer supports writing up to 2GB of data at a time, we have to use a loop
 	// for the bigger buffers.
 	for remaining > 0 {
-		// TODO: Use min on Go 1.21+
-		var writeSize int
-		if remaining > math.MaxInt {
-			writeSize = math.MaxInt
-		} else {
-			writeSize = int(remaining)
-		}
+		writeSize := min(math.MaxInt, int(remaining))
 
 		// Construct a slice from the buffer's data without copying it.
 		n, err := w.Write(unsafe.Slice((*byte)(unsafe.Pointer(uintptr(cbuffer)+uintptr(csize)-uintptr(remaining))), writeSize))

--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,4 @@ require (
 // Local triggered panic when referencing enums
 retract v0.30.1
 
-go 1.20
+go 1.22


### PR DESCRIPTION
This updates to use Go 1.22, since Go 1.21 [reached EOL 4 months ago](https://endoflife.date/go).