### PR TITLE
Update to golang 1.24.

### DIFF
--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.24", "1.25"]
+        go: ["1.23", "1.24"]
     steps:
 
     # Checks out repository
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.24", "1.25"]
+        go: ["1.23", "1.24"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.24", "1.25"]
+        go: ["1.23", "1.24"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v4

--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.22", "1.23"]
+        go: ["1.24", "1.25"]
     steps:
 
     # Checks out repository
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.22", "1.23"]
+        go: ["1.24", "1.25"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.22", "1.23"]
+        go: ["1.24", "1.25"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v4

--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.23", "1.24"]
+        go: ["1.24"]
     steps:
 
     # Checks out repository
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.23", "1.24"]
+        go: ["1.24"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.23", "1.24"]
+        go: ["1.24"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v4

--- a/array.go
+++ b/array.go
@@ -71,7 +71,7 @@ func NewArray(tdbCtx *Context, uri string) (*Array, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb array: %w", array.context.LastError())
 	}
-	freeOnGC(&array)
+	runtime.AddCleanup(&array, freeFreeable, Freeable(&array))
 
 	return &array, nil
 }
@@ -269,7 +269,7 @@ func (a *Array) Schema() (*ArraySchema, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting schema for tiledb array: %w", a.context.LastError())
 	}
-	freeOnGC(&arraySchema)
+	runtime.AddCleanup(&arraySchema, freeFreeable, Freeable(&arraySchema))
 	return &arraySchema, nil
 }
 
@@ -1175,7 +1175,7 @@ func (a *Array) Config() (*Config, error) {
 		return nil, fmt.Errorf("error getting config from array: %w", a.context.LastError())
 	}
 
-	freeOnGC(&config)
+	runtime.AddCleanup(&config, freeFreeable, Freeable(&config))
 
 	if a.config == nil {
 		a.config = &config

--- a/array_experimental.go
+++ b/array_experimental.go
@@ -31,7 +31,7 @@ func GetConsolidationPlan(arr *Array, fragmentSize uint64) (*ConsolidationPlan, 
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting consolidation plan for array: %w", cp.context.LastError())
 	}
-	freeOnGC(cp)
+	runtime.AddCleanup(cp, freeFreeable, Freeable(cp))
 
 	return cp, nil
 }

--- a/array_schema.go
+++ b/array_schema.go
@@ -102,7 +102,7 @@ func NewArraySchema(tdbCtx *Context, arrayType ArrayType) (*ArraySchema, error) 
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb arraySchema: %w", arraySchema.context.LastError())
 	}
-	freeOnGC(&arraySchema)
+	runtime.AddCleanup(&arraySchema, freeFreeable, Freeable(&arraySchema))
 	return &arraySchema, nil
 }
 
@@ -153,7 +153,7 @@ func (a *ArraySchema) AttributeFromIndex(index uint) (*Attribute, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting attribute %d for tiledb arraySchema: %w", index, a.context.LastError())
 	}
-	freeOnGC(&attr)
+	runtime.AddCleanup(&attr, freeFreeable, Freeable(&attr))
 	return &attr, nil
 }
 
@@ -169,7 +169,7 @@ func (a *ArraySchema) AttributeFromName(attrName string) (*Attribute, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting attribute %s for tiledb arraySchema: %w", attrName, a.context.LastError())
 	}
-	freeOnGC(&attr)
+	runtime.AddCleanup(&attr, freeFreeable, Freeable(&attr))
 	return &attr, nil
 }
 
@@ -265,7 +265,7 @@ func (a *ArraySchema) Domain() (*Domain, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error setting domain for tiledb arraySchema: %w", a.context.LastError())
 	}
-	freeOnGC(&domain)
+	runtime.AddCleanup(&domain, freeFreeable, Freeable(&domain))
 	return &domain, nil
 }
 
@@ -351,7 +351,7 @@ func (a *ArraySchema) CoordsFilterList() (*FilterList, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting coordinates filter list for tiledb arraySchema: %w", a.context.LastError())
 	}
-	freeOnGC(&filterList)
+	runtime.AddCleanup(&filterList, freeFreeable, Freeable(&filterList))
 	return &filterList, nil
 }
 
@@ -376,7 +376,7 @@ func (a *ArraySchema) OffsetsFilterList() (*FilterList, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting offsets filter list for tiledb arraySchema: %w", a.context.LastError())
 	}
-	freeOnGC(&filterList)
+	runtime.AddCleanup(&filterList, freeFreeable, Freeable(&filterList))
 	return &filterList, nil
 }
 
@@ -400,7 +400,7 @@ func LoadArraySchema(context *Context, path string) (*ArraySchema, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error in loading arraySchema from %s: %w", path, a.context.LastError())
 	}
-	freeOnGC(&a)
+	runtime.AddCleanup(&a, freeFreeable, Freeable(&a))
 	return &a, nil
 }
 

--- a/array_schema_evolution_experimental.go
+++ b/array_schema_evolution_experimental.go
@@ -29,7 +29,7 @@ func NewArraySchemaEvolution(tdbCtx *Context) (*ArraySchemaEvolution, error) {
 		return nil, fmt.Errorf("error creating tiledb arraySchemaEvolution: %w",
 			arraySchemaEvolution.context.LastError())
 	}
