### PR TITLE
Remove unnecessary uses of `TILEDB_EXPORT`.

### DIFF
--- a/clibrary.c
+++ b/clibrary.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-TILEDB_EXPORT int32_t _num_of_folders_in_path(
+int32_t _num_of_folders_in_path(
   tiledb_ctx_t* ctx,
   tiledb_vfs_t* vfs,
   const char* path,
@@ -12,7 +12,7 @@ TILEDB_EXPORT int32_t _num_of_folders_in_path(
     return ret_val;
 }
 
-TILEDB_EXPORT int32_t _vfs_ls(
+int32_t _vfs_ls(
   tiledb_ctx_t* ctx,
   tiledb_vfs_t* vfs,
   const char* path,
@@ -21,7 +21,7 @@ TILEDB_EXPORT int32_t _vfs_ls(
     return ret_val;
 }
 
-TILEDB_EXPORT int32_t _tiledb_object_walk(
+int32_t _tiledb_object_walk(
   tiledb_ctx_t* ctx,
   const char* path,
   tiledb_walk_order_t order,
@@ -30,7 +30,7 @@ TILEDB_EXPORT int32_t _tiledb_object_walk(
     return ret_val;
 }
 
-TILEDB_EXPORT int32_t _tiledb_object_ls(
+int32_t _tiledb_object_ls(
   tiledb_ctx_t* ctx,
   const char* path,
   void* data) {

--- a/clibrary.h
+++ b/clibrary.h
@@ -9,25 +9,25 @@ int32_t numOfFragmentsInPath(cchar_t* path, void *data);
 int32_t vfsLs(cchar_t* path, void *data);
 int32_t objectsInPath(cchar_t* path, tiledb_object_t objectType, void *data);
 
-TILEDB_EXPORT int32_t _num_of_folders_in_path(
+int32_t _num_of_folders_in_path(
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* path,
     void* data);
 
-TILEDB_EXPORT int32_t _vfs_ls(
+int32_t _vfs_ls(
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* path,
     void* data);
 
-TILEDB_EXPORT int32_t _tiledb_object_walk(
+int32_t _tiledb_object_walk(
     tiledb_ctx_t* ctx,
     const char* path,
     tiledb_walk_order_t order,
     void* data);
 
-TILEDB_EXPORT int32_t _tiledb_object_ls(
+int32_t _tiledb_object_ls(
     tiledb_ctx_t* ctx,
     const char* path,
     void* data);


### PR DESCRIPTION
[SC-61398](https://app.shortcut.com/tiledb-inc/story/61398/unnecessary-uses-of-tiledb-export-in-tiledb-go)

The `TILEDB_EXPORT` symbol is defined in `tiledb.h` to mark exported functions of the TileDB C API, and should not be used by external code. Removing its use in TileDB-Go fixes compile errors on Windows.