### PR TITLE
Add standalone functions for certain operations on arrays and groups.

### DIFF
--- a/array.go
+++ b/array.go
@@ -221,7 +221,7 @@ func (a *Array) Close() error {
 	return nil
 }
 
-// Create creates a new TileDB array given a context, URI and schema.
+// CreateArray creates a new TileDB array given a context, URI and schema.
 func CreateArray(tdbCtx *Context, uri string, arraySchema *ArraySchema) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))

--- a/array.go
+++ b/array.go
@@ -208,17 +208,22 @@ func (a *Array) Close() error {
 	return nil
 }
 
-// Create creates a new TileDB array given an input schema.
-func (a *Array) Create(arraySchema *ArraySchema) error {
-	curi := C.CString(a.uri)
+// Create creates a new TileDB array given a context, URI and schema.
+func CreateArray(tdbCtx *Context, uri string, arraySchema *ArraySchema) error {
+	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_array_create(a.context.tiledbContext, curi, arraySchema.tiledbArraySchema)
-	runtime.KeepAlive(a)
+	ret := C.tiledb_array_create(tdbCtx.tiledbContext, curi, arraySchema.tiledbArraySchema)
+	runtime.KeepAlive(tdbCtx)
 	runtime.KeepAlive(arraySchema)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error creating tiledb array: %w", a.context.LastError())
+		return fmt.Errorf("error creating tiledb array: %w", tdbCtx.LastError())
 	}
 	return nil
+}
+
+// Create creates a new TileDB array given an input schema.
+func (a *Array) Create(arraySchema *ArraySchema) error {
+	return CreateArray(a.context, a.uri, arraySchema)
 }
 
 // Consolidate consolidates the fragments of an array into a single fragment.

--- a/array.go
+++ b/array.go
@@ -222,6 +222,7 @@ func CreateArray(tdbCtx *Context, uri string, arraySchema *ArraySchema) error {
 }
 
 // Create creates a new TileDB array given an input schema.
+// Deprecated: Use CreateArray instead.
 func (a *Array) Create(arraySchema *ArraySchema) error {
 	return CreateArray(a.context, a.uri, arraySchema)
 }