-	freeOnGC(&arraySchemaEvolution)
+	runtime.AddCleanup(&arraySchemaEvolution, freeFreeable, Freeable(&arraySchemaEvolution))
 
 	return &arraySchemaEvolution, nil
 }

--- a/attribute.go
+++ b/attribute.go
@@ -38,7 +38,7 @@ func NewAttribute(context *Context, name string, datatype Datatype) (*Attribute,
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb attribute: %w", context.LastError())
 	}
-	freeOnGC(&attribute)
+	runtime.AddCleanup(&attribute, freeFreeable, Freeable(&attribute))
 
 	return &attribute, nil
 }
@@ -78,7 +78,7 @@ func (a *Attribute) FilterList() (*FilterList, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb attribute filter list: %w", a.context.LastError())
 	}
-	freeOnGC(&filterList)
+	runtime.AddCleanup(&filterList, freeFreeable, Freeable(&filterList))
 
 	return &filterList, nil
 }

--- a/buffer.go
+++ b/buffer.go
@@ -35,7 +35,7 @@ func NewBuffer(context *Context) (*Buffer, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb buffer: %w", buffer.context.LastError())
 	}
-	freeOnGC(&buffer)
+	runtime.AddCleanup(&buffer, freeFreeable, Freeable(&buffer))
 
 	return &buffer, nil
 }

--- a/buffer_list.go
+++ b/buffer_list.go
@@ -26,7 +26,7 @@ func NewBufferList(context *Context) (*BufferList, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb buffer list: %w", bufferList.context.LastError())
 	}
-	freeOnGC(&bufferList)
+	runtime.AddCleanup(&bufferList, freeFreeable, Freeable(&bufferList))
 
 	return &bufferList, nil
 }
@@ -99,7 +99,7 @@ func (b *BufferList) GetBuffer(bufferIndex uint) (*Buffer, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb buffer index %d from buffer list: %w", bufferIndex, b.context.LastError())
 	}
-	freeOnGC(&buffer)
+	runtime.AddCleanup(&buffer, freeFreeable, Freeable(&buffer))
 
 	return &buffer, nil
 }
@@ -129,7 +129,7 @@ func (b *BufferList) Flatten() (*Buffer, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb bufferList num buffers: %w", b.context.LastError())
 	}
-	freeOnGC(&buffer)
+	runtime.AddCleanup(&buffer, freeFreeable, Freeable(&buffer))
 
 	return &buffer, nil
 }

--- a/config.go
+++ b/config.go
@@ -27,7 +27,7 @@ func NewConfig() (*Config, error) {
 		defer C.tiledb_error_free(&err)
 		return nil, fmt.Errorf("error creating tiledb config: %w", cError(err))
 	}
-	freeOnGC(&config)
+	runtime.AddCleanup(&config, freeFreeable, Freeable(&config))
 
 	return &config, nil
 }
@@ -123,7 +123,7 @@ func LoadConfig(uri string) (*Config, error) {
 		defer C.tiledb_error_free(&err)
 		return nil, fmt.Errorf("error loading config from file %s: %w", uri, cError(err))
 	}
-	freeOnGC(&config)
+	runtime.AddCleanup(&config, freeFreeable, Freeable(&config))
 
 	return &config, nil
 }

--- a/config_iter.go
+++ b/config_iter.go
@@ -31,7 +31,7 @@ func NewConfigIter(config *Config, prefix string) (*ConfigIter, error) {
 		defer C.tiledb_error_free(&err)
 		return nil, fmt.Errorf("error creating tiledb config iter: %w", cError(err))
 	}
-	freeOnGC(&ci)
+	runtime.AddCleanup(&ci, freeFreeable, Freeable(&ci))
 
 	return &ci, nil
 }

--- a/context.go
+++ b/context.go
@@ -48,7 +48,7 @@ func NewContext(config *Config) (*Context, error) {
 		}
 		return nil, fmt.Errorf("error creating tiledb context: unknown error")
 	}
-	freeOnGC(&context)
+	runtime.AddCleanup(&context, freeFreeable, Freeable(&context))
 
 	err := context.setDefaultTags()
 	if err != nil {
@@ -112,7 +112,7 @@ func (c *Context) Config() (*Config, error) {
 	} else if ret != C.TILEDB_OK {
 		return nil, errors.New("unknown error in GetConfig")
 	}
-	freeOnGC(&config)
+	runtime.AddCleanup(&config, freeFreeable, Freeable(&config))
 
 	return &config, nil
 }

--- a/dimension.go
+++ b/dimension.go
@@ -238,7 +238,7 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb dimension: %w", context.LastError())
 	}
-	freeOnGC(&dimension)
+	runtime.AddCleanup(&dimension, freeFreeable, Freeable(&dimension))
 
 	return &dimension, nil
 }
@@ -259,7 +259,7 @@ func NewStringDimension(context *Context, name string) (*Dimension, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb dimension: %w", context.LastError())
 	}
-	freeOnGC(&dimension)
+	runtime.AddCleanup(&dimension, freeFreeable, Freeable(&dimension))
 
 	return &dimension, nil
 }
@@ -299,7 +299,7 @@ func (d *Dimension) FilterList() (*FilterList, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb dimension filter list: %w", d.context.LastError())
 	}
-	freeOnGC(&filterList)
+	runtime.AddCleanup(&filterList, freeFreeable, Freeable(&filterList))
 
 	return &filterList, nil
 }

