### PR TITLE
Improve memory safety of cgo interop code.

### DIFF
--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -65,6 +65,8 @@ jobs:
 
     # Tests TileDB-Go
     - name: Test TileDB-Go
+      env:
+        GOEXPERIMENT: cgocheck2
       run: go test -gcflags=all=-d=checkptr=2 -v ./...
 
   Macos_Test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,3 @@
-run:
-  skip-dirs:
+issues:
+  exclude-dirs:
     - cmd

--- a/array.go
+++ b/array.go
@@ -118,6 +118,7 @@ func WithStartTime(start time.Time) ArrayOpenOption {
 func WithEndTimestamp(endTimestamp uint64) ArrayOpenOption {
 	return func(tdbArray *Array) error {
 		ret := C.tiledb_array_set_open_timestamp_end(tdbArray.context.tiledbContext, tdbArray.tiledbArray, C.uint64_t(endTimestamp))
+		runtime.KeepAlive(tdbArray)
 		if ret != C.TILEDB_OK {
 			return fmt.Errorf("error setting end timestamp option: %w", tdbArray.context.LastError())
 		}
@@ -129,6 +130,7 @@ func WithEndTimestamp(endTimestamp uint64) ArrayOpenOption {
 func WithStartTimestamp(startTimestamp uint64) ArrayOpenOption {
 	return func(tdbArray *Array) error {
 		ret := C.tiledb_array_set_open_timestamp_start(tdbArray.context.tiledbContext, tdbArray.tiledbArray, C.uint64_t(startTimestamp))
+		runtime.KeepAlive(tdbArray)
 		if ret != C.TILEDB_OK {
 			return fmt.Errorf("error setting start timestamp option: %w", tdbArray.context.LastError())
 		}
@@ -154,6 +156,7 @@ func (a *Array) OpenWithOptions(queryType QueryType, opts ...ArrayOpenOption) er
 	}
 
 	ret := C.tiledb_array_open(a.context.tiledbContext, a.tiledbArray, C.tiledb_query_type_t(queryType))
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error opening tiledb array for querying: %w", a.context.LastError())
 	}
@@ -172,6 +175,7 @@ creation and submission of queries for both these array objects.
 */
 func (a *Array) Open(queryType QueryType) error {
 	ret := C.tiledb_array_open(a.context.tiledbContext, a.tiledbArray, C.tiledb_query_type_t(queryType))
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error opening tiledb array for querying: %w", a.context.LastError())
 	}
@@ -187,6 +191,7 @@ generally faster than the former alternative.
 */
 func (a *Array) Reopen() error {
 	ret := C.tiledb_array_reopen(a.context.tiledbContext, a.tiledbArray)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error reopening tiledb array for querying: %w", a.context.LastError())
 	}
@@ -196,6 +201,7 @@ func (a *Array) Reopen() error {
 // Close closes a tiledb array. This is automatically called on garbage collection.
 func (a *Array) Close() error {
 	ret := C.tiledb_array_close(a.context.tiledbContext, a.tiledbArray)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error closing tiledb array for querying: %w", a.context.LastError())
 	}
@@ -207,6 +213,8 @@ func (a *Array) Create(arraySchema *ArraySchema) error {
 	curi := C.CString(a.uri)
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_array_create(a.context.tiledbContext, curi, arraySchema.tiledbArraySchema)
+	runtime.KeepAlive(a)
+	runtime.KeepAlive(arraySchema)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error creating tiledb array: %w", a.context.LastError())
 	}
@@ -224,6 +232,8 @@ func (a *Array) Consolidate(config *Config) error {
 	curi := C.CString(a.uri)
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_array_consolidate(a.context.tiledbContext, curi, config.tiledbConfig)
+	runtime.KeepAlive(a)
+	runtime.KeepAlive(config)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error consolidating tiledb array: %w", a.context.LastError())
 	}
@@ -241,6 +251,8 @@ func (a *Array) Vacuum(config *Config) error {
 	curi := C.CString(a.uri)
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_array_vacuum(a.context.tiledbContext, curi, config.tiledbConfig)
+	runtime.KeepAlive(a)
+	runtime.KeepAlive(config)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error vacuuming tiledb array: %w", a.context.LastError())
 	}
@@ -253,6 +265,7 @@ func (a *Array) Vacuum(config *Config) error {
 func (a *Array) Schema() (*ArraySchema, error) {
 	arraySchema := ArraySchema{context: a.context}
 	ret := C.tiledb_array_get_schema(a.context.tiledbContext, a.tiledbArray, &arraySchema.tiledbArraySchema)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting schema for tiledb array: %w", a.context.LastError())
 	}
@@ -264,6 +277,7 @@ func (a *Array) Schema() (*ArraySchema, error) {
 func (a *Array) QueryType() (QueryType, error) {
 	var queryType C.tiledb_query_type_t
 	ret := C.tiledb_array_get_query_type(a.context.tiledbContext, a.tiledbArray, &queryType)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return -1, fmt.Errorf("error getting QueryType for tiledb array: %w", a.context.LastError())
 	}
@@ -299,6 +313,7 @@ func millisToTime(epochMillis uint64) time.Time {
 func (a *Array) OpenStartTimestamp() (uint64, error) {
 	var start C.uint64_t
 	ret := C.tiledb_array_get_open_timestamp_start(a.context.tiledbContext, a.tiledbArray, &start)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting start timestamp for tiledb array: %w", a.context.LastError())
 	}
@@ -309,6 +324,7 @@ func (a *Array) OpenStartTimestamp() (uint64, error) {
 func (a *Array) OpenEndTimestamp() (uint64, error) {
 	var end C.uint64_t
 	ret := C.tiledb_array_get_open_timestamp_end(a.context.tiledbContext, a.tiledbArray, &end)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting end timestamp for tiledb array: %w", a.context.LastError())
 	}
@@ -416,6 +432,7 @@ func (a *Array) NonEmptyDomain() ([]NonEmptyDomain, bool, error) {
 				a.tiledbArray,
 				(C.uint32_t)(dimIdx),
 				tmpDimensionPtr, &isEmpty)
+			runtime.KeepAlive(a)
 			if ret != C.TILEDB_OK {
 				return fmt.Errorf("error in getting non empty domain for dimension: %w", a.context.LastError())
 			}
@@ -513,6 +530,7 @@ func (a *Array) NonEmptyDomainMap() (map[string]interface{}, error) {
 				a.tiledbArray,
 				(C.uint32_t)(dimIdx),
 				tmpDimensionPtr, &isEmpty)
+			runtime.KeepAlive(a)
 			if ret != C.TILEDB_OK {
 				return nil, fmt.Errorf("error in getting non empty domain for dimension: %w", a.context.LastError())
 			}
@@ -592,6 +610,7 @@ func (a *Array) NonEmptyDomainVarFromName(dimName string) (*NonEmptyDomain, bool
 		&cstartSize,
 		&cendSize,
 		&isEmpty)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, false, fmt.Errorf("error in getting non empty domain size for dimension %s for array: %w", dimName, a.context.LastError())
 	}
@@ -621,6 +640,7 @@ func (a *Array) NonEmptyDomainVarFromName(dimName string) (*NonEmptyDomain, bool
 		cstart,
 		cend,
 		&isEmpty)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, false, fmt.Errorf("error in getting non empty domain for dimension %s for array: %w", dimName, a.context.LastError())
 	}
@@ -682,6 +702,7 @@ func (a *Array) NonEmptyDomainVarFromIndex(dimIdx uint) (*NonEmptyDomain, bool, 
 		&cstartSize,
 		&cendSize,
 		&isEmpty)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, false, fmt.Errorf("error in getting non empty domain size for dimension %d for array: %w", dimIdx, a.context.LastError())
 	}
@@ -711,6 +732,7 @@ func (a *Array) NonEmptyDomainVarFromIndex(dimIdx uint) (*NonEmptyDomain, bool, 
 		cstart,
 		cend,
 		&isEmpty)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, false, fmt.Errorf("error in getting non empty domain for dimension index %d for array: %w", dimIdx, a.context.LastError())
 	}
@@ -809,6 +831,7 @@ func (a *Array) NonEmptyDomainFromIndex(dimIdx uint) (*NonEmptyDomain, bool, err
 		a.tiledbArray,
 		(C.uint32_t)(dimIdx),
 		tmpDimensionPtr, &isEmpty)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, false, fmt.Errorf("error in getting non empty domain for dimension: %w", a.context.LastError())
 	}
@@ -843,6 +866,7 @@ func (a *Array) NonEmptyDomainFromName(dimName string) (*NonEmptyDomain, bool, e
 		a.tiledbArray,
 		cDimName,
 		tmpDimensionPtr, &isEmpty)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, false, fmt.Errorf("error in getting non empty domain for dimension: %w", a.context.LastError())
 	}
@@ -861,9 +885,10 @@ func (a *Array) NonEmptyDomainFromName(dimName string) (*NonEmptyDomain, bool, e
 
 // URI returns the array's uri.
 func (a *Array) URI() (string, error) {
-	var curi *C.char
+	var curi *C.char // a must be kept alive while curi is being accessed.
 	C.tiledb_array_get_uri(a.context.tiledbContext, a.tiledbArray, &curi)
 	uri := C.GoString(curi)
+	runtime.KeepAlive(a)
 	if uri == "" {
 		return uri, errors.New("error getting URI for array: uri is empty")
 	}
@@ -880,6 +905,7 @@ func (a *Array) PutCharMetadata(key string, charData string) error {
 	valueNum := C.uint(len(charData))
 	ret := C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray,
 		ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&[]byte(charData)[0]))
+	runtime.KeepAlive(a)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error adding char metadata to array: %w", a.context.LastError())
@@ -974,6 +1000,7 @@ func arrayPutMetadata(a *Array, dt Datatype, key string, valuePtr unsafe.Pointer
 		C.uint(count),
 		valuePtr,
 	)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("could not add metadata to array: %w", a.context.LastError())
 	}
@@ -987,6 +1014,7 @@ func (a *Array) DeleteMetadata(key string) error {
 	defer C.free(unsafe.Pointer(ckey))
 
 	ret := C.tiledb_array_delete_metadata(a.context.tiledbContext, a.tiledbArray, ckey)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deleting metadata from array: %w", a.context.LastError())
 	}
@@ -1004,6 +1032,7 @@ func (a *Array) GetMetadata(key string) (Datatype, uint, interface{}, error) {
 	var cvalue unsafe.Pointer
 
 	ret := C.tiledb_array_get_metadata(a.context.tiledbContext, a.tiledbArray, ckey, &cType, &cValueNum, &cvalue)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, 0, nil, fmt.Errorf("error getting metadata from array: %w, key: %s", a.context.LastError(), key)
 	}
@@ -1028,6 +1057,7 @@ func (a *Array) GetMetadataNum() (uint64, error) {
 	var cNum C.uint64_t
 
 	ret := C.tiledb_array_get_metadata_num(a.context.tiledbContext, a.tiledbArray, &cNum)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting number of metadata from array: %w", a.context.LastError())
 	}
@@ -1059,6 +1089,7 @@ func (a *Array) GetMetadataFromIndexWithValueLimit(index uint64, limit *uint) (*
 
 	ret := C.tiledb_array_get_metadata_from_index(a.context.tiledbContext,
 		a.tiledbArray, cIndex, &cKey, &cKeyLen, &cType, &cValueNum, &cvalue)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting metadata from array: %s, Index: %d", a.context.LastError(), index)
 	}
@@ -1126,6 +1157,8 @@ func (a *Array) SetConfig(config *Config) error {
 	a.config = config
 
 	ret := C.tiledb_array_set_config(a.context.tiledbContext, a.tiledbArray, a.config.tiledbConfig)
+	runtime.KeepAlive(a)
+	runtime.KeepAlive(config)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting config on array: %w", a.context.LastError())
 	}
@@ -1137,6 +1170,7 @@ func (a *Array) SetConfig(config *Config) error {
 func (a *Array) Config() (*Config, error) {
 	config := Config{}
 	ret := C.tiledb_array_get_config(a.context.tiledbContext, a.tiledbArray, &config.tiledbConfig)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting config from array: %w", a.context.LastError())
 	}
@@ -1157,6 +1191,7 @@ func DeleteFragments(tdbCtx *Context, uri string, startTimestamp, endTimestamp u
 
 	ret := C.tiledb_array_delete_fragments_v2(tdbCtx.tiledbContext, curi,
 		C.uint64_t(startTimestamp), C.uint64_t(endTimestamp))
+	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deleting fragments from array: %w", tdbCtx.LastError())
 	}
@@ -1173,6 +1208,7 @@ func DeleteFragmentsList(tdbCtx *Context, uri string, fragmentURIs []string) err
 	defer freeMemory()
 
 	ret := C.tiledb_array_delete_fragments_list(tdbCtx.tiledbContext, curi, (**C.char)(slicePtr(list)), C.size_t(len(list)))
+	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deleting fragments list from array: %w", tdbCtx.LastError())
 	}

--- a/array_experimental.go
+++ b/array_experimental.go
@@ -27,6 +27,7 @@ func GetConsolidationPlan(arr *Array, fragmentSize uint64) (*ConsolidationPlan, 
 	}
 
 	ret := C.tiledb_consolidation_plan_create_with_mbr(cp.context.tiledbContext, arr.tiledbArray, C.uint64_t(fragmentSize), &cp.tiledbConsolidationPlan)
+	runtime.KeepAlive(arr)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting consolidation plan for array: %w", cp.context.LastError())
 	}
@@ -51,6 +52,7 @@ func (cp *ConsolidationPlan) NumNodes() (uint64, error) {
 	var numNodes C.uint64_t
 
 	ret := C.tiledb_consolidation_plan_get_num_nodes(cp.context.tiledbContext, cp.tiledbConsolidationPlan, &numNodes)
+	runtime.KeepAlive(cp)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting consolidation plan num nodes: %w", cp.context.LastError())
 	}
@@ -63,6 +65,7 @@ func (cp *ConsolidationPlan) NumFragments(nodeIndex uint64) (uint64, error) {
 	var numFragments C.uint64_t
 
 	ret := C.tiledb_consolidation_plan_get_num_fragments(cp.context.tiledbContext, cp.tiledbConsolidationPlan, C.uint64_t(nodeIndex), &numFragments)
+	runtime.KeepAlive(cp)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting consolidation plan num fragments: %w", cp.context.LastError())
 	}
@@ -75,6 +78,7 @@ func (cp *ConsolidationPlan) FragmentURI(nodeIndex, fragmentIndex uint64) (strin
 	var curi *C.char
 
 	ret := C.tiledb_consolidation_plan_get_fragment_uri(cp.context.tiledbContext, cp.tiledbConsolidationPlan, C.uint64_t(nodeIndex), C.uint64_t(fragmentIndex), &curi)
+	runtime.KeepAlive(cp)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting consolidation plan fragment uri for node %d and fragment %d: %w", nodeIndex, fragmentIndex, cp.context.LastError())
 	}
@@ -86,6 +90,7 @@ func (cp *ConsolidationPlan) FragmentURI(nodeIndex, fragmentIndex uint64) (strin
 func (cp *ConsolidationPlan) DumpJSON() (string, error) {
 	var cjson *C.char
 	ret := C.tiledb_consolidation_plan_dump_json_str(cp.context.tiledbContext, cp.tiledbConsolidationPlan, &cjson)
+	runtime.KeepAlive(cp)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting consolidation plan json dump: %w", cp.context.LastError())
 	}
@@ -115,6 +120,7 @@ func (a *Array) ConsolidateFragments(config *Config, fragmentList []string) erro
 	defer freeMemory()
 
 	ret := C.tiledb_array_consolidate_fragments(a.context.tiledbContext, curi, (**C.char)(slicePtr(list)), C.uint64_t(len(list)), config.tiledbConfig)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error consolidating tiledb array fragment list: %w", a.context.LastError())
 	}

--- a/array_schema_evolution_experimental.go
+++ b/array_schema_evolution_experimental.go
@@ -9,6 +9,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"unsafe"
 )
 
@@ -23,6 +24,7 @@ func NewArraySchemaEvolution(tdbCtx *Context) (*ArraySchemaEvolution, error) {
 	ret := C.tiledb_array_schema_evolution_alloc(
 		arraySchemaEvolution.context.tiledbContext,
 		&arraySchemaEvolution.tiledbArraySchemaEvolution)
+	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb arraySchemaEvolution: %w",
 			arraySchemaEvolution.context.LastError())
@@ -58,6 +60,8 @@ func (ase *ArraySchemaEvolution) AddAttribute(attribute *Attribute) error {
 	ret := C.tiledb_array_schema_evolution_add_attribute(
 		ase.context.tiledbContext, ase.tiledbArraySchemaEvolution,
 		attribute.tiledbAttribute)
+	runtime.KeepAlive(ase)
+	runtime.KeepAlive(attribute)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf(
 			"error adding attribute %s to tiledb arraySchemaEvolution: %w",
@@ -74,6 +78,7 @@ func (ase *ArraySchemaEvolution) DropAttribute(name string) error {
 
 	ret := C.tiledb_array_schema_evolution_drop_attribute(
 		ase.context.tiledbContext, ase.tiledbArraySchemaEvolution, cname)
+	runtime.KeepAlive(ase)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dropping tiledb attribute: %w",
 			ase.context.LastError())
@@ -89,6 +94,7 @@ func (ase *ArraySchemaEvolution) Evolve(uri string) error {
 
 	ret := C.tiledb_array_evolve(ase.context.tiledbContext, curi,
 		ase.tiledbArraySchemaEvolution)
+	runtime.KeepAlive(ase)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error evolving schema for array %s: %w", uri,
 			ase.context.LastError())

--- a/buffer.go
+++ b/buffer.go
@@ -174,7 +174,7 @@ var _ io.ReaderAt = (*Buffer)(nil)
 // SetBuffer sets the buffer to point at the given Go slice. The memory is now
 // Go-managed.
 func (b *Buffer) SetBuffer(buffer []byte) error {
-	cbuffer := unsafe.Pointer(&buffer[0])
+	cbuffer := unsafe.Pointer(unsafe.SliceData(buffer))
 	b.pinner.Pin(cbuffer)
 
 	ret := C.tiledb_buffer_set_data(b.context.tiledbContext, b.tiledbBuffer, cbuffer, C.uint64_t(len(buffer)))

--- a/buffer.go
+++ b/buffer.go
@@ -19,25 +19,7 @@ import (
 type Buffer struct {
 	tiledbBuffer *C.tiledb_buffer_t
 	context      *Context
-
-	// data is a reference to the memory that this Buffer refers to.
-	// If this is set to `nil`, the Buffer is was allocated and its memory is
-	// owned by TileDB internals.
-	//
-	// Buffer technically violates the contract of CGo, by passing []byte slices
-	// to C code, which holds onto it long after the CGo call has returned.
-	// This means that, without keeping this around, Go thinks it can collect
-	// the store that we've passed in:
-	//
-	//     someBytes := getSomeBytes()
-	//     buf.SetBuffer(someBytes)
-	//     // if it's not referenced later, someBytes might now be collected!
-	//
-	// By holding onto this reference here, we shield the caller from this
-	// happening to them. This is still unsafe per the language spec, but because
-	// the Go garbage collector (as of v1.18) does not move objects around,
-	// this is not THAT dangerous at runtime.
-	data byteBuffer
+	pinner       runtime.Pinner
 }
 
 // NewBuffer allocates a new buffer.
@@ -64,10 +46,10 @@ func NewBuffer(context *Context) (*Buffer, error) {
 // can safely be called many times on the same object; if it has already
 // been freed, it will not be freed again.
 func (b *Buffer) Free() {
-	b.data = nil
 	if b.tiledbBuffer != nil {
 		C.tiledb_buffer_free(&b.tiledbBuffer)
 	}
+	b.pinner.Unpin()
 }
 
 // Context exposes the internal TileDB context used to initialize the buffer.
@@ -192,9 +174,10 @@ var _ io.ReaderAt = (*Buffer)(nil)
 // SetBuffer sets the buffer to point at the given Go slice. The memory is now
 // Go-managed.
 func (b *Buffer) SetBuffer(buffer []byte) error {
-	b.data = byteBuffer(buffer)
+	cbuffer := unsafe.Pointer(&buffer[0])
+	b.pinner.Pin(cbuffer)
 
-	ret := C.tiledb_buffer_set_data(b.context.tiledbContext, b.tiledbBuffer, b.data.start(), C.uint64_t(b.data.lenBytes()))
+	ret := C.tiledb_buffer_set_data(b.context.tiledbContext, b.tiledbBuffer, cbuffer, C.uint64_t(len(buffer)))
 	runtime.KeepAlive(b)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting tiledb buffer: %w", b.context.LastError())
@@ -217,28 +200,11 @@ func (b *Buffer) dataCopy() ([]byte, error) {
 		return nil, nil
 	}
 
-	if b.data == nil {
-		// This is a TileDB-managed buffer. We need to copy its data into Go memory.
-		// We assume that once a buffer is set to point to user-provided memory,
-		// TileDB never updates the buffer to point to its own memory (i.e., the
-		// only time when there will be a buffer pointing to TileDB-owned memory is
-		// when TileDB allocates a fresh buffer, e.g. as an out parameter from a
-		// serialization function).
-
-		// Since this buffer is TileDB-managed, make sure it's not GC'd before we're
-		// done with its memory.
-		defer runtime.KeepAlive(b)
-
-		if csize > math.MaxInt32 {
-			return nil, fmt.Errorf("TileDB's buffer (%d) larger than maximum allowed CGo buffer (%d)", csize, math.MaxInt32)
-		}
-		return C.GoBytes(cbuffer, C.int(csize)), nil
+	if csize > math.MaxInt32 {
+		return nil, fmt.Errorf("TileDB's buffer (%d) larger than maximum allowed CGo buffer (%d)", csize, math.MaxInt32)
 	}
+	cpy := C.GoBytes(cbuffer, C.int(csize))
 
-	gotBytes := b.data.subSlice(cbuffer, uintptr(csize))
-
-	cpy := make([]byte, len(gotBytes))
-	copy(cpy, gotBytes)
 	runtime.KeepAlive(b)
 	return cpy, nil
 }

--- a/buffer.go
+++ b/buffer.go
@@ -49,6 +49,7 @@ func NewBuffer(context *Context) (*Buffer, error) {
 	}
 
 	ret := C.tiledb_buffer_alloc(buffer.context.tiledbContext, &buffer.tiledbBuffer)
+	runtime.KeepAlive(context)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb buffer: %w", buffer.context.LastError())
 	}
@@ -77,6 +78,7 @@ func (b *Buffer) Context() *Context {
 // SetType sets the buffer datatype.
 func (b *Buffer) SetType(datatype Datatype) error {
 	ret := C.tiledb_buffer_set_type(b.context.tiledbContext, b.tiledbBuffer, C.tiledb_datatype_t(datatype))
+	runtime.KeepAlive(b)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting datatype for tiledb buffer: %w", b.context.LastError())
 	}
@@ -87,6 +89,7 @@ func (b *Buffer) SetType(datatype Datatype) error {
 func (b *Buffer) Type() (Datatype, error) {
 	var bufferType C.tiledb_datatype_t
 	ret := C.tiledb_buffer_get_type(b.context.tiledbContext, b.tiledbBuffer, &bufferType)
+	runtime.KeepAlive(b)
 
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb buffer type: %w", b.context.LastError())
@@ -121,7 +124,7 @@ func (b *Buffer) ReadAt(p []byte, off int64) (int, error) {
 		return 0, errors.New("offset cannot be negative")
 	}
 
-	var cbuffer unsafe.Pointer
+	var cbuffer unsafe.Pointer // b must be kept alive while cbuffer is being accessed.
 	var csize C.uint64_t
 
 	ret := C.tiledb_buffer_get_data(b.context.tiledbContext, b.tiledbBuffer, &cbuffer, &csize)
@@ -138,6 +141,7 @@ func (b *Buffer) ReadAt(p []byte, off int64) (int, error) {
 	sizeToRead := min(math.MaxInt, int(availableBytes))
 
 	readSize := copy(p, unsafe.Slice((*byte)(unsafe.Pointer(uintptr(cbuffer)+uintptr(off))), sizeToRead))
+	runtime.KeepAlive(b)
 
 	var err error
 	if int64(readSize)+off == int64(csize) {
@@ -149,7 +153,7 @@ func (b *Buffer) ReadAt(p []byte, off int64) (int, error) {
 
 // WriteTo writes the contents of a Buffer to an io.Writer.
 func (b *Buffer) WriteTo(w io.Writer) (int64, error) {
-	var cbuffer unsafe.Pointer
+	var cbuffer unsafe.Pointer // b must be kept alive while cbuffer is being accessed.
 	var csize C.uint64_t
 
 	ret := C.tiledb_buffer_get_data(b.context.tiledbContext, b.tiledbBuffer, &cbuffer, &csize)
@@ -170,6 +174,7 @@ func (b *Buffer) WriteTo(w io.Writer) (int64, error) {
 
 		// Construct a slice from the buffer's data without copying it.
 		n, err := w.Write(unsafe.Slice((*byte)(unsafe.Pointer(uintptr(cbuffer)+uintptr(csize)-uintptr(remaining))), writeSize))
+		runtime.KeepAlive(b)
 		remaining -= int64(n)
 
 		if err != nil {
@@ -190,6 +195,7 @@ func (b *Buffer) SetBuffer(buffer []byte) error {
 	b.data = byteBuffer(buffer)
 
 	ret := C.tiledb_buffer_set_data(b.context.tiledbContext, b.tiledbBuffer, b.data.start(), C.uint64_t(b.data.lenBytes()))
+	runtime.KeepAlive(b)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting tiledb buffer: %w", b.context.LastError())
 	}
@@ -199,7 +205,7 @@ func (b *Buffer) SetBuffer(buffer []byte) error {
 
 // dataCopy returns a copy of the bytes stored in the buffer.
 func (b *Buffer) dataCopy() ([]byte, error) {
-	var cbuffer unsafe.Pointer
+	var cbuffer unsafe.Pointer // b must be kept alive while cbuffer is being accessed.
 	var csize C.uint64_t
 
 	ret := C.tiledb_buffer_get_data(b.context.tiledbContext, b.tiledbBuffer, &cbuffer, &csize)
@@ -233,6 +239,7 @@ func (b *Buffer) dataCopy() ([]byte, error) {
 
 	cpy := make([]byte, len(gotBytes))
 	copy(cpy, gotBytes)
+	runtime.KeepAlive(b)
 	return cpy, nil
 }
 
@@ -241,6 +248,7 @@ func (b *Buffer) Len() (uint64, error) {
 	var csize C.uint64_t
 
 	ret := C.tiledb_buffer_get_data(b.context.tiledbContext, b.tiledbBuffer, &cbuffer, &csize)
+	runtime.KeepAlive(b)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb buffer data: %w", b.context.LastError())
 	}

--- a/buffer_list.go
+++ b/buffer_list.go
@@ -8,6 +8,7 @@ import "C"
 import (
 	"fmt"
 	"io"
+	"runtime"
 )
 
 // BufferList A list of TileDB BufferList objects
@@ -21,6 +22,7 @@ func NewBufferList(context *Context) (*BufferList, error) {
 	bufferList := BufferList{context: context}
 
 	ret := C.tiledb_buffer_list_alloc(bufferList.context.tiledbContext, &bufferList.tiledbBufferList)
+	runtime.KeepAlive(context)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb buffer list: %w", bufferList.context.LastError())
 	}
@@ -79,6 +81,7 @@ var _ io.WriterTo = (*BufferList)(nil)
 func (b *BufferList) NumBuffers() (uint64, error) {
 	var numBuffers C.uint64_t
 	ret := C.tiledb_buffer_list_get_num_buffers(b.context.tiledbContext, b.tiledbBufferList, &numBuffers)
+	runtime.KeepAlive(b)
 
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb bufferList num buffers: %w", b.context.LastError())
@@ -90,12 +93,13 @@ func (b *BufferList) NumBuffers() (uint64, error) {
 // GetBuffer returns a Buffer at the given index in the list.
 func (b *BufferList) GetBuffer(bufferIndex uint) (*Buffer, error) {
 	buffer := Buffer{context: b.context}
-	freeOnGC(&buffer)
 
 	ret := C.tiledb_buffer_list_get_buffer(b.context.tiledbContext, b.tiledbBufferList, C.uint64_t(bufferIndex), &buffer.tiledbBuffer)
+	runtime.KeepAlive(b)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb buffer index %d from buffer list: %w", bufferIndex, b.context.LastError())
 	}
+	freeOnGC(&buffer)
 
 	return &buffer, nil
 }
@@ -104,6 +108,7 @@ func (b *BufferList) GetBuffer(bufferIndex uint) (*Buffer, error) {
 func (b *BufferList) TotalSize() (uint64, error) {
 	var totalSize C.uint64_t
 	ret := C.tiledb_buffer_list_get_total_size(b.context.tiledbContext, b.tiledbBufferList, &totalSize)
+	runtime.KeepAlive(b)
 
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb bufferList num buffers: %w", b.context.LastError())
@@ -117,13 +122,14 @@ func (b *BufferList) TotalSize() (uint64, error) {
 // Deprecated: Use WriteTo instead for increased performance.
 func (b *BufferList) Flatten() (*Buffer, error) {
 	buffer := Buffer{context: b.context}
-	freeOnGC(&buffer)
 
 	ret := C.tiledb_buffer_list_flatten(b.context.tiledbContext, b.tiledbBufferList, &buffer.tiledbBuffer)
+	runtime.KeepAlive(b)
 
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb bufferList num buffers: %w", b.context.LastError())
 	}
+	freeOnGC(&buffer)
 
 	return &buffer, nil
 }

--- a/context.go
+++ b/context.go
@@ -31,6 +31,7 @@ func NewContext(config *Config) (*Context, error) {
 	} else {
 		ret = C.tiledb_ctx_alloc(nil, &context.tiledbContext)
 	}
+	runtime.KeepAlive(config)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb context: %w", context.LastError())
 	}
@@ -41,9 +42,6 @@ func NewContext(config *Config) (*Context, error) {
 		return nil, fmt.Errorf("error creating tiledb context: %w", err)
 	}
 
-	if config != nil {
-		runtime.KeepAlive(config)
-	}
 	return &context, nil
 }
 
@@ -94,6 +92,7 @@ func (c *Context) CancelAllTasks() error {
 func (c *Context) Config() (*Config, error) {
 	config := Config{}
 	ret := C.tiledb_ctx_get_config(c.tiledbContext, &config.tiledbConfig)
+	runtime.KeepAlive(c)
 
 	if ret == C.TILEDB_OOM {
 		return nil, errors.New("out of Memory error in GetConfig")
@@ -109,6 +108,7 @@ func (c *Context) Config() (*Config, error) {
 func (c *Context) LastError() error {
 	var err *C.tiledb_error_t
 	ret := C.tiledb_ctx_get_last_error(c.tiledbContext, &err)
+	runtime.KeepAlive(c)
 	if ret == C.TILEDB_OOM {
 		return errors.New("out of Memory error in tiledb_ctx_get_last_error")
 	} else if ret != C.TILEDB_OK {
@@ -126,16 +126,13 @@ func (c *Context) LastError() error {
 func (c *Context) IsSupportedFS(fs FS) (bool, error) {
 	var isSupported C.int32_t
 	ret := C.tiledb_ctx_is_supported_fs(c.tiledbContext, C.tiledb_filesystem_t(fs), &isSupported)
+	runtime.KeepAlive(c)
 
 	if ret != C.TILEDB_OK {
 		return false, errors.New("error in checking FS support")
 	}
 
-	if isSupported == 0 {
-		return false, nil
-	}
-
-	return true, nil
+	return isSupported != 0, nil
 }
 
 // SetTag sets the context tag.
@@ -146,6 +143,7 @@ func (c *Context) SetTag(key string, value string) error {
 	defer C.free(unsafe.Pointer(cvalue))
 
 	ret := C.tiledb_ctx_set_tag(c.tiledbContext, ckey, cvalue)
+	runtime.KeepAlive(c)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error in setting tag: %w", c.LastError())
@@ -179,6 +177,7 @@ func (c *Context) Stats() ([]byte, error) {
 	if ret := C.tiledb_ctx_get_stats(c.tiledbContext, &stats); ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting stats from context: %w", c.LastError())
 	}
+	runtime.KeepAlive(c)
 
 	s := C.GoString(stats)
 	if ret := C.tiledb_stats_free_str(&stats); ret != C.TILEDB_OK {

--- a/dimension_label_experimental.go
+++ b/dimension_label_experimental.go
@@ -33,6 +33,7 @@ func (d *DimensionLabel) Free() {
 func (d *DimensionLabel) DimensionIndex() (uint32, error) {
 	var dimensionIndex C.uint32_t
 	ret := C.tiledb_dimension_label_get_dimension_index(d.context.tiledbContext, d.tiledbDimensionLabel, &dimensionIndex)
+	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching dimension index for dimension label: %w", d.context.LastError())
 	}
@@ -42,13 +43,15 @@ func (d *DimensionLabel) DimensionIndex() (uint32, error) {
 
 // AttributeName returns the name of the attribute the label data is stored under.
 func (d *DimensionLabel) AttributeName() (string, error) {
-	var labelAttrName *C.char
-	ret := C.tiledb_dimension_label_get_label_attr_name(d.context.tiledbContext, d.tiledbDimensionLabel, &labelAttrName)
+	var cLabelAttrName *C.char // d must be kept alive while cLabelAttrName is being accessed.
+	ret := C.tiledb_dimension_label_get_label_attr_name(d.context.tiledbContext, d.tiledbDimensionLabel, &cLabelAttrName)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting dimension label attribute name: %w", d.context.LastError())
 	}
 
-	return C.GoString(labelAttrName), nil // copies labelAttrName which is memory owned by core
+	name := C.GoString(cLabelAttrName) // copies cLabelAttrName
+	runtime.KeepAlive(d)
+	return name, nil
 }
 
 // CellValNum returns the number of values per cell for the labels on the dimension label.
@@ -56,6 +59,7 @@ func (d *DimensionLabel) AttributeName() (string, error) {
 func (d *DimensionLabel) CellValNum() (uint32, error) {
 	var labelCellValNum C.uint32_t
 	ret := C.tiledb_dimension_label_get_label_cell_val_num(d.context.tiledbContext, d.tiledbDimensionLabel, &labelCellValNum)
+	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching cell val num for dimension label: %w", d.context.LastError())
 	}
@@ -67,6 +71,7 @@ func (d *DimensionLabel) CellValNum() (uint32, error) {
 func (d *DimensionLabel) Order() (DataOrder, error) {
 	var labelOrder C.tiledb_data_order_t
 	ret := C.tiledb_dimension_label_get_label_order(d.context.tiledbContext, d.tiledbDimensionLabel, &labelOrder)
+	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching label order for dimension label: %w", d.context.LastError())
 	}
@@ -78,6 +83,7 @@ func (d *DimensionLabel) Order() (DataOrder, error) {
 func (d *DimensionLabel) Type() (Datatype, error) {
 	var dataType C.tiledb_datatype_t
 	ret := C.tiledb_dimension_label_get_label_type(d.context.tiledbContext, d.tiledbDimensionLabel, &dataType)
+	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching dimension label type: %w", d.context.LastError())
 	}
@@ -87,24 +93,28 @@ func (d *DimensionLabel) Type() (Datatype, error) {
 
 // Name returns the name for the dimension label.
 func (d *DimensionLabel) Name() (string, error) {
-	var labelName *C.char
-	ret := C.tiledb_dimension_label_get_name(d.context.tiledbContext, d.tiledbDimensionLabel, &labelName)
+	var cLabelName *C.char // d must be kept alive while cLabelName is being accessed.
+	ret := C.tiledb_dimension_label_get_name(d.context.tiledbContext, d.tiledbDimensionLabel, &cLabelName)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting dimension label name: %w", d.context.LastError())
 	}
 
-	return C.GoString(labelName), nil // copies labelName which is memory owned by core
+	labelName := C.GoString(cLabelName) // copies cLabelName
+	runtime.KeepAlive(d)
+	return labelName, nil
 }
 
 // Uri Returns the Uri for the dimension label array.
 func (d *DimensionLabel) URI() (string, error) {
-	var labelUri *C.char
-	ret := C.tiledb_dimension_label_get_uri(d.context.tiledbContext, d.tiledbDimensionLabel, &labelUri)
+	var cLabelUri *C.char // d must be kept alive while cLabelUri is being accessed.
+	ret := C.tiledb_dimension_label_get_uri(d.context.tiledbContext, d.tiledbDimensionLabel, &cLabelUri)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting dimension label URI: %w", d.context.LastError())
 	}
 
-	return C.GoString(labelUri), nil // copies labelUri which is memory owned by core
+	labelUri := C.GoString(cLabelUri) // copies cLabelUri
+	runtime.KeepAlive(d)
+	return labelUri, nil
 }
 
 // AddDimensionLabel adds a dimension label to the array schema.
@@ -112,6 +122,7 @@ func (a *ArraySchema) AddDimensionLabel(dimIndex uint32, name string, order Data
 	cLabelName := C.CString(name)
 	ret := C.tiledb_array_schema_add_dimension_label(a.context.tiledbContext, a.tiledbArraySchema,
 		C.uint32_t(dimIndex), cLabelName, C.tiledb_data_order_t(order), C.tiledb_datatype_t(labelType))
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error adding dimension label to ArraySchema: %w", a.context.LastError())
 	}
@@ -124,6 +135,7 @@ func (a *ArraySchema) DimensionLabelFromIndex(labelIdx uint64) (*DimensionLabel,
 	dimLabel := DimensionLabel{context: a.context}
 	ret := C.tiledb_array_schema_get_dimension_label_from_index(a.context.tiledbContext, a.tiledbArraySchema,
 		C.uint64_t(labelIdx), &dimLabel.tiledbDimensionLabel)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting dimension label '%d' for ArraySchema: %w", labelIdx, a.context.LastError())
 	}
@@ -139,6 +151,7 @@ func (a *ArraySchema) DimensionLabelFromName(name string) (*DimensionLabel, erro
 	dimLabel := DimensionLabel{context: a.context}
 	ret := C.tiledb_array_schema_get_dimension_label_from_name(a.context.tiledbContext, a.tiledbArraySchema,
 		cAttrName, &dimLabel.tiledbDimensionLabel)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting dimension label '%s' for ArraySchema: %w", name, a.context.LastError())
 	}
@@ -155,6 +168,7 @@ func (a *ArraySchema) HasDimensionLabel(name string) (bool, error) {
 	var hasLabel C.int32_t
 	ret := C.tiledb_array_schema_has_dimension_label(a.context.tiledbContext, a.tiledbArraySchema,
 		cLabelName, &hasLabel)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error checking ArraySchema for dimension label '%s': %w", name, a.context.LastError())
 	}
@@ -167,6 +181,7 @@ func (a *ArraySchema) DimensionLabelsNum() (uint64, error) {
 	var labelNum C.uint64_t
 
 	ret := C.tiledb_array_schema_get_dimension_label_num(a.context.tiledbContext, a.tiledbArraySchema, &labelNum)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching dimension label number: %w", a.context.LastError())
 	}
@@ -181,6 +196,8 @@ func (a *ArraySchema) SetDimensionLabelFilterList(name string, filterList Filter
 
 	ret := C.tiledb_array_schema_set_dimension_label_filter_list(a.context.tiledbContext, a.tiledbArraySchema,
 		cName, filterList.tiledbFilterList)
+	runtime.KeepAlive(a)
+	runtime.KeepAlive(filterList)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting dimension label filter list on ArraySchema: %w", a.context.LastError())
 	}
@@ -199,44 +216,30 @@ func (a *ArraySchema) SetDimensionLabelTileExtent(labelName string, dimType Data
 			dimType.ReflectKind(), extentType)
 	}
 
-	// Use extentPtr to ensure cExtent is not collected before it is passed to tiledb.
-	var extentPtr any
-	defer runtime.KeepAlive(extentPtr)
 	// Create extent void*
 	var cExtent unsafe.Pointer
 	switch tmpExtent := extent.(type) {
 	case int8:
-		extentPtr = &tmpExtent
 		cExtent = unsafe.Pointer(&tmpExtent)
 	case int16:
-		extentPtr = &tmpExtent
 		cExtent = unsafe.Pointer(&tmpExtent)
 	case int32:
-		extentPtr = &tmpExtent
 		cExtent = unsafe.Pointer(&tmpExtent)
 	case int64:
-		extentPtr = &tmpExtent
 		cExtent = unsafe.Pointer(&tmpExtent)
 	case uint8:
-		extentPtr = &tmpExtent
 		cExtent = unsafe.Pointer(&tmpExtent)
 	case uint16:
-		extentPtr = &tmpExtent
 		cExtent = unsafe.Pointer(&tmpExtent)
 	case uint32:
-		extentPtr = &tmpExtent
 		cExtent = unsafe.Pointer(&tmpExtent)
 	case uint64:
-		extentPtr = &tmpExtent
 		cExtent = unsafe.Pointer(&tmpExtent)
 	case float32:
-		extentPtr = &tmpExtent
 		cExtent = unsafe.Pointer(&tmpExtent)
 	case float64:
-		extentPtr = &tmpExtent
 		cExtent = unsafe.Pointer(&tmpExtent)
 	case bool:
-		extentPtr = &tmpExtent
 		cExtent = unsafe.Pointer(&tmpExtent)
 	default:
 		return fmt.Errorf("unrecognized dimension datatype passed to SetDimensionLabelTileExtent: %s",
@@ -245,6 +248,8 @@ func (a *ArraySchema) SetDimensionLabelTileExtent(labelName string, dimType Data
 
 	ret := C.tiledb_array_schema_set_dimension_label_tile_extent(a.context.tiledbContext, a.tiledbArraySchema,
 		cName, C.tiledb_datatype_t(dimType), cExtent)
+	runtime.KeepAlive(a)
+	// cExtent is being kept alive by passing it to cgo call.
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting dimension label tile extent on ArraySchema: %w", a.context.LastError())
 	}
@@ -282,6 +287,7 @@ func (sa *Subarray) GetDimensionLabelRangeNum(labelName string) (uint64, error) 
 	defer C.free(unsafe.Pointer(cLabelName))
 
 	ret := C.tiledb_subarray_get_label_range_num(sa.context.tiledbContext, sa.subarray, cLabelName, &rangeNum)
+	runtime.KeepAlive(sa)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error retrieving subarray label range num: %w", sa.context.LastError())
 	}
@@ -309,16 +315,14 @@ func (sa *Subarray) AddDimensionLabelRange(labelName string, r Range) error {
 		endSlice := []byte(r.end.(string))
 		ret = C.tiledb_subarray_add_label_range_var(sa.context.tiledbContext, sa.subarray, cLabelName,
 			slicePtr(startSlice), C.uint64_t(len(startSlice)), slicePtr(endSlice), C.uint64_t(len(endSlice)))
-		runtime.KeepAlive(startSlice)
-		runtime.KeepAlive(endSlice)
 	} else {
 		startValue := addressableValue(r.start)
 		endValue := addressableValue(r.end)
 		ret = C.tiledb_subarray_add_label_range(sa.context.tiledbContext, sa.subarray, cLabelName,
 			startValue.UnsafePointer(), endValue.UnsafePointer(), nil)
-		runtime.KeepAlive(startValue)
-		runtime.KeepAlive(endValue)
 	}
+	runtime.KeepAlive(sa)
+	// The start and end values are being kept alive by passing them to cgo call.
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error adding subarray label range: %w", sa.context.LastError())
 	}
@@ -370,6 +374,7 @@ func (sa *Subarray) GetDimensionLabelRange(labelName string, rangeNum uint64) (R
 			r.end = reflect.NewAt(typ, endPointer).Elem().Interface()
 		}
 	}
+	runtime.KeepAlive(sa)
 	if ret != C.TILEDB_OK {
 		return Range{}, fmt.Errorf("error retrieving subarray range for label %s and range num %d: %w", labelName, rangeNum, sa.context.LastError())
 	}

--- a/domain.go
+++ b/domain.go
@@ -9,6 +9,7 @@ import "C"
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"unsafe"
 )
 
@@ -25,6 +26,7 @@ type Domain struct {
 func NewDomain(tdbCtx *Context) (*Domain, error) {
 	domain := Domain{context: tdbCtx}
 	ret := C.tiledb_domain_alloc(domain.context.tiledbContext, &domain.tiledbDomain)
+	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb domain: %w", domain.context.LastError())
 	}
@@ -53,6 +55,7 @@ func (d *Domain) Context() *Context {
 func (d *Domain) Type() (Datatype, error) {
 	var datatype C.tiledb_datatype_t
 	ret := C.tiledb_domain_get_type(d.context.tiledbContext, d.tiledbDomain, &datatype)
+	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return -1, fmt.Errorf("error getting tiledb domain type: %w", d.context.LastError())
 	}
@@ -63,6 +66,7 @@ func (d *Domain) Type() (Datatype, error) {
 func (d *Domain) NDim() (uint, error) {
 	var ndim C.uint32_t
 	ret := C.tiledb_domain_get_ndim(d.context.tiledbContext, d.tiledbDomain, &ndim)
+	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb domain number of dimensions: %w", d.context.LastError())
 	}
@@ -74,6 +78,7 @@ func (d *Domain) DimensionFromIndex(index uint) (*Dimension, error) {
 	var dim *C.tiledb_dimension_t
 	ret := C.tiledb_domain_get_dimension_from_index(d.context.tiledbContext,
 		d.tiledbDomain, C.uint32_t(index), &dim)
+	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb dimension by index for domain: %w", d.context.LastError())
 	}
@@ -90,6 +95,7 @@ func (d *Domain) DimensionFromName(name string) (*Dimension, error) {
 	defer C.free(unsafe.Pointer(cname))
 	var dim *C.tiledb_dimension_t
 	ret := C.tiledb_domain_get_dimension_from_name(d.context.tiledbContext, d.tiledbDomain, cname, &dim)
+	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb dimension by name for domain: %w", d.context.LastError())
 	}
@@ -102,6 +108,7 @@ func (d *Domain) DimensionFromName(name string) (*Dimension, error) {
 func (d *Domain) AddDimensions(dimensions ...*Dimension) error {
 	for _, dimension := range dimensions {
 		ret := C.tiledb_domain_add_dimension(d.context.tiledbContext, d.tiledbDomain, dimension.tiledbDimension)
+		runtime.KeepAlive(dimension)
 		if ret != C.TILEDB_OK {
 			return fmt.Errorf("error adding dimension to domain: %w", d.context.LastError())
 		}
@@ -115,6 +122,7 @@ func (d *Domain) HasDimension(dimName string) (bool, error) {
 	cDimName := C.CString(dimName)
 	defer C.free(unsafe.Pointer(cDimName))
 	ret := C.tiledb_domain_has_dimension(d.context.tiledbContext, d.tiledbDomain, cDimName, &hasDim)
+	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error finding dimension %s in domain: %w", dimName, d.context.LastError())
 	}
@@ -129,6 +137,7 @@ func (d *Domain) HasDimension(dimName string) (bool, error) {
 // DumpSTDOUT dumps the domain in ASCII format to stdout.
 func (d *Domain) DumpSTDOUT() error {
 	ret := C.tiledb_domain_dump(d.context.tiledbContext, d.tiledbDomain, C.stdout)
+	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping domain to stdout: %w", d.context.LastError())
 	}
@@ -156,6 +165,7 @@ func (d *Domain) Dump(path string) error {
 
 	// Dump domain to file
 	ret := C.tiledb_domain_dump(d.context.tiledbContext, d.tiledbDomain, cFile)
+	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping domain to file %s: %w", path, d.context.LastError())
 	}

--- a/enumeration_experimental.go
+++ b/enumeration_experimental.go
@@ -358,9 +358,9 @@ func ExtendEnumeration[T EnumerationType](tdbCtx *Context, e *Enumeration, value
 			offsets = append(offsets, currOffset)
 			currOffset += uint64(reflect.ValueOf(v).Len())
 		}
-		cData = unsafe.Pointer(&data[0])
+		cData = unsafe.Pointer(unsafe.SliceData(data))
 		cDataLen = C.uint64_t(dataSize)
-		cOffsets = unsafe.Pointer(&offsets[0])
+		cOffsets = unsafe.Pointer(unsafe.SliceData(offsets))
 		cOffsetsLen = C.uint64_t(uintptr(len(values)) * unsafe.Sizeof(uint64(0)))
 	} else {
 		var zz T

--- a/enumeration_experimental.go
+++ b/enumeration_experimental.go
@@ -63,12 +63,12 @@ func enumerationTypeToTileDB[T EnumerationType]() Datatype {
 
 // NewOrderedEnumeration creates an ordered enumeration with name and values.
 func NewOrderedEnumeration[T EnumerationType](tdbCtx *Context, name string, values []T) (*Enumeration, error) {
-	return newEnumeration[T](tdbCtx, name, true, values)
+	return newEnumeration(tdbCtx, name, true, values)
 }
 
 // NewOrderedEnumeration creates an unordered enumeration with name and values.
 func NewUnorderedEnumeration[T EnumerationType](tdbCtx *Context, name string, values []T) (*Enumeration, error) {
-	return newEnumeration[T](tdbCtx, name, false, values)
+	return newEnumeration(tdbCtx, name, false, values)
 }
 
 // newEnumeration creates an enumeration with name and ordered or not values.
@@ -125,6 +125,7 @@ func newEnumeration[T EnumerationType](tdbCtx *Context, name string, ordered boo
 	var tiledbEnum *C.tiledb_enumeration_t
 	ret := C.tiledb_enumeration_alloc(tdbCtx.tiledbContext, cName, C.tiledb_datatype_t(tiledbType), cCellNum, cOrdered,
 		cData, cDataLen, cOffsets, cOffsetsLen, &tiledbEnum)
+	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating enumeration: %w", tdbCtx.LastError())
 	}
@@ -153,6 +154,7 @@ func (e *Enumeration) Name() (string, error) {
 	var str *C.tiledb_string_t
 
 	ret := C.tiledb_enumeration_get_name(e.context.tiledbContext, e.tiledbEnum, &str)
+	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting name: %w", e.context.LastError())
 	}
@@ -173,6 +175,7 @@ func (e *Enumeration) Type() (Datatype, error) {
 	var attrType C.tiledb_datatype_t
 
 	ret := C.tiledb_enumeration_get_type(e.context.tiledbContext, e.tiledbEnum, &attrType)
+	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb enumeration type: %w", e.context.LastError())
 	}
@@ -185,6 +188,7 @@ func (e *Enumeration) CellValNum() (uint32, error) {
 	var cellValNum C.uint32_t
 
 	ret := C.tiledb_enumeration_get_cell_val_num(e.context.tiledbContext, e.tiledbEnum, &cellValNum)
+	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting enumeration cell val num: %w", e.context.LastError())
 	}
@@ -198,6 +202,7 @@ func (e *Enumeration) IsOrdered() (bool, error) {
 	var ordered C.int
 
 	ret := C.tiledb_enumeration_get_ordered(e.context.tiledbContext, e.tiledbEnum, &ordered)
+	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error getting ordered: %w", e.context.LastError())
 	}
@@ -208,6 +213,7 @@ func (e *Enumeration) IsOrdered() (bool, error) {
 // DumpSTDOUT writes a human-readable description of the enumeration to os.Stdout.
 func (e *Enumeration) DumpSTDOUT() error {
 	ret := C.tiledb_enumeration_dump(e.context.tiledbContext, e.tiledbEnum, C.stdout)
+	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping enumeration to stdout: %w", e.context.LastError())
 	}
@@ -231,6 +237,7 @@ func (e *Enumeration) Dump(path string) error {
 	defer C.fclose(cFile)
 
 	ret := C.tiledb_enumeration_dump(e.context.tiledbContext, e.tiledbEnum, cFile)
+	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping enumeration to file %s: %w", path, e.context.LastError())
 	}
@@ -307,6 +314,7 @@ func (e *Enumeration) Values() (interface{}, error) {
 		strs = append(strs, string(chars[start:start+strLen]))
 	}
 
+	runtime.KeepAlive(e)
 	return strs, nil
 }
 
@@ -344,27 +352,28 @@ func ExtendEnumeration[T EnumerationType](tdbCtx *Context, e *Enumeration, value
 		}
 		data := make([]byte, 0, dataSize)
 		offsets := make([]uint64, 0, len(values))
-		defer runtime.KeepAlive(data)
-		defer runtime.KeepAlive(offsets)
 		var currOffset uint64
 		for _, v := range values {
 			data = append(data, reflect.ValueOf(v).String()...)
 			offsets = append(offsets, currOffset)
 			currOffset += uint64(reflect.ValueOf(v).Len())
 		}
-		cData = reflect.ValueOf(data).UnsafePointer()
+		cData = unsafe.Pointer(&data[0])
 		cDataLen = C.uint64_t(dataSize)
-		cOffsets = reflect.ValueOf(offsets).UnsafePointer()
-		cOffsetsLen = C.uint64_t(len(values) * int(reflect.TypeOf(uint64(0)).Size()))
+		cOffsets = unsafe.Pointer(&offsets[0])
+		cOffsetsLen = C.uint64_t(uintptr(len(values)) * unsafe.Sizeof(uint64(0)))
 	} else {
 		var zz T
 		cData = reflect.ValueOf(values).UnsafePointer()
-		cDataLen = C.uint64_t(len(values) * int(reflect.TypeOf(zz).Size()))
+		cDataLen = C.uint64_t(uintptr(len(values)) * unsafe.Sizeof(zz))
 	}
 
 	var extEnum *C.tiledb_enumeration_t
 
 	ret := C.tiledb_enumeration_extend(tdbCtx.tiledbContext, e.tiledbEnum, cData, cDataLen, cOffsets, cOffsetsLen, &extEnum)
+	runtime.KeepAlive(tdbCtx)
+	runtime.KeepAlive(e)
+	// cData and cOffsets are being kept alive by passing them to cgo call.
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error extending enumeration: %w", tdbCtx.LastError())
 	}
@@ -380,6 +389,8 @@ func ExtendEnumeration[T EnumerationType](tdbCtx *Context, e *Enumeration, value
 // AddEnumeration adds the Enumeration to the schema. It must be added before we add it to an attribute.
 func (a *ArraySchema) AddEnumeration(e *Enumeration) error {
 	ret := C.tiledb_array_schema_add_enumeration(a.context.tiledbContext, a.tiledbArraySchema, e.tiledbEnum)
+	runtime.KeepAlive(a)
+	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error adding enumeration: %w", a.context.LastError())
 	}
@@ -393,6 +404,7 @@ func (a *ArraySchema) EnumerationFromName(name string) (*Enumeration, error) {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 	ret := C.tiledb_array_schema_get_enumeration_from_name(a.context.tiledbContext, a.tiledbArraySchema, cName, &enum.tiledbEnum)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting enumeration from name: %w", a.context.LastError())
 	}
@@ -406,6 +418,7 @@ func (a *ArraySchema) EnumerationFromAttributeName(name string) (*Enumeration, e
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 	ret := C.tiledb_array_schema_get_enumeration_from_attribute_name(a.context.tiledbContext, a.tiledbArraySchema, cName, &enum.tiledbEnum)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting enumeration from attribute name: %w", a.context.LastError())
 	}
@@ -417,6 +430,7 @@ func (a *ArraySchema) EnumerationFromAttributeName(name string) (*Enumeration, e
 // The method is called ondemand if the client tries to fetch enumeration values for a tiledb:// array.
 func (a *Array) LoadAllEnumerations() error {
 	ret := C.tiledb_array_load_all_enumerations(a.context.tiledbContext, a.tiledbArray)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error loading all enumerations: %w", a.context.LastError())
 	}
@@ -427,6 +441,7 @@ func (a *Array) LoadAllEnumerations() error {
 // LoadEnumerationsAllSchemas is for use with TileDB cloud arrays. It fetches the enumeration values from the server for all array schemas, past and present.
 func (a *Array) LoadEnumerationsAllSchemas() error {
 	ret := C.tiledb_array_load_enumerations_all_schemas(a.context.tiledbContext, a.tiledbArray)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error loading enumerations for all schemas: %w", a.context.LastError())
 	}
@@ -441,6 +456,7 @@ func (a *Array) GetEnumeration(name string) (*Enumeration, error) {
 
 	var tiledbEnum *C.tiledb_enumeration_t
 	ret := C.tiledb_array_get_enumeration(a.context.tiledbContext, a.tiledbArray, cName, &tiledbEnum)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting enumeration %s: %w", name, a.context.LastError())
 	}
@@ -455,6 +471,7 @@ func (a *Attribute) SetEnumerationName(name string) error {
 	defer C.free(unsafe.Pointer(cName))
 
 	ret := C.tiledb_attribute_set_enumeration_name(a.context.tiledbContext, a.tiledbAttribute, cName)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting enumeration name: %w", a.context.LastError())
 	}
@@ -467,6 +484,7 @@ func (a *Attribute) GetEnumerationName() (string, error) {
 	var str *C.tiledb_string_t
 
 	ret := C.tiledb_attribute_get_enumeration_name(a.context.tiledbContext, a.tiledbAttribute, &str)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting enumeration name: %w", a.context.LastError())
 	}
@@ -490,6 +508,7 @@ func (qc *QueryCondition) UseEnumeration(useEnum bool) error {
 	}
 
 	ret := C.tiledb_query_condition_set_use_enumeration(qc.context.tiledbContext, qc.cond, cUseEnum)
+	runtime.KeepAlive(qc)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error toggling enumerations use: %w", qc.context.LastError())
 	}
@@ -505,6 +524,8 @@ func (ase *ArraySchemaEvolution) AddEnumeration(e *Enumeration) error {
 	}
 
 	ret := C.tiledb_array_schema_evolution_add_enumeration(ase.context.tiledbContext, ase.tiledbArraySchemaEvolution, e.tiledbEnum)
+	runtime.KeepAlive(ase)
+	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error adding enumeration %s to tiledb arraySchemaEvolution: %w", name, ase.context.LastError())
 	}
@@ -518,6 +539,7 @@ func (ase *ArraySchemaEvolution) DropEnumeration(name string) error {
 	defer C.free(unsafe.Pointer(cName))
 
 	ret := C.tiledb_array_schema_evolution_drop_enumeration(ase.context.tiledbContext, ase.tiledbArraySchemaEvolution, cName)
+	runtime.KeepAlive(ase)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dropping enumeration %s from tiledb arraySchemaEvolution: %w", name, ase.context.LastError())
 	}
@@ -528,6 +550,8 @@ func (ase *ArraySchemaEvolution) DropEnumeration(name string) error {
 // ApplyExtendedEnumeration applies to the schema evolution the result of ExtendEnumeration.
 func (ase *ArraySchemaEvolution) ApplyExtendedEnumeration(e *Enumeration) error {
 	ret := C.tiledb_array_schema_evolution_extend_enumeration(ase.context.tiledbContext, ase.tiledbArraySchemaEvolution, e.tiledbEnum)
+	runtime.KeepAlive(ase)
+	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error applying extended enumeration to arraySchemaEvolution: %w", ase.context.LastError())
 	}

--- a/filestore_experimental.go
+++ b/filestore_experimental.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime"
 	"unsafe"
 )
 
@@ -20,6 +21,7 @@ func FileSize(tdbCtx *Context, arrayURI string) (int64, error) {
 
 	var size C.size_t
 	ret := C.tiledb_filestore_size(tdbCtx.tiledbContext, cArrayURI, &size)
+	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting file size: %w", tdbCtx.LastError())
 	}
@@ -36,6 +38,7 @@ func ExportFile(tdbCtx *Context, filePath, arrayURI string) error {
 	defer C.free(unsafe.Pointer(cFileURI))
 
 	ret := C.tiledb_filestore_uri_export(tdbCtx.tiledbContext, cFileURI, cArrayURI)
+	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error exporting file: %w", tdbCtx.LastError())
 	}
@@ -51,6 +54,7 @@ func ImportFile(tdbCtx *Context, arrayURI, filePath string, mimeType FileStoreMi
 	defer C.free(unsafe.Pointer(cFileURI))
 
 	ret := C.tiledb_filestore_uri_import(tdbCtx.tiledbContext, cArrayURI, cFileURI, C.tiledb_mime_type_t(mimeType))
+	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error importing file: %w", tdbCtx.LastError())
 	}
@@ -162,6 +166,7 @@ func NewArraySchemaForFile(tdbCtx *Context, filePath string) (*ArraySchema, erro
 
 	arraySchema := ArraySchema{context: tdbCtx}
 	ret := C.tiledb_filestore_schema_create(tdbCtx.tiledbContext, fileURI, &arraySchema.tiledbArraySchema)
+	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating schema: %w", tdbCtx.LastError())
 	}
@@ -179,6 +184,7 @@ func bufferExport(tdbCtx *Context, uri *C.char, off int64, p []byte) error {
 	}
 
 	ret := C.tiledb_filestore_buffer_export(tdbCtx.tiledbContext, uri, C.size_t(off), slicePtr(p), C.size_t(len(p)))
+	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error exporting buffer data: %w", tdbCtx.LastError())
 	}
@@ -194,6 +200,7 @@ func bufferImport(tdbCtx *Context, uri *C.char, data []byte, mimeType FileStoreM
 	}
 
 	ret := C.tiledb_filestore_buffer_import(tdbCtx.tiledbContext, uri, slicePtr(data), C.size_t(len(data)), C.tiledb_mime_type_t(mimeType))
+	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error importing buffer data: %w", tdbCtx.LastError())
 	}

--- a/filter.go
+++ b/filter.go
@@ -9,6 +9,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"unsafe"
 )
 
@@ -23,6 +24,7 @@ func NewFilter(context *Context, filterType FilterType) (*Filter, error) {
 	filter := Filter{context: context}
 
 	ret := C.tiledb_filter_alloc(filter.context.tiledbContext, C.tiledb_filter_type_t(filterType), &filter.tiledbFilter)
+	runtime.KeepAlive(context)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb filter: %w", filter.context.LastError())
 	}
@@ -51,6 +53,7 @@ func (f *Filter) Context() *Context {
 func (f *Filter) Type() (FilterType, error) {
 	var filterType C.tiledb_filter_type_t
 	ret := C.tiledb_filter_get_type(f.context.tiledbContext, f.tiledbFilter, &filterType)
+	runtime.KeepAlive(f)
 
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb filter type: %w", f.context.LastError())
@@ -97,6 +100,7 @@ func (f *Filter) SetOption(filterOption FilterOption, valueInterface interface{}
 			return fmt.Errorf("error setting tiledb filter option: %w", f.context.LastError())
 		}
 	}
+	runtime.KeepAlive(f)
 
 	return nil
 }
@@ -136,5 +140,6 @@ func (f *Filter) Option(filterOption FilterOption) (interface{}, error) {
 		}
 		return val, nil
 	}
+	runtime.KeepAlive(f)
 	return nil, nil
 }

--- a/filter_list.go
+++ b/filter_list.go
@@ -8,6 +8,7 @@ import "C"
 
 import (
 	"fmt"
+	"runtime"
 )
 
 // FilterList represents
@@ -21,6 +22,7 @@ func NewFilterList(context *Context) (*FilterList, error) {
 	filterList := FilterList{context: context}
 
 	ret := C.tiledb_filter_list_alloc(filterList.context.tiledbContext, &filterList.tiledbFilterList)
+	runtime.KeepAlive(context)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb FilterList: %w", filterList.context.LastError())
 	}
@@ -49,6 +51,8 @@ func (f *FilterList) Context() *Context {
 // each filter in the order the filters were added.
 func (f *FilterList) AddFilter(filter *Filter) error {
 	ret := C.tiledb_filter_list_add_filter(f.context.tiledbContext, f.tiledbFilterList, filter.tiledbFilter)
+	runtime.KeepAlive(f)
+	runtime.KeepAlive(filter)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error adding filter to tiledb FilterList: %w", f.context.LastError())
 	}
@@ -58,6 +62,7 @@ func (f *FilterList) AddFilter(filter *Filter) error {
 // SetMaxChunkSize sets the maximum tile chunk size for a filter list.
 func (f *FilterList) SetMaxChunkSize(maxChunkSize uint32) error {
 	ret := C.tiledb_filter_list_set_max_chunk_size(f.context.tiledbContext, f.tiledbFilterList, C.uint32_t(maxChunkSize))
+	runtime.KeepAlive(f)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting max chunk size on tiledb FilterList: %w", f.context.LastError())
 	}
@@ -68,6 +73,7 @@ func (f *FilterList) SetMaxChunkSize(maxChunkSize uint32) error {
 func (f *FilterList) MaxChunkSize() (uint32, error) {
 	var cMaxChunkSize C.uint32_t
 	ret := C.tiledb_filter_list_get_max_chunk_size(f.context.tiledbContext, f.tiledbFilterList, &cMaxChunkSize)
+	runtime.KeepAlive(f)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching max chunk size from tiledb FilterList: %w", f.context.LastError())
 	}
@@ -78,6 +84,7 @@ func (f *FilterList) MaxChunkSize() (uint32, error) {
 func (f *FilterList) NFilters() (uint32, error) {
 	var cNFilters C.uint32_t
 	ret := C.tiledb_filter_list_get_nfilters(f.context.tiledbContext, f.tiledbFilterList, &cNFilters)
+	runtime.KeepAlive(f)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting number of filter for tiledb FilterList: %w", f.context.LastError())
 	}
@@ -88,6 +95,7 @@ func (f *FilterList) NFilters() (uint32, error) {
 func (f *FilterList) FilterFromIndex(index uint32) (*Filter, error) {
 	filter := Filter{context: f.context}
 	ret := C.tiledb_filter_list_get_filter_from_index(f.context.tiledbContext, f.tiledbFilterList, C.uint32_t(index), &filter.tiledbFilter)
+	runtime.KeepAlive(f)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error fetching filter for index %d from tiledb FilterList: %w", index, f.context.LastError())
 	}

--- a/memory.go
+++ b/memory.go
@@ -38,24 +38,6 @@ func freeOnGC(obj Freeable) {
 // anything in a closure.
 func freeFreeable(obj Freeable) { obj.Free() }
 
-//
-// Memory buffers and related stuff
-//
-
-// byteBuffer provides methods useful for treating byte slices as memory.
-type byteBuffer []byte
-
-func (bb byteBuffer) start() unsafe.Pointer {
-	return slicePtr(bb)
-}
-
-func (bb byteBuffer) lenBytes() uintptr { return uintptr(len(bb)) }
-
-func (bb byteBuffer) subSlice(sliceStart unsafe.Pointer, sliceBytes uintptr) []byte {
-	startIdx := uintptr(sliceStart) - uintptr(bb.start())
-	return bb[startIdx:sliceBytes]
-}
-
 // unsafeSlice creates a slice pointing at the given memory.
 func unsafeSlice[T any](ptr unsafe.Pointer, length uint) []T {
 	if ptr == nil {

--- a/object.go
+++ b/object.go
@@ -9,6 +9,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"unsafe"
 
 	pointer "github.com/mattn/go-pointer"
@@ -25,6 +26,7 @@ func ObjectType(tdbCtx *Context, path string) (ObjectTypeEnum, error) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
 	ret := C.tiledb_object_type(tdbCtx.tiledbContext, cpath, &objectTypeEnum)
+	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return TILEDB_INVALID, fmt.Errorf("cannot get object type from path %s: %w",
 			path, tdbCtx.LastError())
@@ -75,9 +77,11 @@ func ObjectWalk(tdbCtx *Context, path string, walkOrder WalkOrder) (*ObjectList,
 		objectList: []groupDefinition{},
 	}
 	data := pointer.Save(&objectList)
+	defer pointer.Unref(data)
 
 	ret := C._tiledb_object_walk(tdbCtx.tiledbContext, cpath,
 		C.tiledb_walk_order_t(walkOrder), unsafe.Pointer(data))
+	runtime.KeepAlive(tdbCtx)
 
 	fmt.Println(objectList)
 
@@ -102,9 +106,11 @@ func ObjectLs(tdbCtx *Context, path string) (*ObjectList, error) {
 		objectList: []groupDefinition{},
 	}
 	data := pointer.Save(&objectList)
+	defer pointer.Unref(data)
 
 	ret := C._tiledb_object_ls(tdbCtx.tiledbContext, cpath,
 		unsafe.Pointer(data))
+	runtime.KeepAlive(tdbCtx)
 
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("cannot walk in path %s: %w", path,
@@ -125,6 +131,7 @@ func ObjectMove(tdbCtx *Context, path string, newPath string) error {
 	cnewPath := C.CString(newPath)
 	defer C.free(unsafe.Pointer(cnewPath))
 	ret := C.tiledb_object_move(tdbCtx.tiledbContext, cpath, cnewPath)
+	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("cannot move object from %s to %s: %w", path,
 			newPath, tdbCtx.LastError())
@@ -142,6 +149,7 @@ func ObjectRemove(tdbCtx *Context, path string) error {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
 	ret := C.tiledb_object_remove(tdbCtx.tiledbContext, cpath)
+	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("cannot delete object %s: %w", path, tdbCtx.LastError())
 	}

--- a/query.go
+++ b/query.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"runtime"
 	"sync"
 	"unsafe"
 
@@ -67,6 +68,7 @@ func NewQuery(tdbCtx *Context, array *Array) (*Query, error) {
 
 	query := Query{context: tdbCtx, array: array}
 	ret := C.tiledb_query_alloc(query.context.tiledbContext, array.tiledbArray, C.tiledb_query_type_t(queryType), &query.tiledbQuery)
+	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb query: %w", query.context.LastError())
 	}
@@ -284,6 +286,7 @@ func (q *Query) SetLayout(layout Layout) error {
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting query layout: %w", q.context.LastError())
 	}
+	runtime.KeepAlive(q)
 	return nil
 }
 
@@ -292,6 +295,7 @@ func (q *Query) SetQueryCondition(cond *QueryCondition) error {
 	if ret := C.tiledb_query_set_condition(q.context.tiledbContext, q.tiledbQuery, cond.cond); ret != C.TILEDB_OK {
 		return fmt.Errorf("error getting config from query: %w", q.context.LastError())
 	}
+	runtime.KeepAlive(q)
 	return nil
 }
 
@@ -300,6 +304,7 @@ func (q *Query) SetQueryCondition(cond *QueryCondition) error {
 // for any other query type.
 func (q *Query) Finalize() error {
 	ret := C.tiledb_query_finalize(q.context.tiledbContext, q.tiledbQuery)
+	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error finalizing query: %w", q.context.LastError())
 	}
@@ -329,6 +334,7 @@ and resubmit the query.
 */
 func (q *Query) Submit() error {
 	ret := C.tiledb_query_submit(q.context.tiledbContext, q.tiledbQuery)
+	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error submitting query: %w", q.context.LastError())
 	}
@@ -340,6 +346,7 @@ func (q *Query) Submit() error {
 func (q *Query) Status() (QueryStatus, error) {
 	var status C.tiledb_query_status_t
 	ret := C.tiledb_query_get_status(q.context.tiledbContext, q.tiledbQuery, &status)
+	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return -1, fmt.Errorf("error getting query status: %w", q.context.LastError())
 	}
@@ -350,6 +357,7 @@ func (q *Query) Status() (QueryStatus, error) {
 func (q *Query) Type() (QueryType, error) {
 	var queryType C.tiledb_query_type_t
 	ret := C.tiledb_query_get_type(q.context.tiledbContext, q.tiledbQuery, &queryType)
+	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return -1, fmt.Errorf("error getting query type: %w", q.context.LastError())
 	}
@@ -361,6 +369,7 @@ func (q *Query) Type() (QueryType, error) {
 func (q *Query) HasResults() (bool, error) {
 	var hasResults C.int32_t
 	ret := C.tiledb_query_has_results(q.context.tiledbContext, q.tiledbQuery, &hasResults)
+	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error checking if query has results: %w", q.context.LastError())
 	}
@@ -379,6 +388,7 @@ func (q *Query) EstResultSize(attributeName string) (*uint64, error) {
 		q.tiledbQuery,
 		cAttributeName,
 		(*C.uint64_t)(unsafe.Pointer(&size)))
+	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error estimating query result size: %w", q.context.LastError())
 	}
@@ -399,6 +409,7 @@ func (q *Query) EstResultSizeVar(attributeName string) (*uint64, *uint64, error)
 		cAttributeName,
 		(*C.uint64_t)(unsafe.Pointer(&sizeOff)),
 		(*C.uint64_t)(unsafe.Pointer(&sizeVal)))
+	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return nil, nil, fmt.Errorf("error estimating query result var size: %w", q.context.LastError())
 	}
@@ -419,6 +430,7 @@ func (q *Query) EstResultSizeNullable(attributeName string) (*uint64, *uint64, e
 		cAttributeName,
 		(*C.uint64_t)(unsafe.Pointer(&size)),
 		(*C.uint64_t)(unsafe.Pointer(&sizeValidity)))
+	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return nil, nil, fmt.Errorf("error estimating query result size: %w", q.context.LastError())
 	}
@@ -440,6 +452,7 @@ func (q *Query) EstResultSizeVarNullable(attributeName string) (*uint64, *uint64
 		(*C.uint64_t)(unsafe.Pointer(&sizeOff)),
 		(*C.uint64_t)(unsafe.Pointer(&sizeVal)),
 		(*C.uint64_t)(unsafe.Pointer(&sizeValidity)))
+	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return nil, nil, nil, fmt.Errorf("error estimating query result var size: %w", q.context.LastError())
 	}
@@ -623,6 +636,7 @@ func (q *Query) GetFragmentNum() (*uint32, error) {
 		q.context.tiledbContext,
 		q.tiledbQuery,
 		(*C.uint32_t)(unsafe.Pointer(&num)))
+	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting num of fragments: %w", q.context.LastError())
 	}
@@ -632,7 +646,7 @@ func (q *Query) GetFragmentNum() (*uint32, error) {
 
 // GetFragmentURI returns the uri for a fragment.
 func (q *Query) GetFragmentURI(num uint64) (*string, error) {
-	var cURI *C.char
+	var cURI *C.char // q must be kept alive while cURI is being accessed.
 
 	ret := C.tiledb_query_get_fragment_uri(
 		q.context.tiledbContext,
@@ -644,6 +658,7 @@ func (q *Query) GetFragmentURI(num uint64) (*string, error) {
 	}
 
 	uri := C.GoString(cURI)
+	runtime.KeepAlive(q)
 
 	return &uri, nil
 
@@ -659,6 +674,7 @@ func (q *Query) GetFragmentTimestampRange(num uint64) (*uint64, *uint64, error) 
 		(C.uint64_t)(num),
 		(*C.uint64_t)(unsafe.Pointer(&t1)),
 		(*C.uint64_t)(unsafe.Pointer(&t2)))
+	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return nil, nil, fmt.Errorf("error getting fragment timestamp: %w", q.context.LastError())
 	}
@@ -670,6 +686,7 @@ func (q *Query) GetFragmentTimestampRange(num uint64) (*uint64, *uint64, error) 
 func (q *Query) Array() (*Array, error) {
 	array := Array{context: q.context}
 	ret := C.tiledb_query_get_array(q.context.tiledbContext, q.tiledbQuery, &array.tiledbArray)
+	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting array from query: %w", q.context.LastError())
 	}
@@ -682,6 +699,8 @@ func (q *Query) SetConfig(config *Config) error {
 	q.config = config
 
 	ret := C.tiledb_query_set_config(q.context.tiledbContext, q.tiledbQuery, q.config.tiledbConfig)
+	runtime.KeepAlive(q)
+	runtime.KeepAlive(config)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting config on query: %w", q.context.LastError())
 	}
@@ -693,6 +712,7 @@ func (q *Query) SetConfig(config *Config) error {
 func (q *Query) Config() (*Config, error) {
 	config := Config{}
 	ret := C.tiledb_query_get_config(q.context.tiledbContext, q.tiledbQuery, &config.tiledbConfig)
+	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting config from query: %w", q.context.LastError())
 	}
@@ -711,6 +731,7 @@ func (q *Query) Stats() ([]byte, error) {
 	if ret := C.tiledb_query_get_stats(q.context.tiledbContext, q.tiledbQuery, &stats); ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting stats from query: %w", q.context.LastError())
 	}
+	runtime.KeepAlive(q)
 
 	s := C.GoString(stats)
 	if ret := C.tiledb_stats_free_str(&stats); ret != C.TILEDB_OK {
@@ -751,6 +772,7 @@ func (q *Query) SetDataBufferUnsafe(attribute string, buffer unsafe.Pointer, buf
 		cAttribute,
 		buffer,
 		(*C.uint64_t)(unsafe.Pointer(&bufferSize)))
+	runtime.KeepAlive(q)
 
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error setting query data buffer: %w", q.context.LastError())
@@ -985,6 +1007,8 @@ func (q *Query) SetDataBuffer(attributeOrDimension string, buffer interface{}) (
 		cAttributeOrDimension,
 		cbuffer,
 		(*C.uint64_t)(unsafe.Pointer(&bufferSize)))
+	runtime.KeepAlive(q)
+	// cbuffer is being kept alive by passing it to cgo call.
 
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error setting query data buffer: %w", q.context.LastError())
@@ -1090,6 +1114,8 @@ func (q *Query) getDataBufferAndSize(attributeOrDimension string) (interface{}, 
 	var buffer interface{}
 
 	ret = C.tiledb_query_get_data_buffer(q.context.tiledbContext, q.tiledbQuery, cAttributeOrDimension, &cbuffer, &cbufferSize)
+	runtime.KeepAlive(q)
+	// cbuffer and cbufferSize are in Go-owned memory and don't need a KeepAlive.
 	if ret != C.TILEDB_OK {
 		return nil, 0, fmt.Errorf("error getting tiledb query data buffer for %s: %w", attributeOrDimension, q.context.LastError())
 	}
@@ -1201,6 +1227,7 @@ func (q *Query) SetValidityBufferUnsafe(attribute string, buffer unsafe.Pointer,
 		cAttribute,
 		(*C.uint8_t)(buffer),
 		(*C.uint64_t)(unsafe.Pointer(&bufferSize)))
+	runtime.KeepAlive(q)
 
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error setting query validity buffer: %w", q.context.LastError())
@@ -1219,6 +1246,8 @@ func (q *Query) SetValidityBuffer(attributeOrDimension string, buffer []uint8) (
 	cAttributeOrDimension := C.CString(attributeOrDimension)
 	defer C.free(unsafe.Pointer(cAttributeOrDimension))
 
+	q.buffers = append(q.buffers, buffer)
+
 	bufferSize := uint64(len(buffer)) * bytesizes.Uint8
 	if bufferSize == uint64(0) {
 		return nil, errors.New("validity slice has no length, validity slices are required to be initialized before reading or writing")
@@ -1230,6 +1259,7 @@ func (q *Query) SetValidityBuffer(attributeOrDimension string, buffer []uint8) (
 		cAttributeOrDimension,
 		(*C.uint8_t)(unsafe.Pointer(&(buffer)[0])),
 		(*C.uint64_t)(unsafe.Pointer(&bufferSize)))
+	runtime.KeepAlive(q)
 
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error setting query validity buffer: %w", q.context.LastError())
@@ -1267,6 +1297,8 @@ func (q *Query) getValidityBufferAndSize(attributeOrDimension string) ([]uint8, 
 	var cvalidityByteMap *C.uint8_t
 
 	ret := C.tiledb_query_get_validity_buffer(q.context.tiledbContext, q.tiledbQuery, cattributeNameOrDimension, &cvalidityByteMap, &cvalidityByteMapSize)
+	runtime.KeepAlive(q)
+	// cvalidityByteMapSize and cvalidityByteMap are in Go-owned memory and do not need a KeepAlive.
 	if ret != C.TILEDB_OK {
 		return nil, 0, fmt.Errorf("error getting tiledb query validity buffer for %s: %w", attributeOrDimension, q.context.LastError())
 	}
@@ -1303,6 +1335,7 @@ func (q *Query) SetOffsetsBufferUnsafe(attribute string, offset unsafe.Pointer, 
 		cAttribute,
 		(*C.uint64_t)(offset),
 		(*C.uint64_t)(unsafe.Pointer(&offsetSize)))
+	runtime.KeepAlive(q)
 
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error setting query offsets buffer: %w", q.context.LastError())
@@ -1321,6 +1354,8 @@ func (q *Query) SetOffsetsBuffer(attributeOrDimension string, offset []uint64) (
 	cAttributeOrDimension := C.CString(attributeOrDimension)
 	defer C.free(unsafe.Pointer(cAttributeOrDimension))
 
+	q.buffers = append(q.buffers, offset)
+
 	offsetSize := uint64(len(offset)) * bytesizes.Uint64
 	if offsetSize == uint64(0) {
 		return nil, errors.New("offset slice has no length, offset slices are required to be initialized before reading or writing")
@@ -1332,6 +1367,7 @@ func (q *Query) SetOffsetsBuffer(attributeOrDimension string, offset []uint64) (
 		cAttributeOrDimension,
 		(*C.uint64_t)(unsafe.Pointer(&(offset)[0])),
 		(*C.uint64_t)(unsafe.Pointer(&offsetSize)))
+	runtime.KeepAlive(q)
 
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error setting query offsets buffer: %w", q.context.LastError())
@@ -1369,6 +1405,8 @@ func (q *Query) getOffsetsBufferAndSize(attributeOrDimension string) ([]uint64, 
 	var coffsets *C.uint64_t
 
 	ret := C.tiledb_query_get_offsets_buffer(q.context.tiledbContext, q.tiledbQuery, cattributeNameOrDimension, &coffsets, &coffsetsSize)
+	runtime.KeepAlive(q)
+	// coffsetsSize and coffsets point to Go-owned memory and do not need a KeepAlive
 	if ret != C.TILEDB_OK {
 		return nil, 0, fmt.Errorf("error getting tiledb query offset buffer for %s: %w", attributeOrDimension, q.context.LastError())
 	}
@@ -1393,6 +1431,8 @@ func (q *Query) getOffsetsBufferAndSize(attributeOrDimension string) ([]uint64, 
 // SetSubarray sets the subarray for the query.
 func (q *Query) SetSubarray(sa *Subarray) error {
 	ret := C.tiledb_query_set_subarray_t(q.context.tiledbContext, q.tiledbQuery, sa.subarray)
+	runtime.KeepAlive(q)
+	runtime.KeepAlive(sa)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting tiledb query subarray: %w", q.context.LastError())
 	}
@@ -1404,6 +1444,7 @@ func (q *Query) GetSubarray() (*Subarray, error) {
 	var sa *C.tiledb_subarray_t
 
 	ret := C.tiledb_query_get_subarray_t(q.context.tiledbContext, q.tiledbQuery, &sa)
+	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb query subarray: %w", q.context.LastError())
 	}

--- a/query.go
+++ b/query.go
@@ -763,6 +763,9 @@ func (q *Query) SetDataBufferUnsafe(attribute string, buffer unsafe.Pointer, buf
 	cAttribute := C.CString(attribute)
 	defer C.free(unsafe.Pointer(cAttribute))
 
+	q.pinner.Pin(buffer)
+	q.pinner.Pin(&bufferSize)
+
 	ret := C.tiledb_query_set_data_buffer(
 		q.context.tiledbContext,
 		q.tiledbQuery,
@@ -1155,6 +1158,9 @@ func (q *Query) SetValidityBufferUnsafe(attribute string, buffer unsafe.Pointer,
 	cAttribute := C.CString(attribute)
 	defer C.free(unsafe.Pointer(cAttribute))
 
+	q.pinner.Pin(buffer)
+	q.pinner.Pin(&bufferSize)
+
 	ret := C.tiledb_query_set_validity_buffer(
 		q.context.tiledbContext,
 		q.tiledbQuery,
@@ -1264,6 +1270,9 @@ func (q *Query) SetOffsetsBufferUnsafe(attribute string, offset unsafe.Pointer, 
 
 	cAttribute := C.CString(attribute)
 	defer C.free(unsafe.Pointer(cAttribute))
+
+	q.pinner.Pin(offset)
+	q.pinner.Pin(&offsetSize)
 
 	ret := C.tiledb_query_set_offsets_buffer(
 		q.context.tiledbContext,

--- a/query_condition.go
+++ b/query_condition.go
@@ -8,6 +8,7 @@ import "C"
 
 import (
 	"fmt"
+	"runtime"
 	"unsafe"
 )
 
@@ -23,6 +24,7 @@ func NewQueryCondition(tdbCtx *Context, attributeName string, op QueryConditionO
 	if ret := C.tiledb_query_condition_alloc(qc.context.tiledbContext, &qc.cond); ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error allocating tiledb query condition: %w", qc.context.LastError())
 	}
+	runtime.KeepAlive(tdbCtx)
 	freeOnGC(&qc)
 
 	if err := qc.init(attributeName, value, op); err != nil {
@@ -39,6 +41,9 @@ func NewQueryConditionCombination(tdbCtx *Context, left *QueryCondition, op Quer
 	if ret := C.tiledb_query_condition_combine(qc.context.tiledbContext, left.cond, right.cond, C.tiledb_query_condition_combination_op_t(op), &qc.cond); ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error allocating tiledb query condition: %w", qc.context.LastError())
 	}
+	runtime.KeepAlive(tdbCtx)
+	runtime.KeepAlive(left)
+	runtime.KeepAlive(right)
 	freeOnGC(&qc)
 
 	return &qc, nil
@@ -52,6 +57,8 @@ func NewQueryConditionNegated(tdbCtx *Context, qc *QueryCondition) (*QueryCondit
 		return nil, fmt.Errorf("error allocating tiledb query condition: %w", qc.context.LastError())
 	}
 	freeOnGC(&nqc)
+	runtime.KeepAlive(tdbCtx)
+	runtime.KeepAlive(qc)
 
 	return &nqc, nil
 }
@@ -155,6 +162,7 @@ func qcInitInternal(qc *QueryCondition, attributeName string, valuePtr unsafe.Po
 		C.uint64_t(valueSize),
 		C.tiledb_query_condition_op_t(op),
 	)
+	runtime.KeepAlive(qc)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("could not init %q query condition: %w", attributeName, qc.context.LastError())
 	}

--- a/query_experimental.go
+++ b/query_experimental.go
@@ -9,6 +9,7 @@ import "C"
 
 import (
 	"fmt"
+	"runtime"
 )
 
 // QueryStatusDetails contains detailed information about the query status
@@ -21,6 +22,7 @@ func (q *Query) RelevantFragmentNum() (uint64, error) {
 	if ret := C.tiledb_query_get_relevant_fragment_num(q.context.tiledbContext, q.tiledbQuery, &num); ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting relevant fragment num from query: %w", q.context.LastError())
 	}
+	runtime.KeepAlive(q)
 
 	return uint64(num), nil
 }
@@ -32,6 +34,7 @@ func (q *Query) StatusDetails() (QueryStatusDetails, error) {
 	if ret := C.tiledb_query_get_status_details(q.context.tiledbContext, q.tiledbQuery, &cDetails); ret != C.TILEDB_OK {
 		return details, fmt.Errorf("error getting query status details: %w", q.context.LastError())
 	}
+	runtime.KeepAlive(q)
 	details.IncompleteReason = QueryStatusDetailsReason(cDetails.incomplete_reason)
 	return details, nil
 }
@@ -65,6 +68,7 @@ func (q *Query) GetPlan() (string, error) {
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting query plan: %w", q.context.LastError())
 	}
+	runtime.KeepAlive(q)
 	defer C.tiledb_string_free(&plan)
 
 	var sPlan *C.char

--- a/serialize.go
+++ b/serialize.go
@@ -28,6 +28,7 @@ func SerializeArraySchemaToBuffer(schema *ArraySchema, serializationType Seriali
 	freeOnGC(&buffer)
 
 	ret := C.tiledb_serialize_array_schema(schema.context.tiledbContext, schema.tiledbArraySchema, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
+	runtime.KeepAlive(schema)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array schema: %w", schema.context.LastError())
 	}
@@ -62,6 +63,7 @@ func DeserializeArraySchema(buffer *Buffer, serializationType SerializationType,
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error deserializing array schema: %w", schema.context.LastError())
 	}
+	runtime.KeepAlive(schema)
 
 	// This needs to happen *after* the tiledb_deserialize_array_schema call
 	// because that may leave the arraySchema with a non-nil pointer
@@ -88,6 +90,7 @@ func SerializeArraySchemaEvolutionToBuffer(arraySchemaEvolution *ArraySchemaEvol
 		arraySchemaEvolution.tiledbArraySchemaEvolution,
 		C.tiledb_serialization_type_t(serializationType),
 		cClientSide, &buffer.tiledbBuffer)
+	runtime.KeepAlive(arraySchemaEvolution)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array schem evolution: %w",
 			arraySchemaEvolution.context.LastError())
@@ -123,6 +126,7 @@ func DeserializeArraySchemaEvolution(buffer *Buffer, serializationType Serializa
 		arraySchemaEvolution.context.tiledbContext, buffer.tiledbBuffer,
 		C.tiledb_serialization_type_t(serializationType),
 		cClientSide, &arraySchemaEvolution.tiledbArraySchemaEvolution)
+	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error deserializing array schema evolution: %w", arraySchemaEvolution.context.LastError())
 	}
@@ -171,6 +175,7 @@ func SerializeArrayNonEmptyDomainToBuffer(a *Array, serializationType Serializat
 		return nil, fmt.Errorf("error serializing array nonempty domain: %w", a.context.LastError())
 	}
 
+	runtime.KeepAlive(a)
 	return &buffer, nil
 }
 
@@ -213,6 +218,8 @@ func DeserializeArrayNonEmptyDomain(a *Array, buffer *Buffer, serializationType 
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
 	var isEmpty C.int32_t
 	ret := C.tiledb_deserialize_array_nonempty_domain(a.context.tiledbContext, a.tiledbArray, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, tmpDomainPtr, &isEmpty)
+	runtime.KeepAlive(a)
+	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
 		return nil, false, fmt.Errorf("error serializing array nonempty domain: %w", a.context.LastError())
 	}
@@ -300,6 +307,8 @@ func DeserializeArrayNonEmptyDomainAllDimensions(a *Array, buffer *Buffer, seria
 
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
 	ret := C.tiledb_deserialize_array_non_empty_domain_all_dimensions(a.context.tiledbContext, a.tiledbArray, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide)
+	runtime.KeepAlive(a)
+	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deserializing array nonempty domain: %w", a.context.LastError())
 	}
@@ -320,6 +329,7 @@ func SerializeQuery(query *Query, serializationType SerializationType, clientSid
 	}
 
 	ret := C.tiledb_serialize_query(query.context.tiledbContext, query.tiledbQuery, C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferList.tiledbBufferList)
+	runtime.KeepAlive(query)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing query: %w", query.context.LastError())
 	}
@@ -337,6 +347,8 @@ func DeserializeQuery(query *Query, buffer *Buffer, serializationType Serializat
 	}
 
 	ret := C.tiledb_deserialize_query(query.context.tiledbContext, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, query.tiledbQuery)
+	runtime.KeepAlive(query)
+	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deserializing query: %w", query.context.LastError())
 	}
@@ -350,6 +362,7 @@ func SerializeArrayMetadataToBuffer(a *Array, serializationType SerializationTyp
 	freeOnGC(&buffer)
 
 	ret := C.tiledb_serialize_array_metadata(a.context.tiledbContext, a.tiledbArray, C.tiledb_serialization_type_t(serializationType), &buffer.tiledbBuffer)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array metadata: %w", a.context.LastError())
 	}
@@ -372,6 +385,8 @@ func SerializeArrayMetadata(a *Array, serializationType SerializationType) ([]by
 // DeserializeArrayMetadata deserializes array metadata.
 func DeserializeArrayMetadata(a *Array, buffer *Buffer, serializationType SerializationType) error {
 	ret := C.tiledb_deserialize_array_metadata(a.context.tiledbContext, a.tiledbArray, C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer)
+	runtime.KeepAlive(a)
+	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deserializing array metadata: %w", a.context.LastError())
 	}
@@ -391,6 +406,7 @@ func SerializeQueryEstResultSizesToBuffer(q *Query, serializationType Serializat
 	freeOnGC(&buffer)
 
 	ret := C.tiledb_serialize_query_est_result_sizes(q.context.tiledbContext, q.tiledbQuery, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
+	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing query est buffer sizes: %w", q.context.LastError())
 	}
@@ -420,6 +436,8 @@ func DeserializeQueryEstResultSizes(q *Query, buffer *Buffer, serializationType 
 	}
 
 	ret := C.tiledb_deserialize_query_est_result_sizes(q.context.tiledbContext, q.tiledbQuery, C.tiledb_serialization_type_t(serializationType), cClientSide, buffer.tiledbBuffer)
+	runtime.KeepAlive(q)
+	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deserializing query est buffer sizes: %w", q.context.LastError())
 	}
@@ -440,6 +458,8 @@ func SerializeArrayToBuffer(array *Array, serializationType SerializationType, c
 	freeOnGC(&buffer)
 
 	ret := C.tiledb_serialize_array(array.context.tiledbContext, array.tiledbArray, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
+	runtime.KeepAlive(array)
+	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array: %w", array.context.LastError())
 	}
@@ -474,6 +494,7 @@ func DeserializeArray(buffer *Buffer, serializationType SerializationType, clien
 	defer C.free(unsafe.Pointer(cArrayURI))
 
 	ret := C.tiledb_deserialize_array(array.context.tiledbContext, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, cArrayURI, &array.tiledbArray)
+	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error deserializing array: %w", array.context.LastError())
 	}
@@ -501,6 +522,7 @@ func SerializeFragmentInfoToBuffer(fragmentInfo *FragmentInfo, serializationType
 	freeOnGC(&buffer)
 
 	ret := C.tiledb_serialize_fragment_info(fragmentInfo.context.tiledbContext, fragmentInfo.tiledbFragmentInfo, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
+	runtime.KeepAlive(fragmentInfo)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array: %w", fragmentInfo.context.LastError())
 	}
@@ -533,6 +555,8 @@ func DeserializeFragmentInfo(fragmentInfo FragmentInfo, buffer *Buffer, arrayURI
 	defer C.free(unsafe.Pointer(cArrayURI))
 
 	ret := C.tiledb_deserialize_fragment_info(fragmentInfo.context.tiledbContext, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cArrayURI, cClientSide, fragmentInfo.tiledbFragmentInfo)
+	runtime.KeepAlive(fragmentInfo)
+	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deserializing array: %w", fragmentInfo.context.LastError())
 	}
@@ -554,6 +578,7 @@ func SerializeFragmentInfoRequestToBuffer(fragmentInfo *FragmentInfo, serializat
 	freeOnGC(&buffer)
 
 	ret := C.tiledb_serialize_fragment_info_request(fragmentInfo.context.tiledbContext, fragmentInfo.tiledbFragmentInfo, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
+	runtime.KeepAlive(fragmentInfo)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array: %w", fragmentInfo.context.LastError())
 	}
@@ -583,6 +608,8 @@ func DeserializeFragmentInfoRequest(fragmentInfo FragmentInfo, buffer *Buffer, s
 	}
 
 	ret := C.tiledb_deserialize_fragment_info_request(fragmentInfo.context.tiledbContext, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, fragmentInfo.tiledbFragmentInfo)
+	runtime.KeepAlive(fragmentInfo)
+	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deserializing array: %w", fragmentInfo.context.LastError())
 	}
@@ -631,6 +658,7 @@ func SerializeGroupMetadataToBuffer(g *Group, serializationType SerializationTyp
 	freeOnGC(&buffer)
 
 	ret := C.tiledb_serialize_group_metadata(g.context.tiledbContext, g.group, C.tiledb_serialization_type_t(serializationType), &buffer.tiledbBuffer)
+	runtime.KeepAlive(g)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing group metadata: %w", g.context.LastError())
 	}
@@ -662,6 +690,8 @@ func DeserializeGroupMetadata(g *Group, buffer *Buffer, serializationType Serial
 	}
 
 	ret := C.tiledb_deserialize_group_metadata(g.context.tiledbContext, g.group, C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer)
+	runtime.KeepAlive(g)
+	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deserializing group metadata: %w", g.context.LastError())
 	}
@@ -689,6 +719,8 @@ func (g *Group) Deserialize(buffer *Buffer, serializationType SerializationType,
 	}
 
 	ret := C.tiledb_deserialize_group(g.context.tiledbContext, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, g.group)
+	runtime.KeepAlive(g)
+	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deserializing group: %w", g.context.LastError())
 	}
@@ -706,11 +738,12 @@ func HandleLoadArraySchemaRequest(array *Array, request *Buffer, serializationTy
 	}
 
 	ret := C.tiledb_handle_load_array_schema_request(array.context.tiledbContext, array.tiledbArray, C.tiledb_serialization_type_t(serializationType), request.tiledbBuffer, response.tiledbBuffer)
+	runtime.KeepAlive(array)
+	runtime.KeepAlive(request)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error handling LoadArraySchemaRequset: %w", array.context.LastError())
 	}
 
-	runtime.KeepAlive(request)
 	return response, nil
 }
 
@@ -718,11 +751,12 @@ func HandleLoadArraySchemaRequest(array *Array, request *Buffer, serializationTy
 func HandleArrayDeleteFragmentsTimestampsRequest(context *Context, array *Array, buffer *Buffer, serializationType SerializationType) error {
 	ret := C.tiledb_handle_array_delete_fragments_timestamps_request(context.tiledbContext, array.tiledbArray,
 		C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer)
+	runtime.KeepAlive(array)
+	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deserializing delete fragments timestamps: %w", context.LastError())
 	}
 
-	runtime.KeepAlive(buffer)
 	return nil
 }
 
@@ -730,11 +764,12 @@ func HandleArrayDeleteFragmentsTimestampsRequest(context *Context, array *Array,
 func HandleArrayDeleteFragmentsListRequest(context *Context, array *Array, buffer *Buffer, serializationType SerializationType) error {
 	ret := C.tiledb_handle_array_delete_fragments_list_request(context.tiledbContext, array.tiledbArray,
 		C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer)
+	runtime.KeepAlive(array)
+	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deserializing delete fragments list: %w", context.LastError())
 	}
 
-	runtime.KeepAlive(buffer)
 	return nil
 }
 
@@ -750,12 +785,11 @@ func HandleQueryPlanRequest(array *Array, serializationType SerializationType, r
 
 	ret := C.tiledb_handle_query_plan_request(opContext.tiledbContext, array.tiledbArray, C.tiledb_serialization_type_t(serializationType),
 		request.tiledbBuffer, response.tiledbBuffer)
+	runtime.KeepAlive(array)
+	runtime.KeepAlive(request)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error handling query plan request: %w", opContext.LastError())
 	}
-
-	runtime.KeepAlive(request)
-	runtime.KeepAlive(array)
 
 	return response, nil
 }
@@ -772,12 +806,11 @@ func HandleConsolidationPlanRequest(array *Array, serializationType Serializatio
 
 	ret := C.tiledb_handle_consolidation_plan_request(opContext.tiledbContext, array.tiledbArray, C.tiledb_serialization_type_t(serializationType),
 		request.tiledbBuffer, response.tiledbBuffer)
+	runtime.KeepAlive(array)
+	runtime.KeepAlive(request)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error handling consolidation plan request: %w", opContext.LastError())
 	}
-
-	runtime.KeepAlive(request)
-	runtime.KeepAlive(array)
 
 	return response, nil
 }
@@ -791,12 +824,11 @@ func DeserializeLoadEnumerationsRequest(array *Array, serializationType Serializ
 
 	ret := C.tiledb_handle_load_enumerations_request(array.context.tiledbContext, array.tiledbArray, C.tiledb_serialization_type_t(serializationType),
 		request.tiledbBuffer, response.tiledbBuffer)
+	runtime.KeepAlive(array)
+	runtime.KeepAlive(request)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error deserializing load enumerations request: %w", array.context.LastError())
 	}
-
-	runtime.KeepAlive(request)
-	runtime.KeepAlive(array)
 
 	return response, nil
 }

--- a/vfs.go
+++ b/vfs.go
@@ -53,6 +53,7 @@ func (v *VFSfh) IsClosed() (bool, error) {
 	var isClosed C.int32_t
 
 	ret := C.tiledb_vfs_fh_is_closed(v.context.tiledbContext, v.tiledbVFSfh, &isClosed)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return false, errors.New("error in checking if vfs file handler is closed")
@@ -79,6 +80,8 @@ type VFS struct {
 func NewVFS(context *Context, config *Config) (*VFS, error) {
 	vfs := VFS{context: context}
 	ret := C.tiledb_vfs_alloc(context.tiledbContext, config.tiledbConfig, &vfs.tiledbVFS)
+	runtime.KeepAlive(context)
+	runtime.KeepAlive(config)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb VFS: %w", context.LastError())
 	}
@@ -124,6 +127,7 @@ func (v *VFS) CreateBucket(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_vfs_create_bucket(v.context.tiledbContext, v.tiledbVFS, curi)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error in creating s3 bucket %s: %w", uri, v.context.LastError())
@@ -137,6 +141,7 @@ func (v *VFS) RemoveBucket(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_vfs_remove_bucket(v.context.tiledbContext, v.tiledbVFS, curi)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error in removing s3 bucket %s: %w", uri, v.context.LastError())
@@ -150,6 +155,7 @@ func (v *VFS) EmptyBucket(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_vfs_empty_bucket(v.context.tiledbContext, v.tiledbVFS, curi)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error in emptying s3 bucket %s: %w", uri, v.context.LastError())
@@ -164,6 +170,7 @@ func (v *VFS) IsEmptyBucket(uri string) (bool, error) {
 	defer C.free(unsafe.Pointer(curi))
 	var isEmpty C.int32_t
 	ret := C.tiledb_vfs_is_empty_bucket(v.context.tiledbContext, v.tiledbVFS, curi, &isEmpty)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error in checking if s3 bucket %s is empty: %w", uri, v.context.LastError())
@@ -182,6 +189,7 @@ func (v *VFS) IsBucket(uri string) (bool, error) {
 	defer C.free(unsafe.Pointer(curi))
 	var isBucket C.int32_t
 	ret := C.tiledb_vfs_is_bucket(v.context.tiledbContext, v.tiledbVFS, curi, &isBucket)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error in checking if %s is a s3 bucket: %w", uri, v.context.LastError())
@@ -199,6 +207,7 @@ func (v *VFS) CreateDir(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_vfs_create_dir(v.context.tiledbContext, v.tiledbVFS, curi)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error in creating directory %s: %w", uri, v.context.LastError())
@@ -213,6 +222,7 @@ func (v *VFS) IsDir(uri string) (bool, error) {
 	defer C.free(unsafe.Pointer(curi))
 	var isDir C.int32_t
 	ret := C.tiledb_vfs_is_dir(v.context.tiledbContext, v.tiledbVFS, curi, &isDir)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error in checking if %s is a directory: %w", uri, v.context.LastError())
@@ -230,6 +240,7 @@ func (v *VFS) RemoveDir(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_vfs_remove_dir(v.context.tiledbContext, v.tiledbVFS, curi)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error in removing directory %s: %w", uri, v.context.LastError())
@@ -244,6 +255,7 @@ func (v *VFS) IsFile(uri string) (bool, error) {
 	defer C.free(unsafe.Pointer(curi))
 	var isFile C.int32_t
 	ret := C.tiledb_vfs_is_file(v.context.tiledbContext, v.tiledbVFS, curi, &isFile)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error in checking if %s is a file: %w", uri, v.context.LastError())
@@ -261,6 +273,7 @@ func (v *VFS) RemoveFile(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_vfs_remove_file(v.context.tiledbContext, v.tiledbVFS, curi)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error in removing file %s: %w", uri, v.context.LastError())
@@ -275,6 +288,7 @@ func (v *VFS) FileSize(uri string) (uint64, error) {
 	defer C.free(unsafe.Pointer(curi))
 	var cfsize C.uint64_t
 	ret := C.tiledb_vfs_file_size(v.context.tiledbContext, v.tiledbVFS, curi, &cfsize)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error in getting file size %s: %w", uri, v.context.LastError())
@@ -291,6 +305,7 @@ func (v *VFS) MoveFile(oldURI string, newURI string) error {
 	defer C.free(unsafe.Pointer(cNewURI))
 
 	ret := C.tiledb_vfs_move_file(v.context.tiledbContext, v.tiledbVFS, cOldURI, cNewURI)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error in moving file %s to %s: %w", oldURI, newURI, v.context.LastError())
@@ -307,6 +322,7 @@ func (v *VFS) CopyFile(oldURI string, newURI string) error {
 	defer C.free(unsafe.Pointer(cNewURI))
 
 	ret := C.tiledb_vfs_copy_file(v.context.tiledbContext, v.tiledbVFS, cOldURI, cNewURI)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error in copying file %s to %s: %w", oldURI, newURI, v.context.LastError())
@@ -323,6 +339,7 @@ func (v *VFS) MoveDir(oldURI string, newURI string) error {
 	defer C.free(unsafe.Pointer(cNewURI))
 
 	ret := C.tiledb_vfs_move_dir(v.context.tiledbContext, v.tiledbVFS, cOldURI, cNewURI)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error in moving directory %s to %s: %w", oldURI, newURI, v.context.LastError())
@@ -339,6 +356,7 @@ func (v *VFS) Open(uri string, mode VFSMode) (*VFSfh, error) {
 	freeOnGC(fh)
 
 	ret := C.tiledb_vfs_open(v.context.tiledbContext, v.tiledbVFS, curi, C.tiledb_vfs_mode_t(mode), &fh.tiledbVFSfh)
+	runtime.KeepAlive(v)
 
 	if ret == C.TILEDB_OOM {
 		return nil, fmt.Errorf("out of Memory error in VFS.Open: %w", v.context.LastError())
@@ -353,8 +371,8 @@ func (v *VFS) Open(uri string, mode VFSMode) (*VFSfh, error) {
 // was opened in write (or append) mode. It is particularly important to be
 // called after S3 writes, as otherwise the writes will not take effect.
 func (v *VFS) Close(fh *VFSfh) error {
-
 	ret := C.tiledb_vfs_close(v.context.tiledbContext, fh.tiledbVFSfh)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("unknown error in VFS.Close: %w", v.context.LastError())
@@ -369,6 +387,8 @@ func (v *VFS) Read(fh *VFSfh, offset uint64, nbytes uint64) ([]byte, error) {
 	bytes := make([]byte, nbytes)
 	cbuffer := slicePtr(bytes)
 	ret := C.tiledb_vfs_read(v.context.tiledbContext, fh.tiledbVFSfh, C.uint64_t(offset), cbuffer, C.uint64_t(nbytes))
+	runtime.KeepAlive(v)
+	runtime.KeepAlive(fh)
 
 	if ret != C.TILEDB_OK {
 		return []byte{}, fmt.Errorf("unknown error in VFS.Read: %w", v.context.LastError())
@@ -384,6 +404,8 @@ func (v *VFS) Write(fh *VFSfh, bytes []byte) error {
 	cbuffer := slicePtr(bytes)
 	defer runtime.KeepAlive(bytes)
 	ret := C.tiledb_vfs_write(v.context.tiledbContext, fh.tiledbVFSfh, cbuffer, C.uint64_t(len(bytes)))
+	runtime.KeepAlive(v)
+	runtime.KeepAlive(fh)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("unknown error in VFS.Write: %w", v.context.LastError())
@@ -395,6 +417,8 @@ func (v *VFS) Write(fh *VFSfh, bytes []byte) error {
 // Sync flushes a file.
 func (v *VFS) Sync(fh *VFSfh) error {
 	ret := C.tiledb_vfs_sync(v.context.tiledbContext, fh.tiledbVFSfh)
+	runtime.KeepAlive(v)
+	runtime.KeepAlive(fh)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("unknown error in VFS.Sync: %w", v.context.LastError())
@@ -408,6 +432,7 @@ func (v *VFS) Touch(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	ret := C.tiledb_vfs_touch(v.context.tiledbContext, v.tiledbVFS, curi)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error in touching %s: %w", uri, v.context.LastError())
@@ -422,6 +447,7 @@ func (v *VFS) DirSize(uri string) (uint64, error) {
 	defer C.free(unsafe.Pointer(curi))
 	var cfsize C.uint64_t
 	ret := C.tiledb_vfs_dir_size(v.context.tiledbContext, v.tiledbVFS, curi, &cfsize)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error in getting dir size %s: %w", uri, v.context.LastError())
@@ -467,6 +493,7 @@ func (v *VFS) NumOfFragmentsInPath(path string) (int, error) {
 	defer pointer.Unref(data)
 
 	ret := C._num_of_folders_in_path(v.context.tiledbContext, v.tiledbVFS, cpath, data)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error in getting dir list %s: %w", path, v.context.LastError())
@@ -481,6 +508,7 @@ func (v *VFS) NumOfFragmentsInPath(path string) (int, error) {
 func (v *VFSfh) Close() error {
 
 	ret := C.tiledb_vfs_close(v.context.tiledbContext, v.tiledbVFSfh)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("unknown error in VFS.Close: %w", v.context.LastError())
@@ -513,6 +541,7 @@ func (v *VFSfh) Read(p []byte) (int, error) {
 
 	cbuffer := slicePtr(p)
 	ret := C.tiledb_vfs_read(v.context.tiledbContext, v.tiledbVFSfh, C.uint64_t(v.offset), cbuffer, C.uint64_t(nbytes))
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("unknown error in VFS.Read: %w", v.context.LastError())
@@ -555,6 +584,7 @@ func (v *VFSfh) ReadAt(p []byte, off int64) (int, error) {
 
 	cbuffer := slicePtr(p)
 	ret := C.tiledb_vfs_read(v.context.tiledbContext, v.tiledbVFSfh, C.uint64_t(off), cbuffer, C.uint64_t(nbytes))
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("unknown error in VFS.Read: %w", v.context.LastError())
@@ -572,6 +602,7 @@ func (v *VFSfh) Write(bytes []byte) (int, error) {
 	}
 	cbuffer := slicePtr(bytes)
 	ret := C.tiledb_vfs_write(v.context.tiledbContext, v.tiledbVFSfh, cbuffer, C.uint64_t(len(bytes)))
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("unknown error in VFS.Write: %w", v.context.LastError())
@@ -583,6 +614,7 @@ func (v *VFSfh) Write(bytes []byte) (int, error) {
 // Sync flushes a file.
 func (v *VFSfh) Sync() error {
 	ret := C.tiledb_vfs_sync(v.context.tiledbContext, v.tiledbVFSfh)
+	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("unknown error in VFS.Sync: %w", v.context.LastError())
@@ -679,6 +711,7 @@ func (v *VFS) List(path string) ([]string, []string, error) {
 	defer pointer.Unref(data)
 
 	ret := C._vfs_ls(v.context.tiledbContext, v.tiledbVFS, cpath, data)
+	runtime.KeepAlive(v)
 	if ret != C.TILEDB_OK {
 		return nil, nil, fmt.Errorf("error in getting path listing %s: %w", path, v.context.LastError())
 	}
@@ -731,6 +764,7 @@ func (v *VFS) VisitRecursive(path string, callback VisitRecursiveCallback) error
 	defer pointer.Unref(data)
 
 	ret := C._vfs_ls_recursive(v.context.tiledbContext, v.tiledbVFS, cpath, data)
+	runtime.KeepAlive(v)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error in recursively listing path %s: %w", path, v.context.LastError())
 	}


### PR DESCRIPTION
[SC-58351](https://app.shortcut.com/tiledb-inc/story/58351)
[SC-62492](https://app.shortcut.com/tiledb-inc/story/62492)

* We use `runtime.KeepAlive` to keep the finalizers of TileDB objects from being called during each cgo call.
  * The keepalives are put right after the call, ordered by the object's appearence in the C function's parameters.
  * If a C API returns pointers to C-owned memory, these are documented, and the keepalives are put right after the last use of that pointer.
  * If a variable does not need a keepalive when using it or passing it to C, that fact is documented.
* We use the `runtime.Pinner` type to pin memory held long-term by C, in a well-defined way.
  * Unpinning happens in the `Free()` function, after the C handle is freed.
  * This makes us (to the best of my knowledge) no longer reliant on a non-moving garbage collector. I'm not removing the dependency to https://go4.org/unsafe/assume-no-moving-gc right now out of abundance of caution.
* Updates CI to build tests with the `GOEXPERIMENT=cgocheck2` option.