@@ -250,6 +251,7 @@ func ConsolidateArray(tdbCtx *Context, uri string, config *Config) error {
 // Consolidate consolidates the fragments of the array into a single fragment.
 // You must first finalize all queries to the array before consolidation can
 // begin (as consolidation temporarily acquires an exclusive lock on the array).
+// Deprecated: Use ConsolidateArray instead.
 func (a *Array) Consolidate(config *Config) error {
 	return ConsolidateArray(a.context, a.uri, config)
 }
@@ -274,6 +276,7 @@ func VacuumArray(tdbCtx *Context, uri string, config *Config) error {
 }
 
 // Vacuum cleans up the array, such as consolidated fragments and array metadata.
+// Deprecated: Use VacuumArray instead.
 func (a *Array) Vacuum(config *Config) error {
 	return VacuumArray(a.context, a.uri, config)
 }

--- a/array_experimental_test.go
+++ b/array_experimental_test.go
@@ -192,7 +192,7 @@ func TestConsolidateFragments(t *testing.T) {
 			require.EqualValues(t, numFrags, fragToVacuumNum)
 			require.Equal(t, uint32(1), fragInfoNum)
 
-			err = array.Vacuum(config)
+			err = VacuumArray(array.context, array.uri, config)
 			require.NoError(t, err)
 
 			// Check for one fragment after vacuum.

--- a/array_experimental_test.go
+++ b/array_experimental_test.go
@@ -58,12 +58,12 @@ func create1DTestArray(t *testing.T) *Array {
 
 	// Create array on disk
 	tmpArrayPath := t.TempDir()
+	err = CreateArray(context, tmpArrayPath, arraySchema)
+	require.NoError(t, err)
+
 	array, err := NewArray(context, tmpArrayPath)
 	require.NoError(t, err)
 	assert.NotNil(t, array)
-	err = array.Create(arraySchema)
-	require.NoError(t, err)
-
 	return array
 }
 

--- a/array_schema_evolution_experimental_test.go
+++ b/array_schema_evolution_experimental_test.go
@@ -51,13 +51,7 @@ func TestArraySchemaEvolution(t *testing.T) {
 	// tmpArrayPath is the array URI
 	tmpArrayPath := t.TempDir()
 
-	array, err := NewArray(context, tmpArrayPath)
-	require.NoError(t, err)
-	assert.NotNil(t, array)
-
-	require.NoError(t, array.Create(arraySchema))
-
-	require.NoError(t, array.Close())
+	require.NoError(t, CreateArray(context, tmpArrayPath, arraySchema))
 
 	arraySchemaEvolution, err := NewArraySchemaEvolution(context)
 	require.NoError(t, err)
@@ -99,7 +93,7 @@ func TestArraySchemaEvolution(t *testing.T) {
 	// Prepare the array for reading
 	arr, err := NewArray(ctx, tmpArrayPath)
 	require.NoError(t, err)
-	defer array.Free()
+	defer arr.Free()
 
 	require.NoError(t, arr.Open(TILEDB_READ))
 

--- a/array_test.go
+++ b/array_test.go
@@ -70,13 +70,7 @@ func ExampleNewArray() {
 		return
 	}
 
-	array, err := NewArray(context, "my_array")
-	if err != nil {
-		// Handle error
-		return
-	}
-
-	err = array.Create(arraySchema)
+	err = CreateArray(context, "my_array", arraySchema)
 	if err != nil {
 		// Handle error
 		return
@@ -134,15 +128,15 @@ func TestArray(t *testing.T) {
 
 	// create temp group name
 	tmpArrayPath := t.TempDir()
+	arraySchema := buildArraySchema(context, t)
+
+	// Create array on disk
+	require.NoError(t, CreateArray(context, tmpArrayPath, arraySchema))
+
 	// Create new array struct
 	array, err := NewArray(context, tmpArrayPath)
 	require.NoError(t, err)
 	assert.NotNil(t, array)
-
-	arraySchema := buildArraySchema(context, t)
-
-	// Create array on disk
-	require.NoError(t, array.Create(arraySchema))
 
 	// Get array URI
 	uri, err := array.URI()
@@ -224,16 +218,16 @@ func TestArrayEncryption(t *testing.T) {
 
 	// create temp group name
 	tmpArrayPath := t.TempDir()
+	arraySchema := buildArraySchema(context, t)
+
+	// Create array on disk
+	require.NoError(t, CreateArray(context, tmpArrayPath, arraySchema))
+	assert.Nil(t, err)
+
 	// Create new array struct
 	array, err := NewArray(context, tmpArrayPath)
 	require.NoError(t, err)
 	assert.NotNil(t, array)
-
-	arraySchema := buildArraySchema(context, t)
-
-	// Create array on disk
-	require.NoError(t, array.Create(arraySchema))
-	assert.Nil(t, err)
 
 	//err = array.Consolidate()
 	//require.NoError(t, err)
@@ -573,14 +567,14 @@ func newTestArray(t *testing.T) (*Array, error) {
 	// create temp group name
 	tmpArrayPath := t.TempDir()
 
-	array, err := NewArray(context, tmpArrayPath)
+	arraySchema := buildArraySchema(context, t)
+	// Create array on disk
+	err = CreateArray(context, tmpArrayPath, arraySchema)
 	if err != nil {
 		return nil, err
 	}
 
-	arraySchema := buildArraySchema(context, t)
-	// Create array on disk
-	err = array.Create(arraySchema)
+	array, err := NewArray(context, tmpArrayPath)
 	if err != nil {
 		return nil, err
 	}

--- a/dimension_label_experimental_test.go
+++ b/dimension_label_experimental_test.go
@@ -15,11 +15,11 @@ func TestDimensionLabelQuery(t *testing.T) {
 
 	// create the array
 	uri := t.TempDir()
-	array, err := NewArray(tdbCtx, uri)
-	require.NoError(t, err)
-	require.NoError(t, array.Create(schema))
+	require.NoError(t, CreateArray(tdbCtx, uri, schema))
 
 	// initialize the labels
+	array, err := NewArray(tdbCtx, uri)
+	require.NoError(t, err)
 	require.NoError(t, array.Open(TILEDB_WRITE))
 
 	q, err := NewQuery(tdbCtx, array)
@@ -83,9 +83,7 @@ func TestDimensionLabelSchema(t *testing.T) {
 
 	// create the array with the schema and read it back to verify the value
 	uri := t.TempDir()
-	memArray, err := NewArray(tdbCtx, uri)
-	require.NoError(t, err)
-	require.NoError(t, memArray.Create(schema))
+	require.NoError(t, CreateArray(tdbCtx, uri, schema))
 
 	diskArray, err := NewArray(tdbCtx, uri)
 	require.NoError(t, err)

--- a/enumeration_experimental_test.go
+++ b/enumeration_experimental_test.go
@@ -126,9 +126,9 @@ func TestEnumerationAndSchema(t *testing.T) {
 	require.NoError(t, err)
 
 	arrayPath := t.TempDir()
+	require.NoError(t, CreateArray(tdbCtx, arrayPath, schema))
 	array, err := NewArray(tdbCtx, arrayPath)
 	require.NoError(t, err)
-	require.NoError(t, array.Create(schema))
 	require.NoError(t, array.Open(TILEDB_READ))
 	t.Cleanup(func() { array.Close() })
 
@@ -178,9 +178,7 @@ func TestEnumerationQueryCondition(t *testing.T) {
 	require.NoError(t, err)
 
 	arrayPath := t.TempDir()
-	array, err := NewArray(tdbCtx, arrayPath)
-	require.NoError(t, err)
-	require.NoError(t, array.Create(schema))
+	require.NoError(t, CreateArray(tdbCtx, arrayPath, schema))
 
 	//=====
 	// write to the array. Each cell gets the row order rank.
@@ -190,7 +188,7 @@ func TestEnumerationQueryCondition(t *testing.T) {
 	//  8  9 10 11
 	// 12 13 14 15
 
-	array, err = NewArray(tdbCtx, arrayPath)
+	array, err := NewArray(tdbCtx, arrayPath)
 	require.NoError(t, err)
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	wQuery, err := NewQuery(tdbCtx, array)
@@ -316,9 +314,7 @@ func TestEnumerationEmpty(t *testing.T) {
 	require.NoError(t, err)
 
 	arrayPath := t.TempDir()
-	array, err := NewArray(tdbCtx, arrayPath)
-	require.NoError(t, err)
-	require.NoError(t, array.Create(schema))
+	require.NoError(t, CreateArray(tdbCtx, arrayPath, schema))
 }
 
 func TestEnumerationEvolution(t *testing.T) {
@@ -330,9 +326,7 @@ func TestEnumerationEvolution(t *testing.T) {
 	require.NoError(t, err)
 
 	arrayPath := t.TempDir()
-	array, err := NewArray(tdbCtx, arrayPath)
-	require.NoError(t, err)
-	require.NoError(t, array.Create(schema))
+	require.NoError(t, CreateArray(tdbCtx, arrayPath, schema))
 
 	//=====
 	// write to the array. Each cell gets the row order rank + 10
@@ -342,7 +336,7 @@ func TestEnumerationEvolution(t *testing.T) {
 	// 18 19 20 21
 	// 22 23 24 25
 
-	array, err = NewArray(tdbCtx, arrayPath)
+	array, err := NewArray(tdbCtx, arrayPath)
 	require.NoError(t, err)
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	wQuery, err := NewQuery(tdbCtx, array)

--- a/examples_lib/array_metadata.go
+++ b/examples_lib/array_metadata.go
@@ -45,14 +45,8 @@ func createArrayMetadataArray(dir string) {
 	err = schema.AddAttributes(a)
 	checkError(err)
 
-	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
-
-	err = array.Create(schema)
-	checkError(err)
-
-	array.Free()
 }
 
 func writeArrayMetadata(dir string) {

--- a/examples_lib/array_metadata.go
+++ b/examples_lib/array_metadata.go
@@ -159,7 +159,7 @@ func readArrayMetadata(dir string) {
 	err = config.Set("sm.consolidation.mode", "array_meta")
 	checkError(err)
 
-	err = array.Consolidate(config)
+	err = tiledb.ConsolidateArray(ctx, dir, config)
 	checkError(err)
 
 	metadataMap, err := array.GetMetadataMap()

--- a/examples_lib/dimensions_labels.go
+++ b/examples_lib/dimensions_labels.go
@@ -33,7 +33,7 @@ func createArrayWithDimensionLabels(uri string) {
 	checkError(schema.AddAttributes(checkedValue(tiledb.NewAttribute(tdbCtx, "v", tiledb.TILEDB_UINT32))))
 
 	// create the array
-	checkError(checkedValue(tiledb.NewArray(tdbCtx, uri)).Create(schema))
+	checkError(tiledb.CreateArray(tdbCtx, uri, schema))
 
 	// set the dimension labels
 	array := checkedValue(tiledb.NewArray(tdbCtx, uri))

--- a/examples_lib/encryption.go
+++ b/examples_lib/encryption.go
@@ -60,11 +60,7 @@ func createEncryptedArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) encrypted array with AES-256-GCM.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/filters.go
+++ b/examples_lib/filters.go
@@ -2,6 +2,7 @@ package examples_lib
 
 import (
 	"fmt"
+
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 )
 
@@ -92,11 +93,7 @@ func createFilterArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/fragments_consolidation.go
+++ b/examples_lib/fragments_consolidation.go
@@ -48,11 +48,7 @@ func createFragmentsConsolidationArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/multi_attribute.go
+++ b/examples_lib/multi_attribute.go
@@ -58,11 +58,7 @@ func createMultiAttributeArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/quickstart_dense.go
+++ b/examples_lib/quickstart_dense.go
@@ -49,11 +49,7 @@ func createDenseArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/quickstart_sparse.go
+++ b/examples_lib/quickstart_sparse.go
@@ -2,6 +2,7 @@ package examples_lib
 
 import (
 	"fmt"
+
 	tiledb "github.com/TileDB-Inc/TileDB-Go"
 	"github.com/TileDB-Inc/TileDB-Go/bytesizes"
 )
@@ -50,11 +51,7 @@ func createSparseArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/range.go
+++ b/examples_lib/range.go
@@ -49,11 +49,7 @@ func createRangeArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/reading_dense_layouts.go
+++ b/examples_lib/reading_dense_layouts.go
@@ -49,11 +49,7 @@ func createReadingDenseLayoutsArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/reading_incomplete.go
+++ b/examples_lib/reading_incomplete.go
@@ -61,11 +61,7 @@ func createReadingIncompleteArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/reading_range.go
+++ b/examples_lib/reading_range.go
@@ -49,11 +49,7 @@ func createReadRangeArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/reading_sparse_layouts.go
+++ b/examples_lib/reading_sparse_layouts.go
@@ -50,11 +50,7 @@ func createReadingSparseLayoutsArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/reading_timestamp.go
+++ b/examples_lib/reading_timestamp.go
@@ -50,11 +50,7 @@ func createTimestampArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/string_dim.go
+++ b/examples_lib/string_dim.go
@@ -42,11 +42,7 @@ func createStringDimArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/using_tiledb_stats.go
+++ b/examples_lib/using_tiledb_stats.go
@@ -49,11 +49,7 @@ func createStatsArray(dir string, rowTileExtent uint32, colTileExtent uint32) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/vacuum.go
+++ b/examples_lib/vacuum.go
@@ -196,7 +196,7 @@ func consolidateVacuum(dir string) {
 	err = config.Set("sm.consolidation.buffer_size", "8")
 	checkError(err)
 
-	err = array.Consolidate(config)
+	err = tiledb.ConsolidateArray(ctx, dir, config)
 	checkError(err)
 
 	numOfFragments = numFragments(dir)

--- a/examples_lib/vacuum.go
+++ b/examples_lib/vacuum.go
@@ -43,11 +43,7 @@ func createVacuumSparseArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/variable_length.go
+++ b/examples_lib/variable_length.go
@@ -66,11 +66,7 @@ func createVariableLengthArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/writing_dense_global.go
+++ b/examples_lib/writing_dense_global.go
@@ -50,11 +50,7 @@ func createDenseGlobalArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/writing_dense_global_expansion.go
+++ b/examples_lib/writing_dense_global_expansion.go
@@ -48,11 +48,7 @@ func createDenseGlobalExpansionArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/writing_dense_multiple.go
+++ b/examples_lib/writing_dense_multiple.go
@@ -50,11 +50,7 @@ func createDenseMultipleArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/writing_dense_padding.go
+++ b/examples_lib/writing_dense_padding.go
@@ -50,11 +50,7 @@ func createDensePaddingArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/writing_dense_sparse.go
+++ b/examples_lib/writing_dense_sparse.go
@@ -50,11 +50,7 @@ func createDenseSparseArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/writing_sparse_global.go
+++ b/examples_lib/writing_sparse_global.go
@@ -50,11 +50,7 @@ func createSparseGlobalArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/writing_sparse_heter_dim.go
+++ b/examples_lib/writing_sparse_heter_dim.go
@@ -46,11 +46,7 @@ func createSparseHeterDimArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/examples_lib/writing_sparse_multiple.go
+++ b/examples_lib/writing_sparse_multiple.go
@@ -50,11 +50,7 @@ func createMultipleWritesSparseArray(dir string) {
 	checkError(err)
 
 	// Create the (empty) array on disk.
-	array, err := tiledb.NewArray(ctx, dir)
-	checkError(err)
-	defer array.Free()
-
-	err = array.Create(schema)
+	err = tiledb.CreateArray(ctx, dir, schema)
 	checkError(err)
 }
 

--- a/filestore_experimental.go
+++ b/filestore_experimental.go
@@ -69,12 +69,7 @@ func CreateAndImportFile(tdbCtx *Context, arrayURI string, filePath string, mime
 		return err
 	}
 
-	array, err := NewArray(tdbCtx, arrayURI)
-	if err != nil {
-		return err
-	}
-
-	err = array.Create(schema)
+	err = CreateArray(tdbCtx, arrayURI, schema)
 	if err != nil {
 		return err
 	}
@@ -90,12 +85,7 @@ func CreateFile(tdbCtx *Context, arrayURI string, data []byte, mimeType FileStor
 		return err
 	}
 
-	array, err := NewArray(tdbCtx, arrayURI)
-	if err != nil {
-		return err
-	}
-
-	err = array.Create(schema)
+	err = CreateArray(tdbCtx, arrayURI, schema)
 	if err != nil {
 		return err
 	}

--- a/filestore_experimental_test.go
+++ b/filestore_experimental_test.go
@@ -220,9 +220,7 @@ func createEmptyFilestoreArray(t *testing.T, arrayURI string) {
 	require.NoError(t, err)
 	schema, err := NewArraySchemaForFile(tdbCtx, "")
 	require.NoError(t, err)
-	array, err := NewArray(tdbCtx, arrayURI)
-	require.NoError(t, err)
-	err = array.Create(schema)
+	err = CreateArray(tdbCtx, arrayURI, schema)
 	require.NoError(t, err)
 }
 

--- a/fragment_info_test.go
+++ b/fragment_info_test.go
@@ -43,15 +43,16 @@ func TestFragmentInfoEncryption(t *testing.T) {
 func testFragmentInfo(t testing.TB, context *Context) uint64 {
 	// create temp group name
 	tmpArrayPath := t.TempDir()
-	// Create new array struct
-	array, err := NewArray(context, tmpArrayPath)
-	require.NoError(t, err)
-	assert.NotNil(t, array)
 
 	arraySchema := buildArraySchema(context, t)
 
 	// Create array on disk
-	require.NoError(t, array.Create(arraySchema))
+	require.NoError(t, CreateArray(context, tmpArrayPath, arraySchema))
+
+	// Create new array struct
+	array, err := NewArray(context, tmpArrayPath)
+	require.NoError(t, err)
+	assert.NotNil(t, array)
 
 	// Get array URI
 	uri, err := array.URI()

--- a/group.go
+++ b/group.go
@@ -39,6 +39,19 @@ func newGroupFromHandle(context *Context, uri string, group groupHandle) *Group 
 	return &Group{group: group, uri: uri, context: context}
 }
 
+// CreateGroup creates a new TileDB group given a context and URI.
+func CreateGroup(tdbCtx *Context, uri string) error {
+	curi := C.CString(uri)
+	defer C.free(unsafe.Pointer(curi))
+
+	ret := C.tiledb_group_create(tdbCtx.tiledbContext.Get(), curi)
+	runtime.KeepAlive(tdbCtx)
+	if ret != C.TILEDB_OK {
+		return fmt.Errorf("error in creating group: %w", tdbCtx.LastError())
+	}
+	return nil
+}
+
 // NewGroup allocates an embedded group.
 func NewGroup(tdbCtx *Context, uri string) (*Group, error) {
 	curi := C.CString(uri)
@@ -51,19 +64,6 @@ func NewGroup(tdbCtx *Context, uri string) (*Group, error) {
 	}
 
 	return newGroupFromHandle(tdbCtx, uri, newGroupHandle(groupPtr)), nil
-}
-
-// CreateGroup creates a new TileDB group given a context and URI.
-func CreateGroup(tdbCtx *Context, uri string) error {
-	curi := C.CString(uri)
-	defer C.free(unsafe.Pointer(curi))
-
-	ret := C.tiledb_group_create(tdbCtx.tiledbContext.Get(), curi)
-	runtime.KeepAlive(tdbCtx)
-	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error in creating group: %w", tdbCtx.LastError())
-	}
-	return nil
 }
 
 // Create creates a new TileDB group.

--- a/group.go
+++ b/group.go
@@ -50,6 +50,7 @@ func CreateGroup(tdbCtx *Context, uri string) error {
 }
 
 // Create creates a new TileDB group.
+// Deprecated: Use CreateGroup instead.
 func (g *Group) Create() error {
 	return CreateGroup(g.context, g.uri)
 }

--- a/group.go
+++ b/group.go
@@ -53,7 +53,7 @@ func NewGroup(tdbCtx *Context, uri string) (*Group, error) {
 	return newGroupFromHandle(tdbCtx, uri, newGroupHandle(groupPtr)), nil
 }
 
-// Create creates a new TileDB group given a context and URI.
+// CreateGroup creates a new TileDB group given a context and URI.
 func CreateGroup(tdbCtx *Context, uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))

--- a/group.go
+++ b/group.go
@@ -36,17 +36,22 @@ func NewGroup(tdbCtx *Context, uri string) (*Group, error) {
 	return &group, nil
 }
 
-// Create creates a new TileDB group.
-func (g *Group) Create() error {
-	curi := C.CString(g.uri)
+// Create creates a new TileDB group given a context and URI.
+func CreateGroup(tdbCtx *Context, uri string) error {
+	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 
-	ret := C.tiledb_group_create(g.context.tiledbContext, curi)
-	runtime.KeepAlive(g)
+	ret := C.tiledb_group_create(tdbCtx.tiledbContext, curi)
+	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
-		return fmt.Errorf("error in creating group: %w", g.context.LastError())
+		return fmt.Errorf("error in creating group: %w", tdbCtx.LastError())
 	}
 	return nil
+}
+
+// Create creates a new TileDB group.
+func (g *Group) Create() error {
+	return CreateGroup(g.context, g.uri)
 }
 
 func (g *Group) Open(queryType QueryType) error {

--- a/group_test.go
+++ b/group_test.go
@@ -255,17 +255,13 @@ func TestGetIsRelativeURIByName(t *testing.T) {
 	require.NoError(t, err)
 
 	arraySchema := buildArraySchema(tdbCtx, t)
-	array1, err := NewArray(tdbCtx, arrayURI1)
+	err = CreateArray(tdbCtx, arrayURI1, arraySchema)
 	require.NoError(t, err)
-	err = array1.Create(arraySchema)
-	require.NoError(t, err)
-	array2, err := NewArray(tdbCtx, arrayURI2)
-	require.NoError(t, err)
-	err = array2.Create(arraySchema)
+	err = CreateArray(tdbCtx, arrayURI2, arraySchema)
 	require.NoError(t, err)
 
 	require.NoError(t, group.Open(TILEDB_WRITE))
-	require.NoError(t, group.AddMember(array1.uri, "array1", false))
+	require.NoError(t, group.AddMember(arrayURI1, "array1", false))
 	require.NoError(t, group.AddMember("array2", "array2", true))
 	require.NoError(t, group.Close())
 
@@ -307,20 +303,16 @@ func TestGroupDelete(t *testing.T) {
 		require.NoError(t, err)
 
 		arraySchema := buildArraySchema(tdbCtx, t)
-		outerArray, err := NewArray(tdbCtx, outerArrayURI)
+		err = CreateArray(tdbCtx, outerArrayURI, arraySchema)
 		require.NoError(t, err)
-		err = outerArray.Create(arraySchema)
-		require.NoError(t, err)
-		innerArray, err := NewArray(tdbCtx, innerArrayURI)
-		require.NoError(t, err)
-		err = innerArray.Create(arraySchema)
+		err = CreateArray(tdbCtx, innerArrayURI, arraySchema)
 		require.NoError(t, err)
 
 		require.NoError(t, innerGroup.Open(TILEDB_WRITE))
-		require.NoError(t, innerGroup.AddMember(innerArray.uri, "innerArray", false))
+		require.NoError(t, innerGroup.AddMember(innerArrayURI, "innerArray", false))
 		require.NoError(t, innerGroup.Close())
 		require.NoError(t, outerGroup.Open(TILEDB_WRITE))
-		require.NoError(t, outerGroup.AddMember(outerArray.uri, "outerArray", false))
+		require.NoError(t, outerGroup.AddMember(outerArrayURI, "outerArray", false))
 		require.NoError(t, outerGroup.AddMember(innerGroup.uri, "innerGroup", false))
 		require.NoError(t, outerGroup.Close())
 
@@ -420,21 +412,11 @@ func createTestGroup(tdbCtx *Context, uri string) (*Group, error) {
 }
 
 func addTwoArraysToGroup(tdbCtx *Context, group *Group, arraySchema *ArraySchema, arrayURI1, arrayURI2 string) error {
-	array1, err := NewArray(tdbCtx, arrayURI1)
-	if err != nil {
+	if err := CreateArray(tdbCtx, arrayURI1, arraySchema); err != nil {
 		return err
 	}
 
-	if err := array1.Create(arraySchema); err != nil {
-		return err
-	}
-
-	array2, err := NewArray(tdbCtx, arrayURI2)
-	if err != nil {
-		return err
-	}
-
-	if err := array2.Create(arraySchema); err != nil {
+	if err := CreateArray(tdbCtx, arrayURI2, arraySchema); err != nil {
 		return err
 	}
 
@@ -446,11 +428,11 @@ func addTwoArraysToGroup(tdbCtx *Context, group *Group, arraySchema *ArraySchema
 		return err
 	}
 
-	if err := group.AddMember(array1.uri, arrayURI1, false); err != nil {
+	if err := group.AddMember(arrayURI1, arrayURI1, false); err != nil {
 		return err
 	}
 
-	if err := group.AddMember(array2.uri, arrayURI2, false); err != nil {
+	if err := group.AddMember(arrayURI2, arrayURI2, false); err != nil {
 		return err
 	}
 

--- a/group_test.go
+++ b/group_test.go
@@ -18,16 +18,14 @@ func TestGroupCreate(t *testing.T) {
 	tmpGroup := t.TempDir()
 
 	// Create initial group
-	group, err := NewGroup(context, tmpGroup)
-	require.NoError(t, err)
-	require.NoError(t, group.Create())
+	require.NoError(t, CreateGroup(context, tmpGroup))
 
 	// Creating the same group twice should error
-	group, err = NewGroup(context, tmpGroup)
-	require.NoError(t, err)
-	assert.Error(t, group.Create())
+	assert.Error(t, CreateGroup(context, tmpGroup))
 
 	// Test Group.IsOpen
+	group, err := NewGroup(context, tmpGroup)
+	require.NoError(t, err)
 	isOpen, err := group.IsOpen()
 	require.NoError(t, err)
 	assert.False(t, isOpen)
@@ -210,7 +208,11 @@ func TestDeserializeGroup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	g, err := NewGroup(tdbCtx, t.TempDir())
+	groupDir := t.TempDir()
+
+	require.NoError(t, CreateGroup(tdbCtx, groupDir))
+
+	g, err := NewGroup(tdbCtx, groupDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,8 +220,6 @@ func TestDeserializeGroup(t *testing.T) {
 	if err := setConfigForWrite(g, 0); err != nil {
 		t.Fatal(err)
 	}
-
-	require.NoError(t, g.Create())
 
 	require.NoError(t, g.Open(TILEDB_WRITE))
 	if err := buffer.SetBuffer([]byte(`{
@@ -399,15 +399,16 @@ func memberCount(group *Group) (uint64, error) {
 }
 
 func createTestGroup(tdbCtx *Context, uri string) (*Group, error) {
+	if err := CreateGroup(tdbCtx, uri); err != nil {
+		return nil, err
+	}
+
 	// Create initial group
 	group, err := NewGroup(tdbCtx, uri)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := group.Create(); err != nil {
-		return nil, err
-	}
 	return group, nil
 }
 

--- a/query_condition_test.go
+++ b/query_condition_test.go
@@ -302,18 +302,19 @@ func createBasicTestArray(t testing.TB) (*Array, error) {
 
 	// create temp group name
 	tmpArrayPath := t.TempDir()
-	// Create new array struct
-	array, err := NewArray(context, tmpArrayPath)
-	if err != nil {
-		return nil, err
-	}
 
 	// Prepare some data for the array
 	buffD1 := []int32{1, 2, 2}
 	buffD2 := []int32{1, 1, 2}
 
 	// Create array on disk
-	if err = array.Create(arraySchema); err != nil {
+	if err = CreateArray(context, tmpArrayPath, arraySchema); err != nil {
+		return nil, err
+	}
+
+	// Create new array struct
+	array, err := NewArray(context, tmpArrayPath)
+	if err != nil {
 		return nil, err
 	}
 

--- a/query_experimental_test.go
+++ b/query_experimental_test.go
@@ -59,15 +59,15 @@ func TestQueryStatusDetails(t *testing.T) {
 
 	// Create array on disk
 	tmpArrayPath := t.TempDir()
-	array, err := NewArray(context, tmpArrayPath)
-	require.NoError(t, err)
-	assert.NotNil(t, array)
-	err = array.Create(arraySchema)
+	err = CreateArray(context, tmpArrayPath, arraySchema)
 	require.NoError(t, err)
 
 	// Write to array
 
 	// Open array for writing
+	array, err := NewArray(context, tmpArrayPath)
+	require.NoError(t, err)
+	assert.NotNil(t, array)
 	err = array.Open(TILEDB_WRITE)
 	require.NoError(t, err)
 
@@ -248,15 +248,15 @@ func TestQueryPlan(t *testing.T) {
 
 	// Create array on disk
 	tmpArrayPath := t.TempDir()
-	array, err := NewArray(context, tmpArrayPath)
-	require.NoError(t, err)
-	assert.NotNil(t, array)
-	err = array.Create(arraySchema)
+	err = CreateArray(context, tmpArrayPath, arraySchema)
 	require.NoError(t, err)
 
 	// Write to array
 
 	// Open array for writing
+	array, err := NewArray(context, tmpArrayPath)
+	require.NoError(t, err)
+	assert.NotNil(t, array)
 	err = array.Open(TILEDB_WRITE)
 	require.NoError(t, err)
 

--- a/query_test.go
+++ b/query_test.go
@@ -125,15 +125,16 @@ func ExampleNewQuery() {
 		return
 	}
 	defer os.RemoveAll(tmpArrayPath)
-	// Create new array struct
-	array, err := NewArray(context, tmpArrayPath)
+
+	// Create array on disk
+	err = CreateArray(context, tmpArrayPath, arraySchema)
 	if err != nil {
 		// Handle error
 		return
 	}
 
-	// Create array on disk
-	err = array.Create(arraySchema)
+	// Create new array struct
+	array, err := NewArray(context, tmpArrayPath)
 	if err != nil {
 		// Handle error
 		return
@@ -457,15 +458,16 @@ func ExampleNewQueryCondition() {
 
 	// create temp group name
 	tmpArrayPath := os.TempDir()
-	// Create new array struct
-	array, err := NewArray(context, tmpArrayPath)
+
+	// Create array on disk
+	err = CreateArray(context, tmpArrayPath, arraySchema)
 	if err != nil {
 		// Handle error
 		return
 	}
 
-	// Create array on disk
-	err = array.Create(arraySchema)
+	// Create new array struct
+	array, err := NewArray(context, tmpArrayPath)
 	if err != nil {
 		// Handle error
 		return
@@ -703,10 +705,6 @@ func TestQueryEffectiveBufferSize(t *testing.T) {
 
 	// create temp group name
 	tmpArrayPath := t.TempDir()
-	// Create new array struct
-	array, err := NewArray(context, tmpArrayPath)
-	require.NoError(t, err)
-	assert.NotNil(t, array)
 
 	// Prepare some data for the array
 	buffD1 := []int32{1, 2, 2}
@@ -715,7 +713,12 @@ func TestQueryEffectiveBufferSize(t *testing.T) {
 	a1OffWrite := []uint64{0, 1, 3}
 
 	// Create array on disk
-	require.NoError(t, array.Create(arraySchema))
+	require.NoError(t, CreateArray(context, tmpArrayPath, arraySchema))
+
+	// Create new array struct
+	array, err := NewArray(context, tmpArrayPath)
+	require.NoError(t, err)
+	assert.NotNil(t, array)
 
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	query, err := NewQuery(context, array)
@@ -878,10 +881,6 @@ func TestQueryEffectiveBufferSizeHeterogeneous(t *testing.T) {
 
 	// create temp group name
 	tmpArrayPath := t.TempDir()
-	// Create new array struct
-	array, err := NewArray(context, tmpArrayPath)
-	require.NoError(t, err)
-	assert.NotNil(t, array)
 
 	// Prepare some data for the array
 	rowsWrite := []int32{1, 2, 2}
@@ -895,7 +894,12 @@ func TestQueryEffectiveBufferSizeHeterogeneous(t *testing.T) {
 	a3Validity := []uint8{1, 1, 0}
 
 	// Create array on disk
-	require.NoError(t, array.Create(arraySchema))
+	require.NoError(t, CreateArray(context, tmpArrayPath, arraySchema))
+
+	// Create new array struct
+	array, err := NewArray(context, tmpArrayPath)
+	require.NoError(t, err)
+	assert.NotNil(t, array)
 
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	query, err := NewQuery(context, array)
@@ -1149,10 +1153,6 @@ func TestQueryEffectiveBufferSizeStrings(t *testing.T) {
 
 	// create temp group name
 	tmpArrayPath := t.TempDir()
-	// Create new array struct
-	array, err := NewArray(context, tmpArrayPath)
-	require.NoError(t, err)
-	assert.NotNil(t, array)
 
 	// Prepare some data for the array
 	rowsWrite := []byte("abbc")
@@ -1161,7 +1161,12 @@ func TestQueryEffectiveBufferSizeStrings(t *testing.T) {
 	a1OffWrite := []uint64{0, 1, 3}
 
 	// Create array on disk
-	require.NoError(t, array.Create(arraySchema))
+	require.NoError(t, CreateArray(context, tmpArrayPath, arraySchema))
+
+	// Create new array struct
+	array, err := NewArray(context, tmpArrayPath)
+	require.NoError(t, err)
+	assert.NotNil(t, array)
 
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	query, err := NewQuery(context, array)
@@ -1372,10 +1377,6 @@ func TestQueryEffectiveBufferSizeStringsHeterogeneous(t *testing.T) {
 
 	// create temp group name
 	tmpArrayPath := t.TempDir()
-	// Create new array struct
-	array, err := NewArray(context, tmpArrayPath)
-	require.NoError(t, err)
-	assert.NotNil(t, array)
 
 	// Prepare some data for the array
 	rowsWrite := []byte("abbc")
@@ -1385,7 +1386,12 @@ func TestQueryEffectiveBufferSizeStringsHeterogeneous(t *testing.T) {
 	a1OffWrite := []uint64{0, 1, 3}
 
 	// Create array on disk
-	require.NoError(t, array.Create(arraySchema))
+	require.NoError(t, CreateArray(context, tmpArrayPath, arraySchema))
+
+	// Create new array struct
+	array, err := NewArray(context, tmpArrayPath)
+	require.NoError(t, err)
+	assert.NotNil(t, array)
 
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	query, err := NewQuery(context, array)
@@ -1550,13 +1556,14 @@ func TestQueryReadEmpty(t *testing.T) {
 
 	// create temp group name
 	tmpArrayPath := t.TempDir()
+
+	// Create array on disk
+	require.NoError(t, CreateArray(context, tmpArrayPath, arraySchema))
+
 	// Create new array struct
 	array, err := NewArray(context, tmpArrayPath)
 	require.NoError(t, err)
 	assert.NotNil(t, array)
-
-	// Create array on disk
-	require.NoError(t, array.Create(arraySchema))
 
 	// Open array for reading
 	require.NoError(t, array.Open(TILEDB_READ))
@@ -1715,13 +1722,14 @@ func TestDenseQueryWrite(t *testing.T) {
 
 	// create temp group name
 	tmpArrayPath := t.TempDir()
+
+	// Create array on disk
+	require.NoError(t, CreateArray(context, tmpArrayPath, arraySchema))
+
 	// Create new array struct
 	array, err := NewArray(context, tmpArrayPath)
 	require.NoError(t, err)
 	assert.NotNil(t, array)
-
-	// Create array on disk
-	require.NoError(t, array.Create(arraySchema))
 
 	// Open array for writting
 	require.NoError(t, array.Open(TILEDB_WRITE))
@@ -2038,13 +2046,14 @@ func TestSparseQueryDelete(t *testing.T) {
 
 	// create temp group name
 	tmpArrayPath := t.TempDir()
+
+	// Create array on disk
+	require.NoError(t, CreateArray(context, tmpArrayPath, arraySchema))
+
 	// Create new array struct
 	array, err := NewArray(context, tmpArrayPath)
 	require.NoError(t, err)
 	assert.NotNil(t, array)
-
-	// Create array on disk
-	require.NoError(t, array.Create(arraySchema))
 
 	// Open array for writting
 	require.NoError(t, array.Open(TILEDB_WRITE))
@@ -2195,13 +2204,14 @@ func TestSparseQueryWrite(t *testing.T) {
 
 	// create temp group name
 	tmpArrayPath := t.TempDir()
+
+	// Create array on disk
+	require.NoError(t, CreateArray(context, tmpArrayPath, arraySchema))
+
 	// Create new array struct
 	array, err := NewArray(context, tmpArrayPath)
 	require.NoError(t, err)
 	assert.NotNil(t, array)
-
-	// Create array on disk
-	require.NoError(t, array.Create(arraySchema))
 
 	// Open array for writting
 	require.NoError(t, array.Open(TILEDB_WRITE))
@@ -2344,13 +2354,14 @@ func TestSparseQueryWriteNullable(t *testing.T) {
 
 	// create temp group name
 	tmpArrayPath := t.TempDir()
+
+	// Create array on disk
+	require.NoError(t, CreateArray(context, tmpArrayPath, arraySchema))
+
 	// Create new array struct
 	array, err := NewArray(context, tmpArrayPath)
 	require.NoError(t, err)
 	assert.NotNil(t, array)
-
-	// Create array on disk
-	require.NoError(t, array.Create(arraySchema))
 
 	// Open array for writting
 	require.NoError(t, array.Open(TILEDB_WRITE))
@@ -2479,10 +2490,10 @@ func TestSparseQueryWriteHilbertLayout(t *testing.T) {
 	require.NoError(t, arraySchema.SetCellOrder(TILEDB_HILBERT))
 	require.NoError(t, arraySchema.Check())
 	tmpArrayPath := t.TempDir()
+	require.NoError(t, CreateArray(context, tmpArrayPath, arraySchema))
 	array, err := NewArray(context, tmpArrayPath)
 	require.NoError(t, err)
 	assert.NotNil(t, array)
-	require.NoError(t, array.Create(arraySchema))
 
 	// Write query
 	require.NoError(t, array.Open(TILEDB_WRITE))
@@ -2585,10 +2596,8 @@ func TestQueryConfig(t *testing.T) {
 
 	// create temp group name
 	tmpArrayPath := t.TempDir()
-	// Create new array struct
-	array, err := NewArray(context, tmpArrayPath)
-	require.NoError(t, err)
-	assert.NotNil(t, array)
+	// Create array on disk
+	require.NoError(t, CreateArray(context, tmpArrayPath, arraySchema))
 
 	// Prepare some data for the array
 	buffD1 := []int32{1, 2, 2}
@@ -2596,8 +2605,10 @@ func TestQueryConfig(t *testing.T) {
 	a1DataWrite := []int32{1, 2, 3}
 	a1OffWrite := []uint64{0, 4, 8}
 
-	// Create array on disk
-	require.NoError(t, array.Create(arraySchema))
+	// Create new array struct
+	array, err := NewArray(context, tmpArrayPath)
+	require.NoError(t, err)
+	assert.NotNil(t, array)
 
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	query, err := NewQuery(context, array)
@@ -2752,11 +2763,6 @@ func TestQueryStats(t *testing.T) {
 
 	// create temp group name
 	tmpArrayPath := t.TempDir()
-	// Create new array struct
-	array, err := NewArray(context, tmpArrayPath)
-	require.NoError(t, err)
-	assert.NotNil(t, array)
-
 	// Prepare some data for the array
 	buffD1 := []int32{1, 2, 2}
 	buffD2 := []int32{1, 1, 2}
@@ -2764,7 +2770,12 @@ func TestQueryStats(t *testing.T) {
 	a1OffWrite := []uint64{0, 1, 3}
 
 	// Create array on disk
-	require.NoError(t, array.Create(arraySchema))
+	require.NoError(t, CreateArray(context, tmpArrayPath, arraySchema))
+
+	// Create new array struct
+	array, err := NewArray(context, tmpArrayPath)
+	require.NoError(t, err)
+	assert.NotNil(t, array)
 
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	query, err := NewQuery(context, array)
@@ -2883,12 +2894,11 @@ func TestSetDataBufferUnsafe(t *testing.T) {
 	require.NoError(t, arraySchema.AddAttributes(attribute))
 	require.NoError(t, arraySchema.SetDomain(domain))
 	uri := t.TempDir()
-	array, err := NewArray(tdbCtx, uri)
-	require.NoError(t, err)
-	require.NoError(t, array.Create(arraySchema))
-	require.NoError(t, array.Close())
+	require.NoError(t, CreateArray(tdbCtx, uri, arraySchema))
 
 	// open the array and write a slice
+	array, err := NewArray(tdbCtx, uri)
+	require.NoError(t, err)
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	tdbCtx, err = NewContext(config)
 	require.NoError(t, err)
@@ -2961,12 +2971,11 @@ func TestGetDataBuffer(t *testing.T) {
 	require.NoError(t, arraySchema.AddAttributes(attribute))
 	require.NoError(t, arraySchema.SetDomain(domain))
 	uri := t.TempDir()
-	array, err := NewArray(tdbCtx, uri)
-	require.NoError(t, err)
-	require.NoError(t, array.Create(arraySchema))
-	require.NoError(t, array.Close())
+	require.NoError(t, CreateArray(tdbCtx, uri, arraySchema))
 
 	// create a write query, set the data buffer and read it back
+	array, err := NewArray(tdbCtx, uri)
+	require.NoError(t, err)
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	tdbCtx, err = NewContext(config)
 	require.NoError(t, err)
@@ -3005,12 +3014,11 @@ func TestSetDataBuffer(t *testing.T) {
 	require.NoError(t, arraySchema.AddAttributes(attribute))
 	require.NoError(t, arraySchema.SetDomain(domain))
 	uri := t.TempDir()
-	array, err := NewArray(tdbCtx, uri)
-	require.NoError(t, err)
-	require.NoError(t, array.Create(arraySchema))
-	require.NoError(t, array.Close())
+	require.NoError(t, CreateArray(tdbCtx, uri, arraySchema))
 
 	// open the array and write a slice
+	array, err := NewArray(tdbCtx, uri)
+	require.NoError(t, err)
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	tdbCtx, err = NewContext(config)
 	require.NoError(t, err)
@@ -3075,10 +3083,10 @@ func TestGetExpectedDataBufferLength(t *testing.T) {
 	require.NoError(t, arraySchema.AddAttributes(attribute))
 	require.NoError(t, arraySchema.SetDomain(domain))
 	uri := t.TempDir()
+	require.NoError(t, CreateArray(tdbCtx, uri, arraySchema))
+
 	array, err := NewArray(tdbCtx, uri)
 	require.NoError(t, err)
-	require.NoError(t, array.Create(arraySchema))
-
 	require.NoError(t, array.Open(TILEDB_READ))
 	q, err := NewQuery(tdbCtx, array)
 	require.NoError(t, err)
@@ -3161,11 +3169,10 @@ func TestSetValidityBufferUnsafe(t *testing.T) {
 	require.NoError(t, arraySchema.AddAttributes(attribute))
 	require.NoError(t, arraySchema.SetDomain(domain))
 	uri := t.TempDir()
+	require.NoError(t, CreateArray(tdbCtx, uri, arraySchema))
+
 	array, err := NewArray(tdbCtx, uri)
 	require.NoError(t, err)
-	require.NoError(t, array.Create(arraySchema))
-	require.NoError(t, array.Close())
-
 	// open the array and write a slice
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	tdbCtx, err = NewContext(config)
@@ -3244,11 +3251,10 @@ func TestGetValidityBuffer(t *testing.T) {
 	require.NoError(t, arraySchema.AddAttributes(attribute))
 	require.NoError(t, arraySchema.SetDomain(domain))
 	uri := t.TempDir()
+	require.NoError(t, CreateArray(tdbCtx, uri, arraySchema))
+
 	array, err := NewArray(tdbCtx, uri)
 	require.NoError(t, err)
-	require.NoError(t, array.Create(arraySchema))
-	require.NoError(t, array.Close())
-
 	// create a write query, set the validity buffer and read it back
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	tdbCtx, err = NewContext(config)
@@ -3287,11 +3293,10 @@ func TestSetValidityBuffer(t *testing.T) {
 	require.NoError(t, arraySchema.AddAttributes(attribute))
 	require.NoError(t, arraySchema.SetDomain(domain))
 	uri := t.TempDir()
+	require.NoError(t, CreateArray(tdbCtx, uri, arraySchema))
+
 	array, err := NewArray(tdbCtx, uri)
 	require.NoError(t, err)
-	require.NoError(t, array.Create(arraySchema))
-	require.NoError(t, array.Close())
-
 	// open the array and write a slice
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	tdbCtx, err = NewContext(config)
@@ -3365,11 +3370,10 @@ func TestGetExpectedValidityBufferLength(t *testing.T) {
 	require.NoError(t, arraySchema.AddAttributes(attribute))
 	require.NoError(t, arraySchema.SetDomain(domain))
 	uri := t.TempDir()
+	require.NoError(t, CreateArray(tdbCtx, uri, arraySchema))
+
 	array, err := NewArray(tdbCtx, uri)
 	require.NoError(t, err)
-	require.NoError(t, array.Create(arraySchema))
-	require.NoError(t, array.Close())
-
 	require.NoError(t, array.Open(TILEDB_READ))
 	q, err := NewQuery(tdbCtx, array)
 	require.NoError(t, err)
@@ -3457,11 +3461,10 @@ func TestSetOffsetsBufferUnsafe(t *testing.T) {
 	require.NoError(t, arraySchema.AddAttributes(attribute))
 	require.NoError(t, arraySchema.SetDomain(domain))
 	uri := t.TempDir()
+	require.NoError(t, CreateArray(tdbCtx, uri, arraySchema))
+
 	array, err := NewArray(tdbCtx, uri)
 	require.NoError(t, err)
-	require.NoError(t, array.Create(arraySchema))
-	require.NoError(t, array.Close())
-
 	// open the array and write a slice
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	tdbCtx, err = NewContext(config)
@@ -3541,11 +3544,10 @@ func TestGetOffsetsBuffer(t *testing.T) {
 	require.NoError(t, arraySchema.AddAttributes(attribute))
 	require.NoError(t, arraySchema.SetDomain(domain))
 	uri := t.TempDir()
+	require.NoError(t, CreateArray(tdbCtx, uri, arraySchema))
+
 	array, err := NewArray(tdbCtx, uri)
 	require.NoError(t, err)
-	require.NoError(t, array.Create(arraySchema))
-	require.NoError(t, array.Close())
-
 	// create a write query, set the validity buffer and read it back
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	tdbCtx, err = NewContext(config)
@@ -3584,11 +3586,10 @@ func TestSetOffsetsBuffer(t *testing.T) {
 	require.NoError(t, arraySchema.AddAttributes(attribute))
 	require.NoError(t, arraySchema.SetDomain(domain))
 	uri := t.TempDir()
+	require.NoError(t, CreateArray(tdbCtx, uri, arraySchema))
+
 	array, err := NewArray(tdbCtx, uri)
 	require.NoError(t, err)
-	require.NoError(t, array.Create(arraySchema))
-	require.NoError(t, array.Close())
-
 	// open the array and write a slice
 	require.NoError(t, array.Open(TILEDB_WRITE))
 	tdbCtx, err = NewContext(config)
@@ -3662,11 +3663,10 @@ func TestGetExpectedOffsetsBufferLength(t *testing.T) {
 	require.NoError(t, arraySchema.AddAttributes(attribute))
 	require.NoError(t, arraySchema.SetDomain(domain))
 	uri := t.TempDir()
+	require.NoError(t, CreateArray(tdbCtx, uri, arraySchema))
+
 	array, err := NewArray(tdbCtx, uri)
 	require.NoError(t, err)
-	require.NoError(t, array.Create(arraySchema))
-	require.NoError(t, array.Close())
-
 	require.NoError(t, array.Open(TILEDB_READ))
 	q, err := NewQuery(tdbCtx, array)
 	require.NoError(t, err)

--- a/subarray_test.go
+++ b/subarray_test.go
@@ -306,9 +306,7 @@ func createDenseIntegerGrid(t *testing.T, n uint8) string {
 	vAttr, err := NewAttribute(tdbCtx, "v", TILEDB_UINT16)
 	require.NoError(t, err)
 	require.NoError(t, schema.AddAttributes(vAttr))
-	array, err := NewArray(tdbCtx, arrPath)
-	require.NoError(t, err)
-	require.NoError(t, array.Create(schema))
+	require.NoError(t, CreateArray(tdbCtx, arrPath, schema))
 	return arrPath
 }
 
@@ -331,9 +329,7 @@ func createSparse2dTable(t *testing.T) string {
 	vAttr, err := NewAttribute(tdbCtx, "v", TILEDB_UINT16)
 	require.NoError(t, err)
 	require.NoError(t, schema.AddAttributes(vAttr))
-	array, err := NewArray(tdbCtx, arrPath)
-	require.NoError(t, err)
-	require.NoError(t, array.Create(schema))
+	require.NoError(t, CreateArray(tdbCtx, arrPath, schema))
 	return arrPath
 }
 


### PR DESCRIPTION
[SC-64187](https://app.shortcut.com/tiledb-inc/story/64187/add-standalone-apis-to-create-arrays-and-groups)

This PR adds the following functions to TileDB-Go:

```go
func CreateArray(context *tiledb.Context, uri string, schema *tiledb.ArraySchema) error

func CreateGroup(context *tiledb.Context, uri string)

func ConsolidateArray(tdbCtx *Context, uri string, config *Config) error

func VacuumArray(tdbCtx *Context, uri string, config *Config) error
```

Before that, in order to create an array or a group, or consolidate or vacuum an array, you had to first allocate an object with the `New***` function. This is inconsistent with what the C API exposes and what other APIs do.

The changes themselves are pretty straightforward; the majority of changes in this PR are to update all tests and examples to use the new APIs.