--- a/dimension_label_experimental.go
+++ b/dimension_label_experimental.go
@@ -130,7 +130,7 @@ func (a *ArraySchema) AddDimensionLabel(dimIndex uint32, name string, order Data
 	return nil
 }
 
-// DimensionLabelFromName retrieves a dimension label from an array schema with the requested index.
+// DimensionLabelFromIndex retrieves a dimension label from an array schema with the requested index.
 func (a *ArraySchema) DimensionLabelFromIndex(labelIdx uint64) (*DimensionLabel, error) {
 	dimLabel := DimensionLabel{context: a.context}
 	ret := C.tiledb_array_schema_get_dimension_label_from_index(a.context.tiledbContext, a.tiledbArraySchema,
@@ -140,7 +140,7 @@ func (a *ArraySchema) DimensionLabelFromIndex(labelIdx uint64) (*DimensionLabel,
 		return nil, fmt.Errorf("error getting dimension label '%d' for ArraySchema: %w", labelIdx, a.context.LastError())
 	}
 
-	freeOnGC(&dimLabel)
+	runtime.AddCleanup(&dimLabel, freeFreeable, Freeable(&dimLabel))
 	return &dimLabel, nil
 }
 
@@ -156,7 +156,7 @@ func (a *ArraySchema) DimensionLabelFromName(name string) (*DimensionLabel, erro
 		return nil, fmt.Errorf("error getting dimension label '%s' for ArraySchema: %w", name, a.context.LastError())
 	}
 
-	freeOnGC(&dimLabel)
+	runtime.AddCleanup(&dimLabel, freeFreeable, Freeable(&dimLabel))
 	return &dimLabel, nil
 }
 

--- a/domain.go
+++ b/domain.go
@@ -30,7 +30,7 @@ func NewDomain(tdbCtx *Context) (*Domain, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb domain: %w", domain.context.LastError())
 	}
-	freeOnGC(&domain)
+	runtime.AddCleanup(&domain, freeFreeable, Freeable(&domain))
 
 	return &domain, nil
 }
@@ -84,7 +84,7 @@ func (d *Domain) DimensionFromIndex(index uint) (*Dimension, error) {
 	}
 
 	dimension := Dimension{tiledbDimension: dim, context: d.context}
-	freeOnGC(&dimension)
+	runtime.AddCleanup(&dimension, freeFreeable, Freeable(&dimension))
 
 	return &dimension, nil
 }
@@ -100,7 +100,7 @@ func (d *Domain) DimensionFromName(name string) (*Dimension, error) {
 		return nil, fmt.Errorf("error getting tiledb dimension by name for domain: %w", d.context.LastError())
 	}
 	dimension := Dimension{tiledbDimension: dim, context: d.context}
-	freeOnGC(&dimension)
+	runtime.AddCleanup(&dimension, freeFreeable, Freeable(&dimension))
 	return &dimension, nil
 }
 

--- a/examples/array_metadata_test.go
+++ b/examples/array_metadata_test.go
@@ -42,9 +42,9 @@ import (
 	"github.com/TileDB-Inc/TileDB-Go/examples_lib"
 )
 
-// ExampleArrayMetadataArray shows and example creation, writing and reading of a
-// sparse array
-func ExampleArrayMetadataArray() {
+// ExampleRunArrayMetadataArray shows an example of creation, writing, and
+// reading of a sparse array
+func ExampleRunArrayMetadataArray() {
 	examples_lib.RunArrayMetadataArray()
 
 	// Output: Datatype: 0

--- a/examples/config_test.go
+++ b/examples/config_test.go
@@ -39,6 +39,6 @@ import (
 	"github.com/TileDB-Inc/TileDB-Go/examples_lib"
 )
 
-func ExampleConfig() {
+func ExampleRunConfig() {
 	examples_lib.RunConfig()
 }

--- a/examples/deserialize_sparse_layouts_test.go
+++ b/examples/deserialize_sparse_layouts_test.go
@@ -34,7 +34,7 @@ package examples
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
 // ToDo: Add proper test for deserialization
-func ExampleDeserializeSparseLayouts() {
+func ExampleRunDeserializeSparseLayouts() {
 	examples_lib.RunDeserializeSparseLayouts()
 
 	// Output: [1 2]

--- a/examples/dimension_labels_test.go
+++ b/examples/dimension_labels_test.go
@@ -2,7 +2,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleDimensionLabels() {
+func ExampleRunDimensionLabels() {
 	examples_lib.RunDimensionLabels()
 
 	// Output: 33 34 65 66 0

--- a/examples/encryption_test.go
+++ b/examples/encryption_test.go
@@ -39,7 +39,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleEncryptedArray() {
+func ExampleRunEncryptedArray() {
 	examples_lib.RunEncryptedArray()
 
 	// Output: [2 3 4 6 7 8]

--- a/examples/filestore_test.go
+++ b/examples/filestore_test.go
@@ -2,7 +2,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleFilestore() {
+func ExampleRunFilestore() {
 	examples_lib.RunFilestore()
 
 	// Output: Hello World

--- a/examples/filters_test.go
+++ b/examples/filters_test.go
@@ -41,9 +41,9 @@ import (
 	"github.com/TileDB-Inc/TileDB-Go/examples_lib"
 )
 
-// ExampleSparseArray shows and example creation, writing and reading of a
-// sparse array
-func ExampleFiltersArray() {
+// ExampleRunFiltersArray shows an example of creation, writing, and reading
+// of an array using Filters
+func ExampleRunFiltersArray() {
 	examples_lib.RunFiltersArray()
 
 	// Output: Cell (2, 3) has data 3

--- a/examples/fragments_consolidation_test.go
+++ b/examples/fragments_consolidation_test.go
@@ -39,7 +39,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleFragmentsConsolidationArray() {
+func ExampleRunFragmentsConsolidationArray() {
 	examples_lib.RunFragmentsConsolidationArray()
 
 	// Output: Num of fragments: 1

--- a/examples/multi_attribute_test.go
+++ b/examples/multi_attribute_test.go
@@ -40,7 +40,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleMultiAttributeArray() {
+func ExampleRunMultiAttributeArray() {
 	examples_lib.RunMultiAttributeArray()
 
 	// Output: Reading both attributes a1 and a2:

--- a/examples/quickstart_dense_test.go
+++ b/examples/quickstart_dense_test.go
@@ -42,9 +42,9 @@ import (
 	"github.com/TileDB-Inc/TileDB-Go/examples_lib"
 )
 
-// ExampleDenseArray shows and example creation, writing and reading of a dense
-// array
-func ExampleDenseArray() {
+// ExampleRunDenseArray shows an example of creation, writing, and reading of
+// a dense array
+func ExampleRunDenseArray() {
 	examples_lib.RunDenseArray()
 
 	// Output: [2 3 4 6 7 8]

--- a/examples/quickstart_sparse_test.go
+++ b/examples/quickstart_sparse_test.go
@@ -40,9 +40,9 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-// ExampleSparseArray shows and example creation, writing and reading of a
-// sparse array
-func ExampleSparseArray() {
+// ExampleRunSparseArray shows an example of creating, writing, and reading of
+// a sparse array
+func ExampleRunSparseArray() {
 	examples_lib.RunSparseArray()
 
 	// Output: Estimated query size in bytes for attribute 'a': 12

--- a/examples/range_test.go
+++ b/examples/range_test.go
@@ -40,9 +40,9 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-// ExampleRange shows an example of creation, writing of a dense array
+// ExampleRunRange shows an example of creation, writing of a dense array
 // and usage of range functions
-func ExampleRange() {
+func ExampleRunRange() {
 	examples_lib.RunRange()
 
 	// Error adding query range: [TileDB::Dimension] Error: Cannot add range to dimension; Lower range bound 1065353216 cannot be larger than the higher bound 4

--- a/examples/reading_dense_layouts_test.go
+++ b/examples/reading_dense_layouts_test.go
@@ -40,7 +40,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleReadingDenseLayouts() {
+func ExampleRunReadingDenseLayouts() {
 	examples_lib.RunReadingDenseLayouts()
 
 	// Output: Non-empty domain: [1,4], [1,4]

--- a/examples/reading_incomplete_test.go
+++ b/examples/reading_incomplete_test.go
@@ -38,7 +38,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleReadingIncompleteArray() {
+func ExampleRunReadingIncompleteArray() {
 	examples_lib.RunReadingIncompleteArray()
 
 	// Output: Printing results...

--- a/examples/reading_query_conditions_test.go
+++ b/examples/reading_query_conditions_test.go
@@ -41,8 +41,8 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-// ExampleQueryConditionsArray shows how query conditions work
-func ExampleQueryConditionsArray() {
+// ExampleRunQueryConditionsArray shows how query conditions work
+func ExampleRunQueryConditionsArray() {
 	examples_lib.RunQueryConditionsArray()
 	// Output: Non-empty domain: [1,2], [1,4]
 	// Cell (1, 2) has data 2

--- a/examples/reading_range_test.go
+++ b/examples/reading_range_test.go
@@ -40,9 +40,9 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-// ExampleReadRangeArray shows and example creation, writing and range reading
-// of a dense array
-func ExampleReadRangeArray() {
+// ExampleRunReadRangeArray shows an example of creation, writing, and range
+// reading of a dense array
+func ExampleRunReadRangeArray() {
 	examples_lib.RunReadRangeArray()
 
 	// Output: Num of Ranges: 2

--- a/examples/reading_sparse_layouts_test.go
+++ b/examples/reading_sparse_layouts_test.go
@@ -40,7 +40,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleReadingSparseLayouts() {
+func ExampleRunReadingSparseLayouts() {
 	examples_lib.RunReadingSparseLayouts()
 
 	// Output: Non-empty domain: [1,2], [1,4]

--- a/examples/reading_timestamp_test.go
+++ b/examples/reading_timestamp_test.go
@@ -41,8 +41,8 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-// ExampleTimestampArray shows timestamp correlation of written data and metadata
-func ExampleTimestampArray() {
+// ExampleRunTimestampArray shows timestamp correlation of written data and metadata
+func ExampleRunTimestampArray() {
 	examples_lib.RunTimestampArray()
 
 	// Output: Writing meta_key: Write1

--- a/examples/string_dim_test.go
+++ b/examples/string_dim_test.go
@@ -36,9 +36,9 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-// ExampleStringDimArray shows an example of creation, writing and reading of a
-// sparse array with string dim
-func ExampleStringDimArray() {
+// ExampleRunStringDimArray shows an example of creation, writing and reading
+// of a sparse array with string dim
+func ExampleRunStringDimArray() {
 	examples_lib.RunStringDimArray()
 
 	// Output: NonEmptyDomain Dimension Name: d

--- a/examples/using_tiledb_stats_test.go
+++ b/examples/using_tiledb_stats_test.go
@@ -39,6 +39,6 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleUsingTileDBStats() {
+func ExampleRunUsingTileDBStats() {
 	examples_lib.RunUsingTileDBStats()
 }

--- a/examples/vacuum_test.go
+++ b/examples/vacuum_test.go
@@ -29,7 +29,7 @@
  *
  * When run, this program will create a simple 2D sparse array, write some data
  * to it, write again and read num of fragments. Then read from array,
- * consolidate and again read num of fragmens. Then vacuum and read number of
+ * consolidate and again read num of fragments. Then vacuum and read number of
  * fragments.Finally will read from array to verify data read are the same as
  * in first read
  *
@@ -39,8 +39,8 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-// ExampleVacuumSparseArray shows ysage of array vacuum function
-func ExampleVacuumSparseArray() {
+// ExampleRunVacuumSparseArray shows usage of array vacuum function
+func ExampleRunVacuumSparseArray() {
 	examples_lib.RunVacuumSparseArray()
 
 	// Output: Estimated query size in bytes for attribute 'a': 12

--- a/examples/variable_length_test.go
+++ b/examples/variable_length_test.go
@@ -40,7 +40,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleVariableLengthArray() {
+func ExampleRunVariableLengthArray() {
 	examples_lib.RunVariableLengthArray()
 
 	// Output:

--- a/examples/vfs_test.go
+++ b/examples/vfs_test.go
@@ -2,7 +2,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleVfs() {
+func ExampleRunVfs() {
 	examples_lib.RunVfs()
 
 	// Output: Created 'dir_A'

--- a/examples/writing_dense_global_expansion_test.go
+++ b/examples/writing_dense_global_expansion_test.go
@@ -40,7 +40,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleWritingDenseGlobalExpansion() {
+func ExampleRunWritingDenseGlobalExpansion() {
 	examples_lib.RunWritingDenseGlobalExpansion()
 
 	// Output: [1 2 9 3 4 10 5 6 11 7 8 12]

--- a/examples/writing_dense_global_test.go
+++ b/examples/writing_dense_global_test.go
@@ -38,7 +38,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleWritingDenseGlobal() {
+func ExampleRunWritingDenseGlobal() {
 	examples_lib.RunWritingDenseGlobal()
 
 	// Output: [1 2 -2147483648 -2147483648 3 4 -2147483648 -2147483648 5 6 -2147483648 -2147483648 7 8 -2147483648 -2147483648]

--- a/examples/writing_dense_multiple_test.go
+++ b/examples/writing_dense_multiple_test.go
@@ -38,7 +38,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleWritingDenseMultiple() {
+func ExampleRunWritingDenseMultiple() {
 	examples_lib.RunWritingDenseMultiple()
 
 	// Output: [1 2 -2147483648 -2147483648 5 6 7 8 9 10 11 12 -2147483648 -2147483648 -2147483648 -2147483648]

--- a/examples/writing_dense_padding_test.go
+++ b/examples/writing_dense_padding_test.go
@@ -38,7 +38,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleWritingDensePadding() {
+func ExampleRunWritingDensePadding() {
 	examples_lib.RunWritingDensePadding()
 
 	// Output: [-2147483648 -2147483648 -2147483648 -2147483648 1 2 -2147483648 -2147483648 3 4 -2147483648 -2147483648 -2147483648 -2147483648 -2147483648 -2147483648]

--- a/examples/writing_dense_sparse_test.go
+++ b/examples/writing_dense_sparse_test.go
@@ -39,7 +39,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleWritingDenseSparse() {
+func ExampleRunWritingDenseSparse() {
 	examples_lib.RunWritingDenseSparse()
 
 	// Output: Cell (1, 2) has data 1

--- a/examples/writing_sparse_global_test.go
+++ b/examples/writing_sparse_global_test.go
@@ -39,7 +39,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleWritingSparseGlobal() {
+func ExampleRunWritingSparseGlobal() {
 	examples_lib.RunWritingSparseGlobal()
 
 	// Output: Cell (1, 1) has data 1

--- a/examples/writing_sparse_heter_dim_test.go
+++ b/examples/writing_sparse_heter_dim_test.go
@@ -36,9 +36,9 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-// ExampleSparseHeterDimArray shows and example creation, writing and reading of
-// a sparse array using heterogeneus dimensions
-func ExampleSparseHeterDimArray() {
+// ExampleRunSparseHeterDimArray shows an example of creation, writing, and
+// reading of a sparse array using heterogeneous dimensions
+func ExampleRunSparseHeterDimArray() {
 	examples_lib.RunSparseHeterDimArray()
 
 	// Output: Non-empty domain: [1.100000,1.400000], [1,4]

--- a/examples/writing_sparse_multiple_test.go
+++ b/examples/writing_sparse_multiple_test.go
@@ -39,7 +39,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleWritingSparseMultiple() {
+func ExampleRunWritingSparseMultiple() {
 	examples_lib.RunWritingSparseMultiple()
 
 	// Output: Cell (1, 1) has data 1

--- a/filestore_experimental.go
+++ b/filestore_experimental.go
@@ -14,7 +14,7 @@ import (
 	"unsafe"
 )
 
-// Size returns the uncompressed size of the array at arrayURI, which should have a filestore schema.
+// FileSize returns the uncompressed size of the array at arrayURI, which should have a filestore schema.
 func FileSize(tdbCtx *Context, arrayURI string) (int64, error) {
 	cArrayURI := C.CString(arrayURI)
 	defer C.free(unsafe.Pointer(cArrayURI))
@@ -170,7 +170,7 @@ func NewArraySchemaForFile(tdbCtx *Context, filePath string) (*ArraySchema, erro
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating schema: %w", tdbCtx.LastError())
 	}
-	freeOnGC(&arraySchema)
+	runtime.AddCleanup(&arraySchema, freeFreeable, Freeable(&arraySchema))
 
 	return &arraySchema, nil
 }

--- a/filter.go
+++ b/filter.go
@@ -28,7 +28,7 @@ func NewFilter(context *Context, filterType FilterType) (*Filter, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb filter: %w", filter.context.LastError())
 	}
-	freeOnGC(&filter)
+	runtime.AddCleanup(&filter, freeFreeable, Freeable(&filter))
 
 	return &filter, nil
 }

--- a/filter_list.go
+++ b/filter_list.go
@@ -26,7 +26,7 @@ func NewFilterList(context *Context) (*FilterList, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb FilterList: %w", filterList.context.LastError())
 	}
-	freeOnGC(&filterList)
+	runtime.AddCleanup(&filterList, freeFreeable, Freeable(&filterList))
 
 	return &filterList, nil
 }
@@ -99,7 +99,7 @@ func (f *FilterList) FilterFromIndex(index uint32) (*Filter, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error fetching filter for index %d from tiledb FilterList: %w", index, f.context.LastError())
 	}
-	freeOnGC(&filter)
+	runtime.AddCleanup(&filter, freeFreeable, Freeable(&filter))
 	return &filter, nil
 }
 

--- a/fragment_info.go
+++ b/fragment_info.go
@@ -38,7 +38,7 @@ func NewFragmentInfo(tdbCtx *Context, uri string) (*FragmentInfo, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb fragment info: %w", fI.context.LastError())
 	}
-	freeOnGC(&fI)
+	runtime.AddCleanup(&fI, freeFreeable, Freeable(&fI))
 
 	return &fI, nil
 }
@@ -629,7 +629,7 @@ func (fI *FragmentInfo) Config() (*Config, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting config from fragment info: %w", fI.context.LastError())
 	}
-	freeOnGC(&config)
+	runtime.AddCleanup(&config, freeFreeable, Freeable(&config))
 
 	if fI.config == nil {
 		fI.config = &config

--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,4 @@ require (
 // Local triggered panic when referencing enums
 retract v0.30.1
 
-go 1.22
+go 1.24

--- a/group.go
+++ b/group.go
@@ -31,7 +31,7 @@ func NewGroup(tdbCtx *Context, uri string) (*Group, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb group: %w", group.context.LastError())
 	}
-	freeOnGC(&group)
+	runtime.AddCleanup(&group, freeFreeable, Freeable(&group))
 
 	return &group, nil
 }
@@ -92,7 +92,7 @@ func (g *Group) Config() (*Config, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting config from query: %w", g.context.LastError())
 	}
-	freeOnGC(&config)
+	runtime.AddCleanup(&config, freeFreeable, Freeable(&config))
 
 	if g.config == nil {
 		g.config = &config

--- a/memory.go
+++ b/memory.go
@@ -1,7 +1,6 @@
 package tiledb
 
 import (
-	"runtime"
 	"unsafe"
 
 	// Much of this package relies on the fact that the Go GC is non-moving.
@@ -14,24 +13,6 @@ import (
 // to release its resources.
 type Freeable interface {
 	Free() // Releases non–garbage-collected resources held by this object.
-}
-
-// freeOnGC sets a finalizer on the provided object that will cause it to
-// automatically be Free'd when it is collected by the garbage collecter.
-// It should be included immediately after the err-check of the code which
-// creates it:
-//
-//	func NewThingy() (*Thingy, error) {
-//	  thingy := Thingy{}
-//	  ret := C.tiledb_make_thingy(&thingy)
-//	  if ret != C.TILEDB_OK {
-//	    return nil, errors.New("whatever")
-//	  }
-//	  freeOnGC(&thingy)  // <-- put this here
-//	  return &thingy, nil
-//	}
-func freeOnGC(obj Freeable) {
-	runtime.SetFinalizer(obj, freeFreeable)
 }
 
 // freeFreeable frees the Freeable. It's free-floating to avoid capturing

--- a/query.go
+++ b/query.go
@@ -72,7 +72,7 @@ func NewQuery(tdbCtx *Context, array *Array) (*Query, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb query: %w", query.context.LastError())
 	}
-	freeOnGC(&query)
+	runtime.AddCleanup(&query, freeFreeable, Freeable(&query))
 
 	query.resultBufferElements = make(map[string][3]*uint64)
 
@@ -687,7 +687,7 @@ func (q *Query) Array() (*Array, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting array from query: %w", q.context.LastError())
 	}
-	freeOnGC(&array)
+	runtime.AddCleanup(&array, freeFreeable, Freeable(&array))
 	return &array, nil
 }
 
@@ -713,7 +713,7 @@ func (q *Query) Config() (*Config, error) {
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting config from query: %w", q.context.LastError())
 	}
-	freeOnGC(&config)
+	runtime.AddCleanup(&config, freeFreeable, Freeable(&config))
 
 	if q.config == nil {
 		q.config = &config

--- a/query_condition.go
+++ b/query_condition.go
@@ -25,7 +25,7 @@ func NewQueryCondition(tdbCtx *Context, attributeName string, op QueryConditionO
 		return nil, fmt.Errorf("error allocating tiledb query condition: %w", qc.context.LastError())
 	}
 	runtime.KeepAlive(tdbCtx)
-	freeOnGC(&qc)
+	runtime.AddCleanup(&qc, freeFreeable, Freeable(&qc))
 
 	if err := qc.init(attributeName, value, op); err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func NewQueryConditionCombination(tdbCtx *Context, left *QueryCondition, op Quer
 	runtime.KeepAlive(tdbCtx)
 	runtime.KeepAlive(left)
 	runtime.KeepAlive(right)
-	freeOnGC(&qc)
+	runtime.AddCleanup(&qc, freeFreeable, Freeable(&qc))
 
 	return &qc, nil
 }
@@ -56,9 +56,9 @@ func NewQueryConditionNegated(tdbCtx *Context, qc *QueryCondition) (*QueryCondit
 	if ret := C.tiledb_query_condition_negate(qc.context.tiledbContext, qc.cond, &nqc.cond); ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error allocating tiledb query condition: %w", qc.context.LastError())
 	}
-	freeOnGC(&nqc)
 	runtime.KeepAlive(tdbCtx)
 	runtime.KeepAlive(qc)
+	runtime.AddCleanup(&nqc, freeFreeable, Freeable(&nqc))
 
 	return &nqc, nil
 }

--- a/serialize.go
+++ b/serialize.go
@@ -25,7 +25,7 @@ func SerializeArraySchemaToBuffer(schema *ArraySchema, serializationType Seriali
 	}
 
 	buffer := Buffer{context: schema.context}
-	freeOnGC(&buffer)
+	runtime.AddCleanup(&buffer, freeFreeable, Freeable(&buffer))
 
 	ret := C.tiledb_serialize_array_schema(schema.context.tiledbContext, schema.tiledbArraySchema, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	runtime.KeepAlive(schema)
@@ -68,7 +68,7 @@ func DeserializeArraySchema(buffer *Buffer, serializationType SerializationType,
 	// This needs to happen *after* the tiledb_deserialize_array_schema call
 	// because that may leave the arraySchema with a non-nil pointer
 	// to already-freed memory.
-	freeOnGC(&schema)
+	runtime.AddCleanup(&schema, freeFreeable, Freeable(&schema))
 
 	return &schema, nil
 }
@@ -83,7 +83,7 @@ func SerializeArraySchemaEvolutionToBuffer(arraySchemaEvolution *ArraySchemaEvol
 	}
 
 	buffer := Buffer{context: arraySchemaEvolution.context}
-	freeOnGC(&buffer)
+	runtime.AddCleanup(&buffer, freeFreeable, Freeable(&buffer))
 
 	ret := C.tiledb_serialize_array_schema_evolution(
 		arraySchemaEvolution.context.tiledbContext,
@@ -134,7 +134,7 @@ func DeserializeArraySchemaEvolution(buffer *Buffer, serializationType Serializa
 	// This needs to happen *after* the tiledb_deserialize_array_schema_evolution
 	// call because that may leave the schemaEvolution with a non-nil pointer
 	// to already-freed memory.
-	freeOnGC(&arraySchemaEvolution)
+	runtime.AddCleanup(&arraySchemaEvolution, freeFreeable, Freeable(&arraySchemaEvolution))
 
 	return &arraySchemaEvolution, nil
 }
@@ -167,7 +167,7 @@ func SerializeArrayNonEmptyDomainToBuffer(a *Array, serializationType Serializat
 	}
 
 	buffer := Buffer{context: schema.context}
-	freeOnGC(&buffer)
+	runtime.AddCleanup(&buffer, freeFreeable, Freeable(&buffer))
 
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
 	ret = C.tiledb_serialize_array_nonempty_domain(a.context.tiledbContext, a.tiledbArray, slicePtr(tmpDomain), isEmpty, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
@@ -279,7 +279,7 @@ func DeserializeArrayNonEmptyDomain(a *Array, buffer *Buffer, serializationType 
 func SerializeArrayNonEmptyDomainAllDimensionsToBuffer(a *Array, serializationType SerializationType) (*Buffer, error) {
 
 	buffer := Buffer{context: a.context}
-	freeOnGC(&buffer)
+	runtime.AddCleanup(&buffer, freeFreeable, Freeable(&buffer))
 
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
 	ret := C.tiledb_serialize_array_non_empty_domain_all_dimensions(a.context.tiledbContext, a.tiledbArray, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
@@ -319,7 +319,7 @@ func DeserializeArrayNonEmptyDomainAllDimensions(a *Array, buffer *Buffer, seria
 // SerializeQuery serializes a query.
 func SerializeQuery(query *Query, serializationType SerializationType, clientSide bool) (*BufferList, error) {
 	bufferList := BufferList{context: query.context}
-	freeOnGC(&bufferList)
+	runtime.AddCleanup(&bufferList, freeFreeable, Freeable(&bufferList))
 
 	var cClientSide C.int32_t
 	if clientSide {
@@ -359,7 +359,7 @@ func DeserializeQuery(query *Query, buffer *Buffer, serializationType Serializat
 // SerializeArrayMetadataToBuffer gets and serializes the array metadata and returns a Buffer object containing the payload.
 func SerializeArrayMetadataToBuffer(a *Array, serializationType SerializationType) (*Buffer, error) {
 	buffer := Buffer{context: a.context}
-	freeOnGC(&buffer)
+	runtime.AddCleanup(&buffer, freeFreeable, Freeable(&buffer))
 
 	ret := C.tiledb_serialize_array_metadata(a.context.tiledbContext, a.tiledbArray, C.tiledb_serialization_type_t(serializationType), &buffer.tiledbBuffer)
 	runtime.KeepAlive(a)
@@ -403,7 +403,7 @@ func SerializeQueryEstResultSizesToBuffer(q *Query, serializationType Serializat
 	}
 
 	buffer := Buffer{context: q.context}
-	freeOnGC(&buffer)
+	runtime.AddCleanup(&buffer, freeFreeable, Freeable(&buffer))
 
 	ret := C.tiledb_serialize_query_est_result_sizes(q.context.tiledbContext, q.tiledbQuery, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	runtime.KeepAlive(q)
@@ -455,7 +455,7 @@ func SerializeArrayToBuffer(array *Array, serializationType SerializationType, c
 
 	buffer := Buffer{context: array.context}
 	// Set finalizer for free C pointer on gc
-	freeOnGC(&buffer)
+	runtime.AddCleanup(&buffer, freeFreeable, Freeable(&buffer))
 
 	ret := C.tiledb_serialize_array(array.context.tiledbContext, array.tiledbArray, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	runtime.KeepAlive(array)
@@ -503,7 +503,7 @@ func DeserializeArray(buffer *Buffer, serializationType SerializationType, clien
 	// This needs to happen *after* the tiledb_deserialize_array call
 	// because that may leave the array with a non-nil pointer
 	// to already-freed memory.
-	freeOnGC(&array)
+	runtime.AddCleanup(&array, freeFreeable, Freeable(&array))
 
 	return &array, nil
 }
@@ -519,7 +519,7 @@ func SerializeFragmentInfoToBuffer(fragmentInfo *FragmentInfo, serializationType
 
 	buffer := Buffer{context: fragmentInfo.context}
 	// Set finalizer for free C pointer on gc
-	freeOnGC(&buffer)
+	runtime.AddCleanup(&buffer, freeFreeable, Freeable(&buffer))
 
 	ret := C.tiledb_serialize_fragment_info(fragmentInfo.context.tiledbContext, fragmentInfo.tiledbFragmentInfo, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	runtime.KeepAlive(fragmentInfo)
@@ -575,7 +575,7 @@ func SerializeFragmentInfoRequestToBuffer(fragmentInfo *FragmentInfo, serializat
 
 	buffer := Buffer{context: fragmentInfo.context}
 	// Set finalizer for free C pointer on gc
-	freeOnGC(&buffer)
+	runtime.AddCleanup(&buffer, freeFreeable, Freeable(&buffer))
 
 	ret := C.tiledb_serialize_fragment_info_request(fragmentInfo.context.tiledbContext, fragmentInfo.tiledbFragmentInfo, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	runtime.KeepAlive(fragmentInfo)
@@ -642,8 +642,8 @@ func DeserializeQueryAndArray(context *Context, buffer *Buffer, serializationTyp
 		return nil, nil, fmt.Errorf("error deserializing query: %w", context.LastError())
 	}
 
-	freeOnGC(array)
-	freeOnGC(query)
+	runtime.AddCleanup(array, freeFreeable, Freeable(array))
+	runtime.AddCleanup(query, freeFreeable, Freeable(query))
 
 	query.resultBufferElements = make(map[string][3]*uint64)
 
@@ -655,7 +655,7 @@ func DeserializeQueryAndArray(context *Context, buffer *Buffer, serializationTyp
 // SerializeGroupMetadata gets and serializes the group metadata and returns a Buffer object containing the payload
 func SerializeGroupMetadataToBuffer(g *Group, serializationType SerializationType) (*Buffer, error) {
 	buffer := Buffer{context: g.context}
-	freeOnGC(&buffer)
+	runtime.AddCleanup(&buffer, freeFreeable, Freeable(&buffer))
 
 	ret := C.tiledb_serialize_group_metadata(g.context.tiledbContext, g.group, C.tiledb_serialization_type_t(serializationType), &buffer.tiledbBuffer)
 	runtime.KeepAlive(g)

--- a/subarray.go
+++ b/subarray.go
@@ -29,7 +29,7 @@ func (a *Array) NewSubarray() (*Subarray, error) {
 	}
 
 	subarray := &Subarray{array: a, subarray: sa, context: a.context}
-	freeOnGC(subarray)
+	runtime.AddCleanup(subarray, freeFreeable, Freeable(subarray))
 
 	return subarray, nil
 }


### PR DESCRIPTION
This updates to golang 1.24 and converts usages of `runtime.SetFinalizer` to `runtime.AddCleanup`.