### PR TITLE
Refactor handle management.

### DIFF
--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.22", "1.23"]
+        go: ["1.22", "1.23", "1.24"]
     steps:
 
     # Checks out repository
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.22", "1.23"]
+        go: ["1.22", "1.23", "1.24"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        go: ["1.22", "1.23"]
+        go: ["1.22", "1.23", "1.24"]
     steps:
     # Checks out repository
     - uses: actions/checkout@v4

--- a/array.go
+++ b/array.go
@@ -23,7 +23,7 @@ e.g. on disk, in an S3 bucket, etc. Once an array has been opened for reading
 or writing, interact with the data through Query objects.
 */
 type Array struct {
-	tiledbArray *capiHandle[C.tiledb_array_t]
+	tiledbArray arrayHandle
 	context     *Context
 	uri         string
 	config      *Config
@@ -54,7 +54,7 @@ type NonEmptyDomain struct {
 	Bounds        interface{}
 }
 
-func newArrayFromHandle(tdbCtx *Context, arrayHandle *capiHandle[C.tiledb_array_t]) *Array {
+func newArrayFromHandle(tdbCtx *Context, arrayHandle arrayHandle) *Array {
 	return &Array{context: tdbCtx, tiledbArray: arrayHandle}
 }
 

--- a/array.go
+++ b/array.go
@@ -15,6 +15,18 @@ import (
 	"unsafe"
 )
 
+type arrayHandle struct{ *capiHandle }
+
+func freeCapiArray(c unsafe.Pointer) { C.tiledb_array_free((**C.tiledb_array_t)(unsafe.Pointer(&c))) }
+
+func newArrayHandle(ptr *C.tiledb_array_t) arrayHandle {
+	return arrayHandle{newCapiHandle(unsafe.Pointer(ptr), freeCapiArray)}
+}
+
+func (x arrayHandle) Get() *C.tiledb_array_t {
+	return (*C.tiledb_array_t)(x.capiHandle.Get())
+}
+
 /*
 Array struct representing a TileDB array object.
 

--- a/array.go
+++ b/array.go
@@ -82,7 +82,7 @@ func NewArray(tdbCtx *Context, uri string) (*Array, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var arrayPtr *C.tiledb_array_t
-	ret := C.tiledb_array_alloc(tdbCtx.tiledbContext, curi, &arrayPtr)
+	ret := C.tiledb_array_alloc(tdbCtx.tiledbContext.Get(), curi, &arrayPtr)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb array: %w", tdbCtx.LastError())
 	}
@@ -130,7 +130,7 @@ func WithStartTime(start time.Time) ArrayOpenOption {
 // WithEndTimestamp sets the subsequent Open call to use the end_timestamp of the passed value.
 func WithEndTimestamp(endTimestamp uint64) ArrayOpenOption {
 	return func(tdbArray *Array) error {
-		ret := C.tiledb_array_set_open_timestamp_end(tdbArray.context.tiledbContext, tdbArray.tiledbArray.Get(), C.uint64_t(endTimestamp))
+		ret := C.tiledb_array_set_open_timestamp_end(tdbArray.context.tiledbContext.Get(), tdbArray.tiledbArray.Get(), C.uint64_t(endTimestamp))
 		runtime.KeepAlive(tdbArray)
 		if ret != C.TILEDB_OK {
 			return fmt.Errorf("error setting end timestamp option: %w", tdbArray.context.LastError())
@@ -142,7 +142,7 @@ func WithEndTimestamp(endTimestamp uint64) ArrayOpenOption {
 // WithStartTimestamp sets the subsequent Open call to use the start_timestamp of the passed value.
 func WithStartTimestamp(startTimestamp uint64) ArrayOpenOption {
 	return func(tdbArray *Array) error {
-		ret := C.tiledb_array_set_open_timestamp_start(tdbArray.context.tiledbContext, tdbArray.tiledbArray.Get(), C.uint64_t(startTimestamp))
+		ret := C.tiledb_array_set_open_timestamp_start(tdbArray.context.tiledbContext.Get(), tdbArray.tiledbArray.Get(), C.uint64_t(startTimestamp))
 		runtime.KeepAlive(tdbArray)
 		if ret != C.TILEDB_OK {
 			return fmt.Errorf("error setting start timestamp option: %w", tdbArray.context.LastError())
@@ -168,7 +168,7 @@ func (a *Array) OpenWithOptions(queryType QueryType, opts ...ArrayOpenOption) er
 		}
 	}
 
-	ret := C.tiledb_array_open(a.context.tiledbContext, a.tiledbArray.Get(), C.tiledb_query_type_t(queryType))
+	ret := C.tiledb_array_open(a.context.tiledbContext.Get(), a.tiledbArray.Get(), C.tiledb_query_type_t(queryType))
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error opening tiledb array for querying: %w", a.context.LastError())
@@ -187,7 +187,7 @@ array_read for reads and another one array_write for writes, and interleave
 creation and submission of queries for both these array objects.
 */
 func (a *Array) Open(queryType QueryType) error {
-	ret := C.tiledb_array_open(a.context.tiledbContext, a.tiledbArray.Get(), C.tiledb_query_type_t(queryType))
+	ret := C.tiledb_array_open(a.context.tiledbContext.Get(), a.tiledbArray.Get(), C.tiledb_query_type_t(queryType))
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error opening tiledb array for querying: %w", a.context.LastError())
@@ -203,7 +203,7 @@ with open(), or just use reopen() without closing. This function will be
 generally faster than the former alternative.
 */
 func (a *Array) Reopen() error {
-	ret := C.tiledb_array_reopen(a.context.tiledbContext, a.tiledbArray.Get())
+	ret := C.tiledb_array_reopen(a.context.tiledbContext.Get(), a.tiledbArray.Get())
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error reopening tiledb array for querying: %w", a.context.LastError())
@@ -213,7 +213,7 @@ func (a *Array) Reopen() error {
 
 // Close closes a tiledb array. This is automatically called on garbage collection.
 func (a *Array) Close() error {
-	ret := C.tiledb_array_close(a.context.tiledbContext, a.tiledbArray.Get())
+	ret := C.tiledb_array_close(a.context.tiledbContext.Get(), a.tiledbArray.Get())
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error closing tiledb array for querying: %w", a.context.LastError())
@@ -225,7 +225,7 @@ func (a *Array) Close() error {
 func (a *Array) Create(arraySchema *ArraySchema) error {
 	curi := C.CString(a.uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_array_create(a.context.tiledbContext, curi, arraySchema.tiledbArraySchema.Get())
+	ret := C.tiledb_array_create(a.context.tiledbContext.Get(), curi, arraySchema.tiledbArraySchema.Get())
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(arraySchema)
 	if ret != C.TILEDB_OK {
@@ -244,7 +244,7 @@ func (a *Array) Consolidate(config *Config) error {
 
 	curi := C.CString(a.uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_array_consolidate(a.context.tiledbContext, curi, config.tiledbConfig.Get())
+	ret := C.tiledb_array_consolidate(a.context.tiledbContext.Get(), curi, config.tiledbConfig.Get())
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(config)
 	if ret != C.TILEDB_OK {
@@ -263,7 +263,7 @@ func (a *Array) Vacuum(config *Config) error {
 
 	curi := C.CString(a.uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_array_vacuum(a.context.tiledbContext, curi, config.tiledbConfig.Get())
+	ret := C.tiledb_array_vacuum(a.context.tiledbContext.Get(), curi, config.tiledbConfig.Get())
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(config)
 	if ret != C.TILEDB_OK {
@@ -277,7 +277,7 @@ func (a *Array) Vacuum(config *Config) error {
 // Schema returns the ArraySchema for the array.
 func (a *Array) Schema() (*ArraySchema, error) {
 	var arraySchemaPtr *C.tiledb_array_schema_t
-	ret := C.tiledb_array_get_schema(a.context.tiledbContext, a.tiledbArray.Get(), &arraySchemaPtr)
+	ret := C.tiledb_array_get_schema(a.context.tiledbContext.Get(), a.tiledbArray.Get(), &arraySchemaPtr)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting schema for tiledb array: %w", a.context.LastError())
@@ -288,7 +288,7 @@ func (a *Array) Schema() (*ArraySchema, error) {
 // QueryType returns the current query type of an open array.
 func (a *Array) QueryType() (QueryType, error) {
 	var queryType C.tiledb_query_type_t
-	ret := C.tiledb_array_get_query_type(a.context.tiledbContext, a.tiledbArray.Get(), &queryType)
+	ret := C.tiledb_array_get_query_type(a.context.tiledbContext.Get(), a.tiledbArray.Get(), &queryType)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return -1, fmt.Errorf("error getting QueryType for tiledb array: %w", a.context.LastError())
@@ -324,7 +324,7 @@ func millisToTime(epochMillis uint64) time.Time {
 // OpenStartTimestamp returns the current start_timestamp value of an open array.
 func (a *Array) OpenStartTimestamp() (uint64, error) {
 	var start C.uint64_t
-	ret := C.tiledb_array_get_open_timestamp_start(a.context.tiledbContext, a.tiledbArray.Get(), &start)
+	ret := C.tiledb_array_get_open_timestamp_start(a.context.tiledbContext.Get(), a.tiledbArray.Get(), &start)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting start timestamp for tiledb array: %w", a.context.LastError())
@@ -335,7 +335,7 @@ func (a *Array) OpenStartTimestamp() (uint64, error) {
 // OpenEndTimestamp returns the current end_timestamp value of an open array.
 func (a *Array) OpenEndTimestamp() (uint64, error) {
 	var end C.uint64_t
-	ret := C.tiledb_array_get_open_timestamp_end(a.context.tiledbContext, a.tiledbArray.Get(), &end)
+	ret := C.tiledb_array_get_open_timestamp_end(a.context.tiledbContext.Get(), a.tiledbArray.Get(), &end)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting end timestamp for tiledb array: %w", a.context.LastError())
@@ -440,7 +440,7 @@ func (a *Array) NonEmptyDomain() ([]NonEmptyDomain, bool, error) {
 
 			var isEmpty C.int32_t
 			ret := C.tiledb_array_get_non_empty_domain_from_index(
-				a.context.tiledbContext,
+				a.context.tiledbContext.Get(),
 				a.tiledbArray.Get(),
 				(C.uint32_t)(dimIdx),
 				tmpDimensionPtr, &isEmpty)
@@ -538,7 +538,7 @@ func (a *Array) NonEmptyDomainMap() (map[string]interface{}, error) {
 
 			var isEmpty C.int32_t
 			ret := C.tiledb_array_get_non_empty_domain_from_index(
-				a.context.tiledbContext,
+				a.context.tiledbContext.Get(),
 				a.tiledbArray.Get(),
 				(C.uint32_t)(dimIdx),
 				tmpDimensionPtr, &isEmpty)
@@ -616,7 +616,7 @@ func (a *Array) NonEmptyDomainVarFromName(dimName string) (*NonEmptyDomain, bool
 	var cend unsafe.Pointer
 
 	ret := C.tiledb_array_get_non_empty_domain_var_size_from_name(
-		a.context.tiledbContext,
+		a.context.tiledbContext.Get(),
 		a.tiledbArray.Get(),
 		cDimName,
 		&cstartSize,
@@ -646,7 +646,7 @@ func (a *Array) NonEmptyDomainVarFromName(dimName string) (*NonEmptyDomain, bool
 	bounds = append(bounds, end)
 
 	ret = C.tiledb_array_get_non_empty_domain_var_from_name(
-		a.context.tiledbContext,
+		a.context.tiledbContext.Get(),
 		a.tiledbArray.Get(),
 		cDimName,
 		cstart,
@@ -708,7 +708,7 @@ func (a *Array) NonEmptyDomainVarFromIndex(dimIdx uint) (*NonEmptyDomain, bool, 
 	var cend unsafe.Pointer
 
 	ret := C.tiledb_array_get_non_empty_domain_var_size_from_index(
-		a.context.tiledbContext,
+		a.context.tiledbContext.Get(),
 		a.tiledbArray.Get(),
 		(C.uint32_t)(dimIdx),
 		&cstartSize,
@@ -738,7 +738,7 @@ func (a *Array) NonEmptyDomainVarFromIndex(dimIdx uint) (*NonEmptyDomain, bool, 
 	bounds = append(bounds, end)
 
 	ret = C.tiledb_array_get_non_empty_domain_var_from_index(
-		a.context.tiledbContext,
+		a.context.tiledbContext.Get(),
 		a.tiledbArray.Get(),
 		(C.uint32_t)(dimIdx),
 		cstart,
@@ -839,7 +839,7 @@ func (a *Array) NonEmptyDomainFromIndex(dimIdx uint) (*NonEmptyDomain, bool, err
 
 	var isEmpty C.int32_t
 	ret := C.tiledb_array_get_non_empty_domain_from_index(
-		a.context.tiledbContext,
+		a.context.tiledbContext.Get(),
 		a.tiledbArray.Get(),
 		(C.uint32_t)(dimIdx),
 		tmpDimensionPtr, &isEmpty)
@@ -874,7 +874,7 @@ func (a *Array) NonEmptyDomainFromName(dimName string) (*NonEmptyDomain, bool, e
 
 	var isEmpty C.int32_t
 	ret := C.tiledb_array_get_non_empty_domain_from_name(
-		a.context.tiledbContext,
+		a.context.tiledbContext.Get(),
 		a.tiledbArray.Get(),
 		cDimName,
 		tmpDimensionPtr, &isEmpty)
@@ -898,7 +898,7 @@ func (a *Array) NonEmptyDomainFromName(dimName string) (*NonEmptyDomain, bool, e
 // URI returns the array's uri.
 func (a *Array) URI() (string, error) {
 	var curi *C.char // a must be kept alive while curi is being accessed.
-	C.tiledb_array_get_uri(a.context.tiledbContext, a.tiledbArray.Get(), &curi)
+	C.tiledb_array_get_uri(a.context.tiledbContext.Get(), a.tiledbArray.Get(), &curi)
 	uri := C.GoString(curi)
 	runtime.KeepAlive(a)
 	if uri == "" {
@@ -915,7 +915,7 @@ func (a *Array) PutCharMetadata(key string, charData string) error {
 	var datatype Datatype = TILEDB_CHAR
 
 	valueNum := C.uint(len(charData))
-	ret := C.tiledb_array_put_metadata(a.context.tiledbContext, a.tiledbArray.Get(),
+	ret := C.tiledb_array_put_metadata(a.context.tiledbContext.Get(), a.tiledbArray.Get(),
 		ckey, C.tiledb_datatype_t(datatype), valueNum, unsafe.Pointer(&[]byte(charData)[0]))
 	runtime.KeepAlive(a)
 
@@ -1005,7 +1005,7 @@ func arrayPutMetadata(a *Array, dt Datatype, key string, valuePtr unsafe.Pointer
 	cKey := C.CString(key)
 	defer C.free(unsafe.Pointer(cKey))
 	ret := C.tiledb_array_put_metadata(
-		a.context.tiledbContext,
+		a.context.tiledbContext.Get(),
 		a.tiledbArray.Get(),
 		cKey,
 		C.tiledb_datatype_t(dt),
@@ -1025,7 +1025,7 @@ func (a *Array) DeleteMetadata(key string) error {
 	ckey := C.CString(key)
 	defer C.free(unsafe.Pointer(ckey))
 
-	ret := C.tiledb_array_delete_metadata(a.context.tiledbContext, a.tiledbArray.Get(), ckey)
+	ret := C.tiledb_array_delete_metadata(a.context.tiledbContext.Get(), a.tiledbArray.Get(), ckey)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deleting metadata from array: %w", a.context.LastError())
@@ -1043,7 +1043,7 @@ func (a *Array) GetMetadata(key string) (Datatype, uint, interface{}, error) {
 	var cValueNum C.uint
 	var cvalue unsafe.Pointer
 
-	ret := C.tiledb_array_get_metadata(a.context.tiledbContext, a.tiledbArray.Get(), ckey, &cType, &cValueNum, &cvalue)
+	ret := C.tiledb_array_get_metadata(a.context.tiledbContext.Get(), a.tiledbArray.Get(), ckey, &cType, &cValueNum, &cvalue)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, 0, nil, fmt.Errorf("error getting metadata from array: %w, key: %s", a.context.LastError(), key)
@@ -1068,7 +1068,7 @@ func (a *Array) GetMetadata(key string) (Datatype, uint, interface{}, error) {
 func (a *Array) GetMetadataNum() (uint64, error) {
 	var cNum C.uint64_t
 
-	ret := C.tiledb_array_get_metadata_num(a.context.tiledbContext, a.tiledbArray.Get(), &cNum)
+	ret := C.tiledb_array_get_metadata_num(a.context.tiledbContext.Get(), a.tiledbArray.Get(), &cNum)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting number of metadata from array: %w", a.context.LastError())
@@ -1099,7 +1099,7 @@ func (a *Array) GetMetadataFromIndexWithValueLimit(index uint64, limit *uint) (*
 	var cValueNum C.uint
 	var cvalue unsafe.Pointer
 
-	ret := C.tiledb_array_get_metadata_from_index(a.context.tiledbContext,
+	ret := C.tiledb_array_get_metadata_from_index(a.context.tiledbContext.Get(),
 		a.tiledbArray.Get(), cIndex, &cKey, &cKeyLen, &cType, &cValueNum, &cvalue)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
@@ -1166,7 +1166,7 @@ func (a *Array) GetMetadataMapWithValueLimit(limit *uint) (map[string]*ArrayMeta
 
 // SetConfig sets the array config.
 func (a *Array) SetConfig(config *Config) error {
-	ret := C.tiledb_array_set_config(a.context.tiledbContext, a.tiledbArray.Get(), config.tiledbConfig.Get())
+	ret := C.tiledb_array_set_config(a.context.tiledbContext.Get(), a.tiledbArray.Get(), config.tiledbConfig.Get())
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(config)
 	if ret != C.TILEDB_OK {
@@ -1179,7 +1179,7 @@ func (a *Array) SetConfig(config *Config) error {
 // Config gets the array config.
 func (a *Array) Config() (*Config, error) {
 	var configPtr *C.tiledb_config_t
-	ret := C.tiledb_array_get_config(a.context.tiledbContext, a.tiledbArray.Get(), &configPtr)
+	ret := C.tiledb_array_get_config(a.context.tiledbContext.Get(), a.tiledbArray.Get(), &configPtr)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting config from array: %w", a.context.LastError())
@@ -1193,7 +1193,7 @@ func DeleteFragments(tdbCtx *Context, uri string, startTimestamp, endTimestamp u
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 
-	ret := C.tiledb_array_delete_fragments_v2(tdbCtx.tiledbContext, curi,
+	ret := C.tiledb_array_delete_fragments_v2(tdbCtx.tiledbContext.Get(), curi,
 		C.uint64_t(startTimestamp), C.uint64_t(endTimestamp))
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
@@ -1211,7 +1211,7 @@ func DeleteFragmentsList(tdbCtx *Context, uri string, fragmentURIs []string) err
 	list, freeMemory := cStringArray(fragmentURIs)
 	defer freeMemory()
 
-	ret := C.tiledb_array_delete_fragments_list(tdbCtx.tiledbContext, curi, (**C.char)(slicePtr(list)), C.size_t(len(list)))
+	ret := C.tiledb_array_delete_fragments_list(tdbCtx.tiledbContext.Get(), curi, (**C.char)(slicePtr(list)), C.size_t(len(list)))
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deleting fragments list from array: %w", tdbCtx.LastError())

--- a/array_experimental.go
+++ b/array_experimental.go
@@ -26,7 +26,7 @@ func GetConsolidationPlan(arr *Array, fragmentSize uint64) (*ConsolidationPlan, 
 		context: arr.context,
 	}
 
-	ret := C.tiledb_consolidation_plan_create_with_mbr(cp.context.tiledbContext, arr.tiledbArray, C.uint64_t(fragmentSize), &cp.tiledbConsolidationPlan)
+	ret := C.tiledb_consolidation_plan_create_with_mbr(cp.context.tiledbContext, arr.tiledbArray.Get(), C.uint64_t(fragmentSize), &cp.tiledbConsolidationPlan)
 	runtime.KeepAlive(arr)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting consolidation plan for array: %w", cp.context.LastError())

--- a/array_experimental.go
+++ b/array_experimental.go
@@ -131,7 +131,7 @@ func (a *Array) ConsolidateFragments(config *Config, fragmentList []string) erro
 	list, freeMemory := cStringArray(fragmentList)
 	defer freeMemory()
 
-	ret := C.tiledb_array_consolidate_fragments(a.context.tiledbContext, curi, (**C.char)(slicePtr(list)), C.uint64_t(len(list)), config.tiledbConfig)
+	ret := C.tiledb_array_consolidate_fragments(a.context.tiledbContext, curi, (**C.char)(slicePtr(list)), C.uint64_t(len(list)), config.tiledbConfig.Get())
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error consolidating tiledb array fragment list: %w", a.context.LastError())

--- a/array_experimental.go
+++ b/array_experimental.go
@@ -13,27 +13,41 @@ import (
 	"unsafe"
 )
 
+type consolidationPlanHandle struct{ *capiHandle }
+
+func freeCapiConsolidationPlan(c unsafe.Pointer) {
+	C.tiledb_consolidation_plan_free((**C.tiledb_consolidation_plan_t)(unsafe.Pointer(&c)))
+}
+
+func newConsolidationPlanHandle(ptr *C.tiledb_consolidation_plan_t) consolidationPlanHandle {
+	return consolidationPlanHandle{newCapiHandle(unsafe.Pointer(ptr), freeCapiConsolidationPlan)}
+}
+
+func (x consolidationPlanHandle) Get() *C.tiledb_consolidation_plan_t {
+	return (*C.tiledb_consolidation_plan_t)(x.capiHandle.Get())
+}
+
 // ConsolidationPlan is a consolidation plan for array
 type ConsolidationPlan struct {
-	tiledbConsolidationPlan *C.tiledb_consolidation_plan_t
+	tiledbConsolidationPlan consolidationPlanHandle
 	context                 *Context
+}
+
+func newConsolidationPlanFromHandle(context *Context, handle consolidationPlanHandle) *ConsolidationPlan {
+	return &ConsolidationPlan{tiledbConsolidationPlan: handle, context: context}
 }
 
 // GetConsolidationPlan creates a consolidation plan for the already opened array.
 // The plan and the array will share the same tiledb context
 func GetConsolidationPlan(arr *Array, fragmentSize uint64) (*ConsolidationPlan, error) {
-	cp := &ConsolidationPlan{
-		context: arr.context,
-	}
-
-	ret := C.tiledb_consolidation_plan_create_with_mbr(cp.context.tiledbContext, arr.tiledbArray.Get(), C.uint64_t(fragmentSize), &cp.tiledbConsolidationPlan)
+	var consolidationPlanPtr *C.tiledb_consolidation_plan_t
+	ret := C.tiledb_consolidation_plan_create_with_mbr(arr.context.tiledbContext, arr.tiledbArray.Get(), C.uint64_t(fragmentSize), &consolidationPlanPtr)
 	runtime.KeepAlive(arr)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error getting consolidation plan for array: %w", cp.context.LastError())
+		return nil, fmt.Errorf("error getting consolidation plan for array: %w", arr.context.LastError())
 	}
-	freeOnGC(cp)
 
-	return cp, nil
+	return newConsolidationPlanFromHandle(arr.context, newConsolidationPlanHandle(consolidationPlanPtr)), nil
 }
 
 // Free releases the internal TileDB core data that was allocated on the C heap.
@@ -42,16 +56,14 @@ func GetConsolidationPlan(arr *Array, fragmentSize uint64) (*ConsolidationPlan, 
 // can safely be called many times on the same object; if it has already
 // been freed, it will not be freed again.
 func (cp *ConsolidationPlan) Free() {
-	if cp.tiledbConsolidationPlan != nil {
-		C.tiledb_consolidation_plan_free(&cp.tiledbConsolidationPlan)
-	}
+	cp.tiledbConsolidationPlan.Free()
 }
 
 // NumNodes returns the number of nodes for the plan
 func (cp *ConsolidationPlan) NumNodes() (uint64, error) {
 	var numNodes C.uint64_t
 
-	ret := C.tiledb_consolidation_plan_get_num_nodes(cp.context.tiledbContext, cp.tiledbConsolidationPlan, &numNodes)
+	ret := C.tiledb_consolidation_plan_get_num_nodes(cp.context.tiledbContext, cp.tiledbConsolidationPlan.Get(), &numNodes)
 	runtime.KeepAlive(cp)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting consolidation plan num nodes: %w", cp.context.LastError())
@@ -64,7 +76,7 @@ func (cp *ConsolidationPlan) NumNodes() (uint64, error) {
 func (cp *ConsolidationPlan) NumFragments(nodeIndex uint64) (uint64, error) {
 	var numFragments C.uint64_t
 
-	ret := C.tiledb_consolidation_plan_get_num_fragments(cp.context.tiledbContext, cp.tiledbConsolidationPlan, C.uint64_t(nodeIndex), &numFragments)
+	ret := C.tiledb_consolidation_plan_get_num_fragments(cp.context.tiledbContext, cp.tiledbConsolidationPlan.Get(), C.uint64_t(nodeIndex), &numFragments)
 	runtime.KeepAlive(cp)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting consolidation plan num fragments: %w", cp.context.LastError())
@@ -77,7 +89,7 @@ func (cp *ConsolidationPlan) NumFragments(nodeIndex uint64) (uint64, error) {
 func (cp *ConsolidationPlan) FragmentURI(nodeIndex, fragmentIndex uint64) (string, error) {
 	var curi *C.char
 
-	ret := C.tiledb_consolidation_plan_get_fragment_uri(cp.context.tiledbContext, cp.tiledbConsolidationPlan, C.uint64_t(nodeIndex), C.uint64_t(fragmentIndex), &curi)
+	ret := C.tiledb_consolidation_plan_get_fragment_uri(cp.context.tiledbContext, cp.tiledbConsolidationPlan.Get(), C.uint64_t(nodeIndex), C.uint64_t(fragmentIndex), &curi)
 	runtime.KeepAlive(cp)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting consolidation plan fragment uri for node %d and fragment %d: %w", nodeIndex, fragmentIndex, cp.context.LastError())
@@ -89,7 +101,7 @@ func (cp *ConsolidationPlan) FragmentURI(nodeIndex, fragmentIndex uint64) (strin
 // DumpJSON returns a json serialization of the plan
 func (cp *ConsolidationPlan) DumpJSON() (string, error) {
 	var cjson *C.char
-	ret := C.tiledb_consolidation_plan_dump_json_str(cp.context.tiledbContext, cp.tiledbConsolidationPlan, &cjson)
+	ret := C.tiledb_consolidation_plan_dump_json_str(cp.context.tiledbContext, cp.tiledbConsolidationPlan.Get(), &cjson)
 	runtime.KeepAlive(cp)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting consolidation plan json dump: %w", cp.context.LastError())

--- a/array_experimental.go
+++ b/array_experimental.go
@@ -41,7 +41,7 @@ func newConsolidationPlanFromHandle(context *Context, handle consolidationPlanHa
 // The plan and the array will share the same tiledb context
 func GetConsolidationPlan(arr *Array, fragmentSize uint64) (*ConsolidationPlan, error) {
 	var consolidationPlanPtr *C.tiledb_consolidation_plan_t
-	ret := C.tiledb_consolidation_plan_create_with_mbr(arr.context.tiledbContext, arr.tiledbArray.Get(), C.uint64_t(fragmentSize), &consolidationPlanPtr)
+	ret := C.tiledb_consolidation_plan_create_with_mbr(arr.context.tiledbContext.Get(), arr.tiledbArray.Get(), C.uint64_t(fragmentSize), &consolidationPlanPtr)
 	runtime.KeepAlive(arr)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting consolidation plan for array: %w", arr.context.LastError())
@@ -63,7 +63,7 @@ func (cp *ConsolidationPlan) Free() {
 func (cp *ConsolidationPlan) NumNodes() (uint64, error) {
 	var numNodes C.uint64_t
 
-	ret := C.tiledb_consolidation_plan_get_num_nodes(cp.context.tiledbContext, cp.tiledbConsolidationPlan.Get(), &numNodes)
+	ret := C.tiledb_consolidation_plan_get_num_nodes(cp.context.tiledbContext.Get(), cp.tiledbConsolidationPlan.Get(), &numNodes)
 	runtime.KeepAlive(cp)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting consolidation plan num nodes: %w", cp.context.LastError())
@@ -76,7 +76,7 @@ func (cp *ConsolidationPlan) NumNodes() (uint64, error) {
 func (cp *ConsolidationPlan) NumFragments(nodeIndex uint64) (uint64, error) {
 	var numFragments C.uint64_t
 
-	ret := C.tiledb_consolidation_plan_get_num_fragments(cp.context.tiledbContext, cp.tiledbConsolidationPlan.Get(), C.uint64_t(nodeIndex), &numFragments)
+	ret := C.tiledb_consolidation_plan_get_num_fragments(cp.context.tiledbContext.Get(), cp.tiledbConsolidationPlan.Get(), C.uint64_t(nodeIndex), &numFragments)
 	runtime.KeepAlive(cp)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting consolidation plan num fragments: %w", cp.context.LastError())
@@ -89,7 +89,7 @@ func (cp *ConsolidationPlan) NumFragments(nodeIndex uint64) (uint64, error) {
 func (cp *ConsolidationPlan) FragmentURI(nodeIndex, fragmentIndex uint64) (string, error) {
 	var curi *C.char
 
-	ret := C.tiledb_consolidation_plan_get_fragment_uri(cp.context.tiledbContext, cp.tiledbConsolidationPlan.Get(), C.uint64_t(nodeIndex), C.uint64_t(fragmentIndex), &curi)
+	ret := C.tiledb_consolidation_plan_get_fragment_uri(cp.context.tiledbContext.Get(), cp.tiledbConsolidationPlan.Get(), C.uint64_t(nodeIndex), C.uint64_t(fragmentIndex), &curi)
 	runtime.KeepAlive(cp)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting consolidation plan fragment uri for node %d and fragment %d: %w", nodeIndex, fragmentIndex, cp.context.LastError())
@@ -101,7 +101,7 @@ func (cp *ConsolidationPlan) FragmentURI(nodeIndex, fragmentIndex uint64) (strin
 // DumpJSON returns a json serialization of the plan
 func (cp *ConsolidationPlan) DumpJSON() (string, error) {
 	var cjson *C.char
-	ret := C.tiledb_consolidation_plan_dump_json_str(cp.context.tiledbContext, cp.tiledbConsolidationPlan.Get(), &cjson)
+	ret := C.tiledb_consolidation_plan_dump_json_str(cp.context.tiledbContext.Get(), cp.tiledbConsolidationPlan.Get(), &cjson)
 	runtime.KeepAlive(cp)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting consolidation plan json dump: %w", cp.context.LastError())
@@ -131,7 +131,7 @@ func (a *Array) ConsolidateFragments(config *Config, fragmentList []string) erro
 	list, freeMemory := cStringArray(fragmentList)
 	defer freeMemory()
 
-	ret := C.tiledb_array_consolidate_fragments(a.context.tiledbContext, curi, (**C.char)(slicePtr(list)), C.uint64_t(len(list)), config.tiledbConfig.Get())
+	ret := C.tiledb_array_consolidate_fragments(a.context.tiledbContext.Get(), curi, (**C.char)(slicePtr(list)), C.uint64_t(len(list)), config.tiledbConfig.Get())
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error consolidating tiledb array fragment list: %w", a.context.LastError())

--- a/array_schema.go
+++ b/array_schema.go
@@ -291,7 +291,7 @@ func (a *ArraySchema) Attributes() ([]*Attribute, error) {
 
 // SetDomain sets the array domain.
 func (a *ArraySchema) SetDomain(domain *Domain) error {
-	ret := C.tiledb_array_schema_set_domain(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), domain.tiledbDomain)
+	ret := C.tiledb_array_schema_set_domain(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), domain.tiledbDomain.Get())
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(domain)
 	if ret != C.TILEDB_OK {
@@ -302,14 +302,14 @@ func (a *ArraySchema) SetDomain(domain *Domain) error {
 
 // Domain returns the array's domain.
 func (a *ArraySchema) Domain() (*Domain, error) {
-	domain := Domain{context: a.context}
-	ret := C.tiledb_array_schema_get_domain(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &domain.tiledbDomain)
+	var domainPtr *C.tiledb_domain_t
+	ret := C.tiledb_array_schema_get_domain(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &domainPtr)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error setting domain for tiledb arraySchema: %w", a.context.LastError())
 	}
-	freeOnGC(&domain)
-	return &domain, nil
+
+	return newDomainFromHandle(a.context, newDomainHandle(domainPtr)), nil
 }
 
 // SetCapacity sets the tile capacity.
@@ -377,7 +377,7 @@ func (a *ArraySchema) TileOrder() (Layout, error) {
 
 // SetCoordsFilterList sets the filter list used for coordinates.
 func (a *ArraySchema) SetCoordsFilterList(filterList *FilterList) error {
-	ret := C.tiledb_array_schema_set_coords_filter_list(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), filterList.tiledbFilterList)
+	ret := C.tiledb_array_schema_set_coords_filter_list(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), filterList.tiledbFilterList.Get())
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(filterList)
 	if ret != C.TILEDB_OK {
@@ -388,14 +388,14 @@ func (a *ArraySchema) SetCoordsFilterList(filterList *FilterList) error {
 
 // CoordsFilterList returns a copy of the filter list of the coordinates.
 func (a *ArraySchema) CoordsFilterList() (*FilterList, error) {
-	filterList := FilterList{context: a.context}
-	ret := C.tiledb_array_schema_get_coords_filter_list(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &filterList.tiledbFilterList)
+	var filterListPtr *C.tiledb_filter_list_t
+	ret := C.tiledb_array_schema_get_coords_filter_list(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &filterListPtr)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting coordinates filter list for tiledb arraySchema: %w", a.context.LastError())
 	}
-	freeOnGC(&filterList)
-	return &filterList, nil
+
+	return newFilterListFromHandle(a.context, newFilterListHandle(filterListPtr)), nil
 }
 
 // SetOffsetsFilterList sets the filter list for the offsets of
@@ -403,7 +403,7 @@ func (a *ArraySchema) CoordsFilterList() (*FilterList, error) {
 func (a *ArraySchema) SetOffsetsFilterList(filterList *FilterList) error {
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(filterList)
-	ret := C.tiledb_array_schema_set_offsets_filter_list(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), filterList.tiledbFilterList)
+	ret := C.tiledb_array_schema_set_offsets_filter_list(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), filterList.tiledbFilterList.Get())
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting offsets filter list for tiledb arraySchema: %w", a.context.LastError())
 	}
@@ -413,14 +413,14 @@ func (a *ArraySchema) SetOffsetsFilterList(filterList *FilterList) error {
 // OffsetsFilterList returns a copy of the FilterList of the offsets for
 // variable-length attributes.
 func (a *ArraySchema) OffsetsFilterList() (*FilterList, error) {
-	filterList := FilterList{context: a.context}
-	ret := C.tiledb_array_schema_get_offsets_filter_list(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &filterList.tiledbFilterList)
+	var filterListPtr *C.tiledb_filter_list_t
+	ret := C.tiledb_array_schema_get_offsets_filter_list(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &filterListPtr)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting offsets filter list for tiledb arraySchema: %w", a.context.LastError())
 	}
-	freeOnGC(&filterList)
-	return &filterList, nil
+
+	return newFilterListFromHandle(a.context, newFilterListHandle(filterListPtr)), nil
 }
 
 // Check validates the schema.

--- a/array_schema.go
+++ b/array_schema.go
@@ -130,7 +130,7 @@ func (a *ArraySchema) UnmarshalJSON(b []byte) error {
 	// Deserialize into a new array schema
 	var newCSchema *C.tiledb_array_schema_t
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
-	ret := C.tiledb_deserialize_array_schema(a.context.tiledbContext, buffer.tiledbBuffer.Get(), C.TILEDB_JSON, cClientSide, &newCSchema)
+	ret := C.tiledb_deserialize_array_schema(a.context.tiledbContext.Get(), buffer.tiledbBuffer.Get(), C.TILEDB_JSON, cClientSide, &newCSchema)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deserializing array schema: %w", a.context.LastError())
@@ -145,7 +145,7 @@ func (a *ArraySchema) UnmarshalJSON(b []byte) error {
 // NewArraySchema allocates a new ArraySchema.
 func NewArraySchema(tdbCtx *Context, arrayType ArrayType) (*ArraySchema, error) {
 	var arraySchemaPtr *C.tiledb_array_schema_t
-	ret := C.tiledb_array_schema_alloc(tdbCtx.tiledbContext, C.tiledb_array_type_t(arrayType), &arraySchemaPtr)
+	ret := C.tiledb_array_schema_alloc(tdbCtx.tiledbContext.Get(), C.tiledb_array_type_t(arrayType), &arraySchemaPtr)
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb arraySchema: %w", tdbCtx.LastError())
@@ -165,7 +165,7 @@ func (a *ArraySchema) Free() {
 // AddAttributes adds one or more attributes to the array.
 func (a *ArraySchema) AddAttributes(attributes ...*Attribute) error {
 	for _, attribute := range attributes {
-		ret := C.tiledb_array_schema_add_attribute(a.context.tiledbContext, a.tiledbArraySchema.Get(), attribute.tiledbAttribute.Get())
+		ret := C.tiledb_array_schema_add_attribute(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), attribute.tiledbAttribute.Get())
 		runtime.KeepAlive(a)
 		runtime.KeepAlive(attribute)
 		if ret != C.TILEDB_OK {
@@ -178,7 +178,7 @@ func (a *ArraySchema) AddAttributes(attributes ...*Attribute) error {
 // AttributeNum returns the number of attributes.
 func (a *ArraySchema) AttributeNum() (uint, error) {
 	var attrNum C.uint32_t
-	ret := C.tiledb_array_schema_get_attribute_num(a.context.tiledbContext, a.tiledbArraySchema.Get(), &attrNum)
+	ret := C.tiledb_array_schema_get_attribute_num(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &attrNum)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting attribute number for tiledb arraySchema: %w", a.context.LastError())
@@ -190,7 +190,7 @@ func (a *ArraySchema) AttributeNum() (uint, error) {
 func (a *ArraySchema) AttributeFromIndex(index uint) (*Attribute, error) {
 	var attributePtr *C.tiledb_attribute_t
 	ret := C.tiledb_array_schema_get_attribute_from_index(
-		a.context.tiledbContext,
+		a.context.tiledbContext.Get(),
 		a.tiledbArraySchema.Get(),
 		C.uint32_t(index),
 		&attributePtr)
@@ -208,7 +208,7 @@ func (a *ArraySchema) AttributeFromName(attrName string) (*Attribute, error) {
 	cAttrName := C.CString(attrName)
 	defer C.free(unsafe.Pointer(cAttrName))
 	var attributePtr *C.tiledb_attribute_t
-	ret := C.tiledb_array_schema_get_attribute_from_name(a.context.tiledbContext, a.tiledbArraySchema.Get(), cAttrName, &attributePtr)
+	ret := C.tiledb_array_schema_get_attribute_from_name(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), cAttrName, &attributePtr)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting attribute %s for tiledb arraySchema: %w", attrName, a.context.LastError())
@@ -221,7 +221,7 @@ func (a *ArraySchema) HasAttribute(attrName string) (bool, error) {
 	var hasAttr C.int32_t
 	cAttrName := C.CString(attrName)
 	defer C.free(unsafe.Pointer(cAttrName))
-	ret := C.tiledb_array_schema_has_attribute(a.context.tiledbContext, a.tiledbArraySchema.Get(), cAttrName, &hasAttr)
+	ret := C.tiledb_array_schema_has_attribute(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), cAttrName, &hasAttr)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error finding attribute %s in schema: %w", attrName, a.context.LastError())
@@ -243,7 +243,7 @@ func (a *ArraySchema) SetAllowsDups(allowsDups bool) error {
 		allowsDupsInt = 1
 	}
 
-	ret := C.tiledb_array_schema_set_allows_dups(a.context.tiledbContext, a.tiledbArraySchema.Get(), C.int32_t(allowsDupsInt))
+	ret := C.tiledb_array_schema_set_allows_dups(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), C.int32_t(allowsDupsInt))
 	runtime.KeepAlive(a)
 
 	if ret != C.TILEDB_OK {
@@ -257,7 +257,7 @@ func (a *ArraySchema) SetAllowsDups(allowsDups bool) error {
 // It should always be `0` for dense arrays.
 func (a *ArraySchema) AllowsDups() (bool, error) {
 	var allowsDups C.int32_t
-	ret := C.tiledb_array_schema_get_allows_dups(a.context.tiledbContext, a.tiledbArraySchema.Get(), &allowsDups)
+	ret := C.tiledb_array_schema_get_allows_dups(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &allowsDups)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error getting allows dups for schema: %w", a.context.LastError())
@@ -291,7 +291,7 @@ func (a *ArraySchema) Attributes() ([]*Attribute, error) {
 
 // SetDomain sets the array domain.
 func (a *ArraySchema) SetDomain(domain *Domain) error {
-	ret := C.tiledb_array_schema_set_domain(a.context.tiledbContext, a.tiledbArraySchema.Get(), domain.tiledbDomain)
+	ret := C.tiledb_array_schema_set_domain(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), domain.tiledbDomain)
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(domain)
 	if ret != C.TILEDB_OK {
@@ -303,7 +303,7 @@ func (a *ArraySchema) SetDomain(domain *Domain) error {
 // Domain returns the array's domain.
 func (a *ArraySchema) Domain() (*Domain, error) {
 	domain := Domain{context: a.context}
-	ret := C.tiledb_array_schema_get_domain(a.context.tiledbContext, a.tiledbArraySchema.Get(), &domain.tiledbDomain)
+	ret := C.tiledb_array_schema_get_domain(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &domain.tiledbDomain)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error setting domain for tiledb arraySchema: %w", a.context.LastError())
@@ -314,7 +314,7 @@ func (a *ArraySchema) Domain() (*Domain, error) {
 
 // SetCapacity sets the tile capacity.
 func (a *ArraySchema) SetCapacity(capacity uint64) error {
-	ret := C.tiledb_array_schema_set_capacity(a.context.tiledbContext, a.tiledbArraySchema.Get(), C.uint64_t(capacity))
+	ret := C.tiledb_array_schema_set_capacity(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), C.uint64_t(capacity))
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting capacity for tiledb arraySchema: %w", a.context.LastError())
@@ -325,7 +325,7 @@ func (a *ArraySchema) SetCapacity(capacity uint64) error {
 // Capacity returns the tile capacity.
 func (a *ArraySchema) Capacity() (uint64, error) {
 	var capacity C.uint64_t
-	ret := C.tiledb_array_schema_get_capacity(a.context.tiledbContext, a.tiledbArraySchema.Get(), &capacity)
+	ret := C.tiledb_array_schema_get_capacity(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &capacity)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting capacity for tiledb arraySchema: %w", a.context.LastError())
@@ -335,7 +335,7 @@ func (a *ArraySchema) Capacity() (uint64, error) {
 
 // SetCellOrder sets the cell order.
 func (a *ArraySchema) SetCellOrder(cellOrder Layout) error {
-	ret := C.tiledb_array_schema_set_cell_order(a.context.tiledbContext, a.tiledbArraySchema.Get(), C.tiledb_layout_t(cellOrder))
+	ret := C.tiledb_array_schema_set_cell_order(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), C.tiledb_layout_t(cellOrder))
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting cell order for tiledb arraySchema: %w", a.context.LastError())
@@ -346,7 +346,7 @@ func (a *ArraySchema) SetCellOrder(cellOrder Layout) error {
 // CellOrder returns the cell order.
 func (a *ArraySchema) CellOrder() (Layout, error) {
 	var cellOrder C.tiledb_layout_t
-	ret := C.tiledb_array_schema_get_cell_order(a.context.tiledbContext, a.tiledbArraySchema.Get(), &cellOrder)
+	ret := C.tiledb_array_schema_get_cell_order(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &cellOrder)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return -1, fmt.Errorf("error getting cell order for tiledb arraySchema: %w", a.context.LastError())
@@ -356,7 +356,7 @@ func (a *ArraySchema) CellOrder() (Layout, error) {
 
 // SetTileOrder sets the tile order.
 func (a *ArraySchema) SetTileOrder(tileOrder Layout) error {
-	ret := C.tiledb_array_schema_set_tile_order(a.context.tiledbContext, a.tiledbArraySchema.Get(), C.tiledb_layout_t(tileOrder))
+	ret := C.tiledb_array_schema_set_tile_order(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), C.tiledb_layout_t(tileOrder))
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting cell order for tiledb arraySchema: %w", a.context.LastError())
@@ -367,7 +367,7 @@ func (a *ArraySchema) SetTileOrder(tileOrder Layout) error {
 // TileOrder returns the tile order.
 func (a *ArraySchema) TileOrder() (Layout, error) {
 	var cellOrder C.tiledb_layout_t
-	ret := C.tiledb_array_schema_get_tile_order(a.context.tiledbContext, a.tiledbArraySchema.Get(), &cellOrder)
+	ret := C.tiledb_array_schema_get_tile_order(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &cellOrder)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return -1, fmt.Errorf("error getting cell order for tiledb arraySchema: %w", a.context.LastError())
@@ -377,7 +377,7 @@ func (a *ArraySchema) TileOrder() (Layout, error) {
 
 // SetCoordsFilterList sets the filter list used for coordinates.
 func (a *ArraySchema) SetCoordsFilterList(filterList *FilterList) error {
-	ret := C.tiledb_array_schema_set_coords_filter_list(a.context.tiledbContext, a.tiledbArraySchema.Get(), filterList.tiledbFilterList)
+	ret := C.tiledb_array_schema_set_coords_filter_list(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), filterList.tiledbFilterList)
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(filterList)
 	if ret != C.TILEDB_OK {
@@ -389,7 +389,7 @@ func (a *ArraySchema) SetCoordsFilterList(filterList *FilterList) error {
 // CoordsFilterList returns a copy of the filter list of the coordinates.
 func (a *ArraySchema) CoordsFilterList() (*FilterList, error) {
 	filterList := FilterList{context: a.context}
-	ret := C.tiledb_array_schema_get_coords_filter_list(a.context.tiledbContext, a.tiledbArraySchema.Get(), &filterList.tiledbFilterList)
+	ret := C.tiledb_array_schema_get_coords_filter_list(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &filterList.tiledbFilterList)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting coordinates filter list for tiledb arraySchema: %w", a.context.LastError())
@@ -403,7 +403,7 @@ func (a *ArraySchema) CoordsFilterList() (*FilterList, error) {
 func (a *ArraySchema) SetOffsetsFilterList(filterList *FilterList) error {
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(filterList)
-	ret := C.tiledb_array_schema_set_offsets_filter_list(a.context.tiledbContext, a.tiledbArraySchema.Get(), filterList.tiledbFilterList)
+	ret := C.tiledb_array_schema_set_offsets_filter_list(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), filterList.tiledbFilterList)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting offsets filter list for tiledb arraySchema: %w", a.context.LastError())
 	}
@@ -414,7 +414,7 @@ func (a *ArraySchema) SetOffsetsFilterList(filterList *FilterList) error {
 // variable-length attributes.
 func (a *ArraySchema) OffsetsFilterList() (*FilterList, error) {
 	filterList := FilterList{context: a.context}
-	ret := C.tiledb_array_schema_get_offsets_filter_list(a.context.tiledbContext, a.tiledbArraySchema.Get(), &filterList.tiledbFilterList)
+	ret := C.tiledb_array_schema_get_offsets_filter_list(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &filterList.tiledbFilterList)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting offsets filter list for tiledb arraySchema: %w", a.context.LastError())
@@ -425,7 +425,7 @@ func (a *ArraySchema) OffsetsFilterList() (*FilterList, error) {
 
 // Check validates the schema.
 func (a *ArraySchema) Check() error {
-	ret := C.tiledb_array_schema_check(a.context.tiledbContext, a.tiledbArraySchema.Get())
+	ret := C.tiledb_array_schema_check(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get())
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error in checking arraySchema: %w", a.context.LastError())
@@ -438,7 +438,7 @@ func LoadArraySchema(context *Context, path string) (*ArraySchema, error) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
 	var arraySchemaPtr *C.tiledb_array_schema_t
-	ret := C.tiledb_array_schema_load(context.tiledbContext, cpath, &arraySchemaPtr)
+	ret := C.tiledb_array_schema_load(context.tiledbContext.Get(), cpath, &arraySchemaPtr)
 	runtime.KeepAlive(context)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error in loading arraySchema from %s: %w", path, context.LastError())
@@ -448,7 +448,7 @@ func LoadArraySchema(context *Context, path string) (*ArraySchema, error) {
 
 // DumpSTDOUT dumps the array schema in ASCII format to stdout.
 func (a *ArraySchema) DumpSTDOUT() error {
-	ret := C.tiledb_array_schema_dump(a.context.tiledbContext, a.tiledbArraySchema.Get(), C.stdout)
+	ret := C.tiledb_array_schema_dump(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), C.stdout)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping array schema to stdout: %w", a.context.LastError())
@@ -476,7 +476,7 @@ func (a *ArraySchema) Dump(path string) error {
 	defer C.fclose(cFile)
 
 	// Dump array schema to file
-	ret := C.tiledb_array_schema_dump(a.context.tiledbContext, a.tiledbArraySchema.Get(), cFile)
+	ret := C.tiledb_array_schema_dump(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), cFile)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping array schema to file %s: %w", path, a.context.LastError())
@@ -487,7 +487,7 @@ func (a *ArraySchema) Dump(path string) error {
 // Type fetches the tiledb array type.
 func (a *ArraySchema) Type() (ArrayType, error) {
 	var arrayType C.tiledb_array_type_t
-	ret := C.tiledb_array_schema_get_array_type(a.context.tiledbContext, a.tiledbArraySchema.Get(), &arrayType)
+	ret := C.tiledb_array_schema_get_array_type(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &arrayType)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return TILEDB_DENSE, fmt.Errorf("error fetching array schema type: %w", a.context.LastError())

--- a/array_schema.go
+++ b/array_schema.go
@@ -128,7 +128,7 @@ func (a *ArraySchema) UnmarshalJSON(b []byte) error {
 	// Deserialize into a new array schema
 	var newCSchema *C.tiledb_array_schema_t
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
-	ret := C.tiledb_deserialize_array_schema(a.context.tiledbContext, buffer.tiledbBuffer, C.TILEDB_JSON, cClientSide, &newCSchema)
+	ret := C.tiledb_deserialize_array_schema(a.context.tiledbContext, buffer.tiledbBuffer.Get(), C.TILEDB_JSON, cClientSide, &newCSchema)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error deserializing array schema: %w", a.context.LastError())

--- a/array_schema.go
+++ b/array_schema.go
@@ -15,10 +15,12 @@ import (
 	"unsafe"
 )
 
+// arraySchemaHandle safely wraps a pointer to tiledb_array_schema_t.
+// This handle type differs from the rest because it supports replacing the
+// handle after creation. For this reason, its member functions must use a pointer receiver.
 type arraySchemaHandle struct {
 	// An unsafe pointer to the capiHandle holding the schema.
-	// This pointer must be accessed using atomic functions, because the MarshalJSON function
-	// replaces the native handle of an existing object.
+	// This pointer must be accessed using atomic functions.
 	// We cannot wrap atomic.Pointer[capiHandle] in a struct and pass it around because of lint warnings,
 	// and we cannot mutate the native handle of an existing capiHandle because it's impossible to atomically
 	// set the finalizer.

--- a/array_schema.go
+++ b/array_schema.go
@@ -11,8 +11,53 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"sync/atomic"
 	"unsafe"
 )
+
+type arraySchemaHandle struct {
+	// An unsafe pointer to the capiHandle holding the schema.
+	// This pointer must be accessed using atomic functions, because the MarshalJSON function
+	// replaces the native handle of an existing object.
+	// We cannot wrap atomic.Pointer[capiHandle] in a struct and pass it around because of lint warnings,
+	// and we cannot mutate the native handle of an existing capiHandle because it's impossible to atomically
+	// set the finalizer.
+	h unsafe.Pointer
+}
+
+func freeCapiArraySchema(c unsafe.Pointer) {
+	C.tiledb_array_schema_free((**C.tiledb_array_schema_t)(unsafe.Pointer(&c)))
+}
+
+func newArraySchemaCapiHandle(ptr *C.tiledb_array_schema_t) *capiHandle {
+	return newCapiHandle(unsafe.Pointer(ptr), freeCapiArraySchema)
+}
+
+func newArraySchemaHandle(ptr *C.tiledb_array_schema_t) arraySchemaHandle {
+	h := newArraySchemaCapiHandle(ptr)
+	return arraySchemaHandle{h: unsafe.Pointer(h)}
+}
+
+func (x *arraySchemaHandle) loadCapiHandle() *capiHandle {
+	return (*capiHandle)(atomic.LoadPointer(&x.h))
+}
+
+func (x *arraySchemaHandle) Get() *C.tiledb_array_schema_t {
+	return (*C.tiledb_array_schema_t)(x.loadCapiHandle().Get())
+}
+
+// Reset reassigns the native handle held by the array schema handle, and frees the existing one.
+// This method is safe to call from multiple goroutines.
+func (x *arraySchemaHandle) Reset(ptr *C.tiledb_array_schema_t) {
+	h := newArraySchemaCapiHandle(ptr)
+	prevHandle := atomic.SwapPointer(&x.h, unsafe.Pointer(h))
+	// If the handle has been freed previously, this won't fail.
+	(*capiHandle)(prevHandle).Free()
+}
+
+func (x *arraySchemaHandle) Free() {
+	x.loadCapiHandle().Free()
+}
 
 /*
 ArraySchema describes an array.
@@ -25,8 +70,12 @@ The schema is an independent description of an array. A schema can be used to cr
 	Compression details for Array level factors like offsets and coordinates
 */
 type ArraySchema struct {
-	tiledbArraySchema *C.tiledb_array_schema_t
+	tiledbArraySchema arraySchemaHandle
 	context           *Context
+}
+
+func newArraySchemaFromHandle(context *Context, handle arraySchemaHandle) *ArraySchema {
+	return &ArraySchema{tiledbArraySchema: handle, context: context}
 }
 
 // MarshalJSON marshals arraySchema struct to json using tiledb.
@@ -86,24 +135,20 @@ func (a *ArraySchema) UnmarshalJSON(b []byte) error {
 	}
 
 	// Replace the C schema object with the deserialized one.
-	if a.tiledbArraySchema != nil {
-		C.tiledb_array_schema_free(&a.tiledbArraySchema)
-	}
-	a.tiledbArraySchema = newCSchema
+	a.tiledbArraySchema.Reset(newCSchema)
 
 	return nil
 }
 
 // NewArraySchema allocates a new ArraySchema.
 func NewArraySchema(tdbCtx *Context, arrayType ArrayType) (*ArraySchema, error) {
-	arraySchema := ArraySchema{context: tdbCtx}
-	ret := C.tiledb_array_schema_alloc(arraySchema.context.tiledbContext, C.tiledb_array_type_t(arrayType), &arraySchema.tiledbArraySchema)
+	var arraySchemaPtr *C.tiledb_array_schema_t
+	ret := C.tiledb_array_schema_alloc(tdbCtx.tiledbContext, C.tiledb_array_type_t(arrayType), &arraySchemaPtr)
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error creating tiledb arraySchema: %w", arraySchema.context.LastError())
+		return nil, fmt.Errorf("error creating tiledb arraySchema: %w", tdbCtx.LastError())
 	}
-	freeOnGC(&arraySchema)
-	return &arraySchema, nil
+	return newArraySchemaFromHandle(tdbCtx, newArraySchemaHandle(arraySchemaPtr)), nil
 }
 
 // Free releases the internal TileDB core data that was allocated on the C heap.
@@ -112,15 +157,13 @@ func NewArraySchema(tdbCtx *Context, arrayType ArrayType) (*ArraySchema, error) 
 // can safely be called many times on the same object; if it has already
 // been freed, it will not be freed again.
 func (a *ArraySchema) Free() {
-	if a.tiledbArraySchema != nil {
-		C.tiledb_array_schema_free(&a.tiledbArraySchema)
-	}
+	a.tiledbArraySchema.Free()
 }
 
 // AddAttributes adds one or more attributes to the array.
 func (a *ArraySchema) AddAttributes(attributes ...*Attribute) error {
 	for _, attribute := range attributes {
-		ret := C.tiledb_array_schema_add_attribute(a.context.tiledbContext, a.tiledbArraySchema, attribute.tiledbAttribute)
+		ret := C.tiledb_array_schema_add_attribute(a.context.tiledbContext, a.tiledbArraySchema.Get(), attribute.tiledbAttribute)
 		runtime.KeepAlive(a)
 		runtime.KeepAlive(attribute)
 		if ret != C.TILEDB_OK {
@@ -133,7 +176,7 @@ func (a *ArraySchema) AddAttributes(attributes ...*Attribute) error {
 // AttributeNum returns the number of attributes.
 func (a *ArraySchema) AttributeNum() (uint, error) {
 	var attrNum C.uint32_t
-	ret := C.tiledb_array_schema_get_attribute_num(a.context.tiledbContext, a.tiledbArraySchema, &attrNum)
+	ret := C.tiledb_array_schema_get_attribute_num(a.context.tiledbContext, a.tiledbArraySchema.Get(), &attrNum)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting attribute number for tiledb arraySchema: %w", a.context.LastError())
@@ -146,7 +189,7 @@ func (a *ArraySchema) AttributeFromIndex(index uint) (*Attribute, error) {
 	attr := Attribute{context: a.context}
 	ret := C.tiledb_array_schema_get_attribute_from_index(
 		a.context.tiledbContext,
-		a.tiledbArraySchema,
+		a.tiledbArraySchema.Get(),
 		C.uint32_t(index),
 		&attr.tiledbAttribute)
 	runtime.KeepAlive(a)
@@ -164,7 +207,7 @@ func (a *ArraySchema) AttributeFromName(attrName string) (*Attribute, error) {
 	cAttrName := C.CString(attrName)
 	defer C.free(unsafe.Pointer(cAttrName))
 	attr := Attribute{context: a.context}
-	ret := C.tiledb_array_schema_get_attribute_from_name(a.context.tiledbContext, a.tiledbArraySchema, cAttrName, &attr.tiledbAttribute)
+	ret := C.tiledb_array_schema_get_attribute_from_name(a.context.tiledbContext, a.tiledbArraySchema.Get(), cAttrName, &attr.tiledbAttribute)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting attribute %s for tiledb arraySchema: %w", attrName, a.context.LastError())
@@ -178,7 +221,7 @@ func (a *ArraySchema) HasAttribute(attrName string) (bool, error) {
 	var hasAttr C.int32_t
 	cAttrName := C.CString(attrName)
 	defer C.free(unsafe.Pointer(cAttrName))
-	ret := C.tiledb_array_schema_has_attribute(a.context.tiledbContext, a.tiledbArraySchema, cAttrName, &hasAttr)
+	ret := C.tiledb_array_schema_has_attribute(a.context.tiledbContext, a.tiledbArraySchema.Get(), cAttrName, &hasAttr)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error finding attribute %s in schema: %w", attrName, a.context.LastError())
@@ -200,7 +243,7 @@ func (a *ArraySchema) SetAllowsDups(allowsDups bool) error {
 		allowsDupsInt = 1
 	}
 
-	ret := C.tiledb_array_schema_set_allows_dups(a.context.tiledbContext, a.tiledbArraySchema, C.int32_t(allowsDupsInt))
+	ret := C.tiledb_array_schema_set_allows_dups(a.context.tiledbContext, a.tiledbArraySchema.Get(), C.int32_t(allowsDupsInt))
 	runtime.KeepAlive(a)
 
 	if ret != C.TILEDB_OK {
@@ -214,7 +257,7 @@ func (a *ArraySchema) SetAllowsDups(allowsDups bool) error {
 // It should always be `0` for dense arrays.
 func (a *ArraySchema) AllowsDups() (bool, error) {
 	var allowsDups C.int32_t
-	ret := C.tiledb_array_schema_get_allows_dups(a.context.tiledbContext, a.tiledbArraySchema, &allowsDups)
+	ret := C.tiledb_array_schema_get_allows_dups(a.context.tiledbContext, a.tiledbArraySchema.Get(), &allowsDups)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error getting allows dups for schema: %w", a.context.LastError())
@@ -248,7 +291,7 @@ func (a *ArraySchema) Attributes() ([]*Attribute, error) {
 
 // SetDomain sets the array domain.
 func (a *ArraySchema) SetDomain(domain *Domain) error {
-	ret := C.tiledb_array_schema_set_domain(a.context.tiledbContext, a.tiledbArraySchema, domain.tiledbDomain)
+	ret := C.tiledb_array_schema_set_domain(a.context.tiledbContext, a.tiledbArraySchema.Get(), domain.tiledbDomain)
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(domain)
 	if ret != C.TILEDB_OK {
@@ -260,7 +303,7 @@ func (a *ArraySchema) SetDomain(domain *Domain) error {
 // Domain returns the array's domain.
 func (a *ArraySchema) Domain() (*Domain, error) {
 	domain := Domain{context: a.context}
-	ret := C.tiledb_array_schema_get_domain(a.context.tiledbContext, a.tiledbArraySchema, &domain.tiledbDomain)
+	ret := C.tiledb_array_schema_get_domain(a.context.tiledbContext, a.tiledbArraySchema.Get(), &domain.tiledbDomain)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error setting domain for tiledb arraySchema: %w", a.context.LastError())
@@ -271,7 +314,7 @@ func (a *ArraySchema) Domain() (*Domain, error) {
 
 // SetCapacity sets the tile capacity.
 func (a *ArraySchema) SetCapacity(capacity uint64) error {
-	ret := C.tiledb_array_schema_set_capacity(a.context.tiledbContext, a.tiledbArraySchema, C.uint64_t(capacity))
+	ret := C.tiledb_array_schema_set_capacity(a.context.tiledbContext, a.tiledbArraySchema.Get(), C.uint64_t(capacity))
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting capacity for tiledb arraySchema: %w", a.context.LastError())
@@ -282,7 +325,7 @@ func (a *ArraySchema) SetCapacity(capacity uint64) error {
 // Capacity returns the tile capacity.
 func (a *ArraySchema) Capacity() (uint64, error) {
 	var capacity C.uint64_t
-	ret := C.tiledb_array_schema_get_capacity(a.context.tiledbContext, a.tiledbArraySchema, &capacity)
+	ret := C.tiledb_array_schema_get_capacity(a.context.tiledbContext, a.tiledbArraySchema.Get(), &capacity)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting capacity for tiledb arraySchema: %w", a.context.LastError())
@@ -292,7 +335,7 @@ func (a *ArraySchema) Capacity() (uint64, error) {
 
 // SetCellOrder sets the cell order.
 func (a *ArraySchema) SetCellOrder(cellOrder Layout) error {
-	ret := C.tiledb_array_schema_set_cell_order(a.context.tiledbContext, a.tiledbArraySchema, C.tiledb_layout_t(cellOrder))
+	ret := C.tiledb_array_schema_set_cell_order(a.context.tiledbContext, a.tiledbArraySchema.Get(), C.tiledb_layout_t(cellOrder))
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting cell order for tiledb arraySchema: %w", a.context.LastError())
@@ -303,7 +346,7 @@ func (a *ArraySchema) SetCellOrder(cellOrder Layout) error {
 // CellOrder returns the cell order.
 func (a *ArraySchema) CellOrder() (Layout, error) {
 	var cellOrder C.tiledb_layout_t
-	ret := C.tiledb_array_schema_get_cell_order(a.context.tiledbContext, a.tiledbArraySchema, &cellOrder)
+	ret := C.tiledb_array_schema_get_cell_order(a.context.tiledbContext, a.tiledbArraySchema.Get(), &cellOrder)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return -1, fmt.Errorf("error getting cell order for tiledb arraySchema: %w", a.context.LastError())
@@ -313,7 +356,7 @@ func (a *ArraySchema) CellOrder() (Layout, error) {
 
 // SetTileOrder sets the tile order.
 func (a *ArraySchema) SetTileOrder(tileOrder Layout) error {
-	ret := C.tiledb_array_schema_set_tile_order(a.context.tiledbContext, a.tiledbArraySchema, C.tiledb_layout_t(tileOrder))
+	ret := C.tiledb_array_schema_set_tile_order(a.context.tiledbContext, a.tiledbArraySchema.Get(), C.tiledb_layout_t(tileOrder))
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting cell order for tiledb arraySchema: %w", a.context.LastError())
@@ -324,7 +367,7 @@ func (a *ArraySchema) SetTileOrder(tileOrder Layout) error {
 // TileOrder returns the tile order.
 func (a *ArraySchema) TileOrder() (Layout, error) {
 	var cellOrder C.tiledb_layout_t
-	ret := C.tiledb_array_schema_get_tile_order(a.context.tiledbContext, a.tiledbArraySchema, &cellOrder)
+	ret := C.tiledb_array_schema_get_tile_order(a.context.tiledbContext, a.tiledbArraySchema.Get(), &cellOrder)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return -1, fmt.Errorf("error getting cell order for tiledb arraySchema: %w", a.context.LastError())
@@ -334,7 +377,7 @@ func (a *ArraySchema) TileOrder() (Layout, error) {
 
 // SetCoordsFilterList sets the filter list used for coordinates.
 func (a *ArraySchema) SetCoordsFilterList(filterList *FilterList) error {
-	ret := C.tiledb_array_schema_set_coords_filter_list(a.context.tiledbContext, a.tiledbArraySchema, filterList.tiledbFilterList)
+	ret := C.tiledb_array_schema_set_coords_filter_list(a.context.tiledbContext, a.tiledbArraySchema.Get(), filterList.tiledbFilterList)
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(filterList)
 	if ret != C.TILEDB_OK {
@@ -346,7 +389,7 @@ func (a *ArraySchema) SetCoordsFilterList(filterList *FilterList) error {
 // CoordsFilterList returns a copy of the filter list of the coordinates.
 func (a *ArraySchema) CoordsFilterList() (*FilterList, error) {
 	filterList := FilterList{context: a.context}
-	ret := C.tiledb_array_schema_get_coords_filter_list(a.context.tiledbContext, a.tiledbArraySchema, &filterList.tiledbFilterList)
+	ret := C.tiledb_array_schema_get_coords_filter_list(a.context.tiledbContext, a.tiledbArraySchema.Get(), &filterList.tiledbFilterList)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting coordinates filter list for tiledb arraySchema: %w", a.context.LastError())
@@ -360,7 +403,7 @@ func (a *ArraySchema) CoordsFilterList() (*FilterList, error) {
 func (a *ArraySchema) SetOffsetsFilterList(filterList *FilterList) error {
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(filterList)
-	ret := C.tiledb_array_schema_set_offsets_filter_list(a.context.tiledbContext, a.tiledbArraySchema, filterList.tiledbFilterList)
+	ret := C.tiledb_array_schema_set_offsets_filter_list(a.context.tiledbContext, a.tiledbArraySchema.Get(), filterList.tiledbFilterList)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting offsets filter list for tiledb arraySchema: %w", a.context.LastError())
 	}
@@ -371,7 +414,7 @@ func (a *ArraySchema) SetOffsetsFilterList(filterList *FilterList) error {
 // variable-length attributes.
 func (a *ArraySchema) OffsetsFilterList() (*FilterList, error) {
 	filterList := FilterList{context: a.context}
-	ret := C.tiledb_array_schema_get_offsets_filter_list(a.context.tiledbContext, a.tiledbArraySchema, &filterList.tiledbFilterList)
+	ret := C.tiledb_array_schema_get_offsets_filter_list(a.context.tiledbContext, a.tiledbArraySchema.Get(), &filterList.tiledbFilterList)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting offsets filter list for tiledb arraySchema: %w", a.context.LastError())
@@ -382,7 +425,7 @@ func (a *ArraySchema) OffsetsFilterList() (*FilterList, error) {
 
 // Check validates the schema.
 func (a *ArraySchema) Check() error {
-	ret := C.tiledb_array_schema_check(a.context.tiledbContext, a.tiledbArraySchema)
+	ret := C.tiledb_array_schema_check(a.context.tiledbContext, a.tiledbArraySchema.Get())
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error in checking arraySchema: %w", a.context.LastError())
@@ -394,19 +437,18 @@ func (a *ArraySchema) Check() error {
 func LoadArraySchema(context *Context, path string) (*ArraySchema, error) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
-	a := ArraySchema{context: context}
-	ret := C.tiledb_array_schema_load(a.context.tiledbContext, cpath, &a.tiledbArraySchema)
+	var arraySchemaPtr *C.tiledb_array_schema_t
+	ret := C.tiledb_array_schema_load(context.tiledbContext, cpath, &arraySchemaPtr)
 	runtime.KeepAlive(context)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error in loading arraySchema from %s: %w", path, a.context.LastError())
+		return nil, fmt.Errorf("error in loading arraySchema from %s: %w", path, context.LastError())
 	}
-	freeOnGC(&a)
-	return &a, nil
+	return newArraySchemaFromHandle(context, newArraySchemaHandle(arraySchemaPtr)), nil
 }
 
 // DumpSTDOUT dumps the array schema in ASCII format to stdout.
 func (a *ArraySchema) DumpSTDOUT() error {
-	ret := C.tiledb_array_schema_dump(a.context.tiledbContext, a.tiledbArraySchema, C.stdout)
+	ret := C.tiledb_array_schema_dump(a.context.tiledbContext, a.tiledbArraySchema.Get(), C.stdout)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping array schema to stdout: %w", a.context.LastError())
@@ -434,7 +476,7 @@ func (a *ArraySchema) Dump(path string) error {
 	defer C.fclose(cFile)
 
 	// Dump array schema to file
-	ret := C.tiledb_array_schema_dump(a.context.tiledbContext, a.tiledbArraySchema, cFile)
+	ret := C.tiledb_array_schema_dump(a.context.tiledbContext, a.tiledbArraySchema.Get(), cFile)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping array schema to file %s: %w", path, a.context.LastError())
@@ -445,7 +487,7 @@ func (a *ArraySchema) Dump(path string) error {
 // Type fetches the tiledb array type.
 func (a *ArraySchema) Type() (ArrayType, error) {
 	var arrayType C.tiledb_array_type_t
-	ret := C.tiledb_array_schema_get_array_type(a.context.tiledbContext, a.tiledbArraySchema, &arrayType)
+	ret := C.tiledb_array_schema_get_array_type(a.context.tiledbContext, a.tiledbArraySchema.Get(), &arrayType)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return TILEDB_DENSE, fmt.Errorf("error fetching array schema type: %w", a.context.LastError())

--- a/array_schema_evolution_experimental.go
+++ b/array_schema_evolution_experimental.go
@@ -40,7 +40,7 @@ func newArraySchemaEvolutionFromHandle(context *Context, handle arraySchemaEvolu
 func NewArraySchemaEvolution(tdbCtx *Context) (*ArraySchemaEvolution, error) {
 	var arraySchemaEvolutionPtr *C.tiledb_array_schema_evolution_t
 	ret := C.tiledb_array_schema_evolution_alloc(
-		tdbCtx.tiledbContext,
+		tdbCtx.tiledbContext.Get(),
 		&arraySchemaEvolutionPtr)
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
@@ -73,7 +73,7 @@ func (ase *ArraySchemaEvolution) AddAttribute(attribute *Attribute) error {
 	}
 
 	ret := C.tiledb_array_schema_evolution_add_attribute(
-		ase.context.tiledbContext, ase.tiledbArraySchemaEvolution.Get(),
+		ase.context.tiledbContext.Get(), ase.tiledbArraySchemaEvolution.Get(),
 		attribute.tiledbAttribute.Get())
 	runtime.KeepAlive(ase)
 	runtime.KeepAlive(attribute)
@@ -92,7 +92,7 @@ func (ase *ArraySchemaEvolution) DropAttribute(name string) error {
 	defer C.free(unsafe.Pointer(cname))
 
 	ret := C.tiledb_array_schema_evolution_drop_attribute(
-		ase.context.tiledbContext, ase.tiledbArraySchemaEvolution.Get(), cname)
+		ase.context.tiledbContext.Get(), ase.tiledbArraySchemaEvolution.Get(), cname)
 	runtime.KeepAlive(ase)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dropping tiledb attribute: %w",
@@ -107,7 +107,7 @@ func (ase *ArraySchemaEvolution) Evolve(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 
-	ret := C.tiledb_array_evolve(ase.context.tiledbContext, curi,
+	ret := C.tiledb_array_evolve(ase.context.tiledbContext.Get(), curi,
 		ase.tiledbArraySchemaEvolution.Get())
 	runtime.KeepAlive(ase)
 	if ret != C.TILEDB_OK {

--- a/array_schema_evolution_experimental.go
+++ b/array_schema_evolution_experimental.go
@@ -13,25 +13,42 @@ import (
 	"unsafe"
 )
 
+type arraySchemaEvolutionHandle struct{ *capiHandle }
+
+func freeCapiArraySchemaEvolution(c unsafe.Pointer) {
+	C.tiledb_array_schema_evolution_free((**C.tiledb_array_schema_evolution_t)(unsafe.Pointer(&c)))
+}
+
+func newArraySchemaEvolutionHandle(ptr *C.tiledb_array_schema_evolution_t) arraySchemaEvolutionHandle {
+	return arraySchemaEvolutionHandle{newCapiHandle(unsafe.Pointer(ptr), freeCapiArraySchemaEvolution)}
+}
+
+func (x arraySchemaEvolutionHandle) Get() *C.tiledb_array_schema_evolution_t {
+	return (*C.tiledb_array_schema_evolution_t)(x.capiHandle.Get())
+}
+
 type ArraySchemaEvolution struct {
-	tiledbArraySchemaEvolution *C.tiledb_array_schema_evolution_t
+	tiledbArraySchemaEvolution arraySchemaEvolutionHandle
 	context                    *Context
+}
+
+func newArraySchemaEvolutionFromHandle(context *Context, handle arraySchemaEvolutionHandle) *ArraySchemaEvolution {
+	return &ArraySchemaEvolution{tiledbArraySchemaEvolution: handle, context: context}
 }
 
 // NewArraySchemaEvolution creates a TileDB schema evolution object.
 func NewArraySchemaEvolution(tdbCtx *Context) (*ArraySchemaEvolution, error) {
-	arraySchemaEvolution := ArraySchemaEvolution{context: tdbCtx}
+	var arraySchemaEvolutionPtr *C.tiledb_array_schema_evolution_t
 	ret := C.tiledb_array_schema_evolution_alloc(
-		arraySchemaEvolution.context.tiledbContext,
-		&arraySchemaEvolution.tiledbArraySchemaEvolution)
+		tdbCtx.tiledbContext,
+		&arraySchemaEvolutionPtr)
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb arraySchemaEvolution: %w",
-			arraySchemaEvolution.context.LastError())
+			tdbCtx.LastError())
 	}
-	freeOnGC(&arraySchemaEvolution)
 
-	return &arraySchemaEvolution, nil
+	return newArraySchemaEvolutionFromHandle(tdbCtx, newArraySchemaEvolutionHandle(arraySchemaEvolutionPtr)), nil
 }
 
 // Free releases the internal TileDB core data that was allocated on the C heap.
@@ -40,9 +57,7 @@ func NewArraySchemaEvolution(tdbCtx *Context) (*ArraySchemaEvolution, error) {
 // can safely be called many times on the same object; if it has already
 // been freed, it will not be freed again.
 func (ase *ArraySchemaEvolution) Free() {
-	if ase.tiledbArraySchemaEvolution != nil {
-		C.tiledb_array_schema_evolution_free(&ase.tiledbArraySchemaEvolution)
-	}
+	ase.tiledbArraySchemaEvolution.Free()
 }
 
 // Context exposes the internal TileDB context used to initialize the array schema evolution
@@ -58,8 +73,8 @@ func (ase *ArraySchemaEvolution) AddAttribute(attribute *Attribute) error {
 	}
 
 	ret := C.tiledb_array_schema_evolution_add_attribute(
-		ase.context.tiledbContext, ase.tiledbArraySchemaEvolution,
-		attribute.tiledbAttribute)
+		ase.context.tiledbContext, ase.tiledbArraySchemaEvolution.Get(),
+		attribute.tiledbAttribute.Get())
 	runtime.KeepAlive(ase)
 	runtime.KeepAlive(attribute)
 	if ret != C.TILEDB_OK {
@@ -77,7 +92,7 @@ func (ase *ArraySchemaEvolution) DropAttribute(name string) error {
 	defer C.free(unsafe.Pointer(cname))
 
 	ret := C.tiledb_array_schema_evolution_drop_attribute(
-		ase.context.tiledbContext, ase.tiledbArraySchemaEvolution, cname)
+		ase.context.tiledbContext, ase.tiledbArraySchemaEvolution.Get(), cname)
 	runtime.KeepAlive(ase)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dropping tiledb attribute: %w",
@@ -93,7 +108,7 @@ func (ase *ArraySchemaEvolution) Evolve(uri string) error {
 	defer C.free(unsafe.Pointer(curi))
 
 	ret := C.tiledb_array_evolve(ase.context.tiledbContext, curi,
-		ase.tiledbArraySchemaEvolution)
+		ase.tiledbArraySchemaEvolution.Get())
 	runtime.KeepAlive(ase)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error evolving schema for array %s: %w", uri,

--- a/attribute.go
+++ b/attribute.go
@@ -51,7 +51,7 @@ func NewAttribute(context *Context, name string, datatype Datatype) (*Attribute,
 	defer C.free(unsafe.Pointer(cname))
 
 	var attributePtr *C.tiledb_attribute_t
-	ret := C.tiledb_attribute_alloc(context.tiledbContext, cname, C.tiledb_datatype_t(datatype), &attributePtr)
+	ret := C.tiledb_attribute_alloc(context.tiledbContext.Get(), cname, C.tiledb_datatype_t(datatype), &attributePtr)
 	runtime.KeepAlive(context)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb attribute: %w", context.LastError())
@@ -76,7 +76,7 @@ func (a *Attribute) Context() *Context {
 
 // SetFilterList sets the attribute filterList.
 func (a *Attribute) SetFilterList(filterlist *FilterList) error {
-	ret := C.tiledb_attribute_set_filter_list(a.context.tiledbContext, a.tiledbAttribute.Get(), filterlist.tiledbFilterList)
+	ret := C.tiledb_attribute_set_filter_list(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), filterlist.tiledbFilterList)
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(filterlist)
 	if ret != C.TILEDB_OK {
@@ -88,7 +88,7 @@ func (a *Attribute) SetFilterList(filterlist *FilterList) error {
 // FilterList returns a copy of the filter list for attribute.
 func (a *Attribute) FilterList() (*FilterList, error) {
 	filterList := FilterList{context: a.context}
-	ret := C.tiledb_attribute_get_filter_list(a.context.tiledbContext, a.tiledbAttribute.Get(), &filterList.tiledbFilterList)
+	ret := C.tiledb_attribute_get_filter_list(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), &filterList.tiledbFilterList)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb attribute filter list: %w", a.context.LastError())
@@ -102,7 +102,7 @@ func (a *Attribute) FilterList() (*FilterList, error) {
 // This is inferred from the type parameter of the NewAttribute
 // function, but can also be set manually.
 func (a *Attribute) SetCellValNum(val uint32) error {
-	ret := C.tiledb_attribute_set_cell_val_num(a.context.tiledbContext,
+	ret := C.tiledb_attribute_set_cell_val_num(a.context.tiledbContext.Get(),
 		a.tiledbAttribute.Get(), C.uint32_t(val))
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
@@ -115,7 +115,7 @@ func (a *Attribute) SetCellValNum(val uint32) error {
 // For variable-sized attributes returns TILEDB_VAR_NUM.
 func (a *Attribute) CellValNum() (uint32, error) {
 	var cellValNum C.uint32_t
-	ret := C.tiledb_attribute_get_cell_val_num(a.context.tiledbContext, a.tiledbAttribute.Get(), &cellValNum)
+	ret := C.tiledb_attribute_get_cell_val_num(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), &cellValNum)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb attribute cell val num: %w", a.context.LastError())
@@ -127,7 +127,7 @@ func (a *Attribute) CellValNum() (uint32, error) {
 // CellSize gets the attribute cell size.
 func (a *Attribute) CellSize() (uint64, error) {
 	var cellSize C.uint64_t
-	ret := C.tiledb_attribute_get_cell_size(a.context.tiledbContext, a.tiledbAttribute.Get(), &cellSize)
+	ret := C.tiledb_attribute_get_cell_size(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), &cellSize)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb attribute cell size: %w", a.context.LastError())
@@ -205,7 +205,7 @@ func attributeSetFillValue[T scalarType](a *Attribute, value T) error {
 
 func attributeSetFillValueInternal(a *Attribute, value unsafe.Pointer, valueSize uint64) error {
 	ret := C.tiledb_attribute_set_fill_value(
-		a.context.tiledbContext,
+		a.context.tiledbContext.Get(),
 		a.tiledbAttribute.Get(),
 		value,
 		C.uint64_t(valueSize),
@@ -290,7 +290,7 @@ func attributeSetFillValueNullableInternal(a *Attribute, value unsafe.Pointer, v
 		cValid = 1
 	}
 	ret := C.tiledb_attribute_set_fill_value_nullable(
-		a.context.tiledbContext,
+		a.context.tiledbContext.Get(),
 		a.tiledbAttribute.Get(),
 		value,
 		C.uint64_t(valueSize),
@@ -313,7 +313,7 @@ func (a *Attribute) GetFillValue() (interface{}, uint64, error) {
 	var fillValueSize C.uint64_t
 	var cvalue unsafe.Pointer // a must be kept alive while cvalue is being accessed.
 
-	ret := C.tiledb_attribute_get_fill_value(a.context.tiledbContext, a.tiledbAttribute.Get(), &cvalue, &fillValueSize)
+	ret := C.tiledb_attribute_get_fill_value(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), &cvalue, &fillValueSize)
 	if ret != C.TILEDB_OK {
 		return nil, 0, fmt.Errorf("error getting tiledb attribute fill value: %w", a.context.LastError())
 	}
@@ -343,7 +343,7 @@ func (a *Attribute) GetFillValueNullable() (interface{}, uint64, bool, error) {
 	var cvalue unsafe.Pointer // a must be kept alive while cvalue is being accessed.
 	var cvalid C.uint8_t
 
-	ret := C.tiledb_attribute_get_fill_value_nullable(a.context.tiledbContext, a.tiledbAttribute.Get(), &cvalue, &fillValueSize, &cvalid)
+	ret := C.tiledb_attribute_get_fill_value_nullable(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), &cvalue, &fillValueSize, &cvalid)
 	if ret != C.TILEDB_OK {
 		return nil, 0, false, fmt.Errorf("error getting tiledb attribute fill value: %w", a.context.LastError())
 	}
@@ -365,7 +365,7 @@ func (a *Attribute) GetFillValueNullable() (interface{}, uint64, bool, error) {
 // Name returns the name of the attribute.
 func (a *Attribute) Name() (string, error) {
 	var cName *C.char // a must be kept alive while cName is being accessed.
-	ret := C.tiledb_attribute_get_name(a.context.tiledbContext, a.tiledbAttribute.Get(), &cName)
+	ret := C.tiledb_attribute_get_name(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), &cName)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting tiledb attribute name: %w", a.context.LastError())
 	}
@@ -379,7 +379,7 @@ func (a *Attribute) Name() (string, error) {
 // Type returns the attribute datatype.
 func (a *Attribute) Type() (Datatype, error) {
 	var attrType C.tiledb_datatype_t
-	ret := C.tiledb_attribute_get_type(a.context.tiledbContext, a.tiledbAttribute.Get(), &attrType)
+	ret := C.tiledb_attribute_get_type(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), &attrType)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb attribute type: %w", a.context.LastError())
@@ -389,7 +389,7 @@ func (a *Attribute) Type() (Datatype, error) {
 
 // DumpSTDOUT dumps the attribute in ASCII format to stdout.
 func (a *Attribute) DumpSTDOUT() error {
-	ret := C.tiledb_attribute_dump(a.context.tiledbContext, a.tiledbAttribute.Get(), C.stdout)
+	ret := C.tiledb_attribute_dump(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), C.stdout)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping attribute to stdout: %w", a.context.LastError())
@@ -417,7 +417,7 @@ func (a *Attribute) Dump(path string) error {
 	defer C.fclose(cFile)
 
 	// Dump attribute to file
-	ret := C.tiledb_attribute_dump(a.context.tiledbContext, a.tiledbAttribute.Get(), cFile)
+	ret := C.tiledb_attribute_dump(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), cFile)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping attribute to file %s: %w", path, a.context.LastError())
@@ -431,7 +431,7 @@ func (a *Attribute) SetNullable(nullable bool) error {
 	if nullable {
 		cNullable = 1
 	}
-	ret := C.tiledb_attribute_set_nullable(a.context.tiledbContext,
+	ret := C.tiledb_attribute_set_nullable(a.context.tiledbContext.Get(),
 		a.tiledbAttribute.Get(), cNullable)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
@@ -443,7 +443,7 @@ func (a *Attribute) SetNullable(nullable bool) error {
 // Nullable returns if the attribute is nullable or not.
 func (a *Attribute) Nullable() (bool, error) {
 	var nullable C.uint8_t
-	ret := C.tiledb_attribute_get_nullable(a.context.tiledbContext, a.tiledbAttribute.Get(), &nullable)
+	ret := C.tiledb_attribute_get_nullable(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), &nullable)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error getting tiledb attribute nullable: %w", a.context.LastError())

--- a/attribute.go
+++ b/attribute.go
@@ -76,7 +76,7 @@ func (a *Attribute) Context() *Context {
 
 // SetFilterList sets the attribute filterList.
 func (a *Attribute) SetFilterList(filterlist *FilterList) error {
-	ret := C.tiledb_attribute_set_filter_list(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), filterlist.tiledbFilterList)
+	ret := C.tiledb_attribute_set_filter_list(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), filterlist.tiledbFilterList.Get())
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(filterlist)
 	if ret != C.TILEDB_OK {
@@ -87,15 +87,14 @@ func (a *Attribute) SetFilterList(filterlist *FilterList) error {
 
 // FilterList returns a copy of the filter list for attribute.
 func (a *Attribute) FilterList() (*FilterList, error) {
-	filterList := FilterList{context: a.context}
-	ret := C.tiledb_attribute_get_filter_list(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), &filterList.tiledbFilterList)
+	var filterListPtr *C.tiledb_filter_list_t
+	ret := C.tiledb_attribute_get_filter_list(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), &filterListPtr)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb attribute filter list: %w", a.context.LastError())
 	}
-	freeOnGC(&filterList)
 
-	return &filterList, nil
+	return newFilterListFromHandle(a.context, newFilterListHandle(filterListPtr)), nil
 }
 
 // SetCellValNum sets the number of attribute values per cell.

--- a/buffer.go
+++ b/buffer.go
@@ -42,15 +42,15 @@ func newBufferHandle(ptr *C.tiledb_buffer_t) bufferHandle {
 	return bufferHandle{newCapiHandle(unsafe.Pointer(state), freeCapiBufferState)}
 }
 
-func (x *bufferHandle) getState() *bufferHandleState {
+func (x bufferHandle) getState() *bufferHandleState {
 	return (*bufferHandleState)(x.capiHandle.Get())
 }
 
-func (x *bufferHandle) Get() *C.tiledb_buffer_t {
+func (x bufferHandle) Get() *C.tiledb_buffer_t {
 	return x.getState().ptr
 }
 
-func (x *bufferHandle) Pin(p any) {
+func (x bufferHandle) Pin(p any) {
 	x.getState().pinner.Pin(p)
 }
 

--- a/buffer.go
+++ b/buffer.go
@@ -72,7 +72,7 @@ func NewBuffer(context *Context) (*Buffer, error) {
 	}
 
 	var bufferPtr *C.tiledb_buffer_t
-	ret := C.tiledb_buffer_alloc(context.tiledbContext, &bufferPtr)
+	ret := C.tiledb_buffer_alloc(context.tiledbContext.Get(), &bufferPtr)
 	runtime.KeepAlive(context)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb buffer: %w", context.LastError())
@@ -97,7 +97,7 @@ func (b *Buffer) Context() *Context {
 
 // SetType sets the buffer datatype.
 func (b *Buffer) SetType(datatype Datatype) error {
-	ret := C.tiledb_buffer_set_type(b.context.tiledbContext, b.tiledbBuffer.Get(), C.tiledb_datatype_t(datatype))
+	ret := C.tiledb_buffer_set_type(b.context.tiledbContext.Get(), b.tiledbBuffer.Get(), C.tiledb_datatype_t(datatype))
 	runtime.KeepAlive(b)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting datatype for tiledb buffer: %w", b.context.LastError())
@@ -108,7 +108,7 @@ func (b *Buffer) SetType(datatype Datatype) error {
 // Type returns the buffer datatype.
 func (b *Buffer) Type() (Datatype, error) {
 	var bufferType C.tiledb_datatype_t
-	ret := C.tiledb_buffer_get_type(b.context.tiledbContext, b.tiledbBuffer.Get(), &bufferType)
+	ret := C.tiledb_buffer_get_type(b.context.tiledbContext.Get(), b.tiledbBuffer.Get(), &bufferType)
 	runtime.KeepAlive(b)
 
 	if ret != C.TILEDB_OK {
@@ -147,7 +147,7 @@ func (b *Buffer) ReadAt(p []byte, off int64) (int, error) {
 	var cbuffer unsafe.Pointer // b must be kept alive while cbuffer is being accessed.
 	var csize C.uint64_t
 
-	ret := C.tiledb_buffer_get_data(b.context.tiledbContext, b.tiledbBuffer.Get(), &cbuffer, &csize)
+	ret := C.tiledb_buffer_get_data(b.context.tiledbContext.Get(), b.tiledbBuffer.Get(), &cbuffer, &csize)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb buffer data: %w", b.context.LastError())
 	}
@@ -176,7 +176,7 @@ func (b *Buffer) WriteTo(w io.Writer) (int64, error) {
 	var cbuffer unsafe.Pointer // b must be kept alive while cbuffer is being accessed.
 	var csize C.uint64_t
 
-	ret := C.tiledb_buffer_get_data(b.context.tiledbContext, b.tiledbBuffer.Get(), &cbuffer, &csize)
+	ret := C.tiledb_buffer_get_data(b.context.tiledbContext.Get(), b.tiledbBuffer.Get(), &cbuffer, &csize)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb buffer data: %w", b.context.LastError())
 	}
@@ -215,7 +215,7 @@ func (b *Buffer) SetBuffer(buffer []byte) error {
 	cbuffer := unsafe.Pointer(unsafe.SliceData(buffer))
 	b.tiledbBuffer.Pin(cbuffer)
 
-	ret := C.tiledb_buffer_set_data(b.context.tiledbContext, b.tiledbBuffer.Get(), cbuffer, C.uint64_t(len(buffer)))
+	ret := C.tiledb_buffer_set_data(b.context.tiledbContext.Get(), b.tiledbBuffer.Get(), cbuffer, C.uint64_t(len(buffer)))
 	runtime.KeepAlive(b)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting tiledb buffer: %w", b.context.LastError())
@@ -229,7 +229,7 @@ func (b *Buffer) dataCopy() ([]byte, error) {
 	var cbuffer unsafe.Pointer // b must be kept alive while cbuffer is being accessed.
 	var csize C.uint64_t
 
-	ret := C.tiledb_buffer_get_data(b.context.tiledbContext, b.tiledbBuffer.Get(), &cbuffer, &csize)
+	ret := C.tiledb_buffer_get_data(b.context.tiledbContext.Get(), b.tiledbBuffer.Get(), &cbuffer, &csize)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb buffer data: %w", b.context.LastError())
 	}
@@ -251,7 +251,7 @@ func (b *Buffer) Len() (uint64, error) {
 	var cbuffer unsafe.Pointer
 	var csize C.uint64_t
 
-	ret := C.tiledb_buffer_get_data(b.context.tiledbContext, b.tiledbBuffer.Get(), &cbuffer, &csize)
+	ret := C.tiledb_buffer_get_data(b.context.tiledbContext.Get(), b.tiledbBuffer.Get(), &cbuffer, &csize)
 	runtime.KeepAlive(b)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb buffer data: %w", b.context.LastError())

--- a/buffer_list.go
+++ b/buffer_list.go
@@ -92,16 +92,14 @@ func (b *BufferList) NumBuffers() (uint64, error) {
 
 // GetBuffer returns a Buffer at the given index in the list.
 func (b *BufferList) GetBuffer(bufferIndex uint) (*Buffer, error) {
-	buffer := Buffer{context: b.context}
-
-	ret := C.tiledb_buffer_list_get_buffer(b.context.tiledbContext, b.tiledbBufferList, C.uint64_t(bufferIndex), &buffer.tiledbBuffer)
+	var bufferPtr *C.tiledb_buffer_t
+	ret := C.tiledb_buffer_list_get_buffer(b.context.tiledbContext, b.tiledbBufferList, C.uint64_t(bufferIndex), &bufferPtr)
 	runtime.KeepAlive(b)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb buffer index %d from buffer list: %w", bufferIndex, b.context.LastError())
 	}
-	freeOnGC(&buffer)
 
-	return &buffer, nil
+	return newBufferFromHandle(b.context, newBufferHandle(bufferPtr)), nil
 }
 
 // TotalSize returns the total number of bytes in the buffers in the list.
@@ -121,15 +119,13 @@ func (b *BufferList) TotalSize() (uint64, error) {
 //
 // Deprecated: Use WriteTo instead for increased performance.
 func (b *BufferList) Flatten() (*Buffer, error) {
-	buffer := Buffer{context: b.context}
-
-	ret := C.tiledb_buffer_list_flatten(b.context.tiledbContext, b.tiledbBufferList, &buffer.tiledbBuffer)
+	var bufferPtr *C.tiledb_buffer_t
+	ret := C.tiledb_buffer_list_flatten(b.context.tiledbContext, b.tiledbBufferList, &bufferPtr)
 	runtime.KeepAlive(b)
 
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb bufferList num buffers: %w", b.context.LastError())
 	}
-	freeOnGC(&buffer)
 
-	return &buffer, nil
+	return newBufferFromHandle(b.context, newBufferHandle(bufferPtr)), nil
 }

--- a/buffer_list.go
+++ b/buffer_list.go
@@ -9,26 +9,43 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"unsafe"
 )
+
+type bufferListHandle struct{ *capiHandle }
+
+func freeCapiBufferList(c unsafe.Pointer) {
+	C.tiledb_buffer_list_free((**C.tiledb_buffer_list_t)(unsafe.Pointer(&c)))
+}
+
+func newBufferListHandle(ptr *C.tiledb_buffer_list_t) bufferListHandle {
+	return bufferListHandle{newCapiHandle(unsafe.Pointer(ptr), freeCapiBufferList)}
+}
+
+func (x bufferListHandle) Get() *C.tiledb_buffer_list_t {
+	return (*C.tiledb_buffer_list_t)(x.capiHandle.Get())
+}
 
 // BufferList A list of TileDB BufferList objects
 type BufferList struct {
-	tiledbBufferList *C.tiledb_buffer_list_t
+	tiledbBufferList bufferListHandle
 	context          *Context
+}
+
+func newBufferListFromHandle(context *Context, handle bufferListHandle) *BufferList {
+	return &BufferList{tiledbBufferList: handle, context: context}
 }
 
 // NewBufferList Allocs a new buffer list
 func NewBufferList(context *Context) (*BufferList, error) {
-	bufferList := BufferList{context: context}
-
-	ret := C.tiledb_buffer_list_alloc(bufferList.context.tiledbContext, &bufferList.tiledbBufferList)
+	var bufferListPtr *C.tiledb_buffer_list_t
+	ret := C.tiledb_buffer_list_alloc(context.tiledbContext, &bufferListPtr)
 	runtime.KeepAlive(context)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error creating tiledb buffer list: %w", bufferList.context.LastError())
+		return nil, fmt.Errorf("error creating tiledb buffer list: %w", context.LastError())
 	}
-	freeOnGC(&bufferList)
 
-	return &bufferList, nil
+	return newBufferListFromHandle(context, newBufferListHandle(bufferListPtr)), nil
 }
 
 // Free releases the internal TileDB core data that was allocated on the C heap.
@@ -37,9 +54,7 @@ func NewBufferList(context *Context) (*BufferList, error) {
 // can safely be called many times on the same object; if it has already
 // been freed, it will not be freed again.
 func (b *BufferList) Free() {
-	if b.tiledbBufferList != nil {
-		C.tiledb_buffer_list_free(&b.tiledbBufferList)
-	}
+	b.tiledbBufferList.Free()
 }
 
 // Context exposes the internal TileDB context used to initialize the buffer list.
@@ -80,7 +95,7 @@ var _ io.WriterTo = (*BufferList)(nil)
 // NumBuffers returns number of buffers in the list.
 func (b *BufferList) NumBuffers() (uint64, error) {
 	var numBuffers C.uint64_t
-	ret := C.tiledb_buffer_list_get_num_buffers(b.context.tiledbContext, b.tiledbBufferList, &numBuffers)
+	ret := C.tiledb_buffer_list_get_num_buffers(b.context.tiledbContext, b.tiledbBufferList.Get(), &numBuffers)
 	runtime.KeepAlive(b)
 
 	if ret != C.TILEDB_OK {
@@ -93,7 +108,7 @@ func (b *BufferList) NumBuffers() (uint64, error) {
 // GetBuffer returns a Buffer at the given index in the list.
 func (b *BufferList) GetBuffer(bufferIndex uint) (*Buffer, error) {
 	var bufferPtr *C.tiledb_buffer_t
-	ret := C.tiledb_buffer_list_get_buffer(b.context.tiledbContext, b.tiledbBufferList, C.uint64_t(bufferIndex), &bufferPtr)
+	ret := C.tiledb_buffer_list_get_buffer(b.context.tiledbContext, b.tiledbBufferList.Get(), C.uint64_t(bufferIndex), &bufferPtr)
 	runtime.KeepAlive(b)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb buffer index %d from buffer list: %w", bufferIndex, b.context.LastError())
@@ -105,7 +120,7 @@ func (b *BufferList) GetBuffer(bufferIndex uint) (*Buffer, error) {
 // TotalSize returns the total number of bytes in the buffers in the list.
 func (b *BufferList) TotalSize() (uint64, error) {
 	var totalSize C.uint64_t
-	ret := C.tiledb_buffer_list_get_total_size(b.context.tiledbContext, b.tiledbBufferList, &totalSize)
+	ret := C.tiledb_buffer_list_get_total_size(b.context.tiledbContext, b.tiledbBufferList.Get(), &totalSize)
 	runtime.KeepAlive(b)
 
 	if ret != C.TILEDB_OK {
@@ -120,7 +135,7 @@ func (b *BufferList) TotalSize() (uint64, error) {
 // Deprecated: Use WriteTo instead for increased performance.
 func (b *BufferList) Flatten() (*Buffer, error) {
 	var bufferPtr *C.tiledb_buffer_t
-	ret := C.tiledb_buffer_list_flatten(b.context.tiledbContext, b.tiledbBufferList, &bufferPtr)
+	ret := C.tiledb_buffer_list_flatten(b.context.tiledbContext, b.tiledbBufferList.Get(), &bufferPtr)
 	runtime.KeepAlive(b)
 
 	if ret != C.TILEDB_OK {

--- a/buffer_list.go
+++ b/buffer_list.go
@@ -39,7 +39,7 @@ func newBufferListFromHandle(context *Context, handle bufferListHandle) *BufferL
 // NewBufferList Allocs a new buffer list
 func NewBufferList(context *Context) (*BufferList, error) {
 	var bufferListPtr *C.tiledb_buffer_list_t
-	ret := C.tiledb_buffer_list_alloc(context.tiledbContext, &bufferListPtr)
+	ret := C.tiledb_buffer_list_alloc(context.tiledbContext.Get(), &bufferListPtr)
 	runtime.KeepAlive(context)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb buffer list: %w", context.LastError())
@@ -95,7 +95,7 @@ var _ io.WriterTo = (*BufferList)(nil)
 // NumBuffers returns number of buffers in the list.
 func (b *BufferList) NumBuffers() (uint64, error) {
 	var numBuffers C.uint64_t
-	ret := C.tiledb_buffer_list_get_num_buffers(b.context.tiledbContext, b.tiledbBufferList.Get(), &numBuffers)
+	ret := C.tiledb_buffer_list_get_num_buffers(b.context.tiledbContext.Get(), b.tiledbBufferList.Get(), &numBuffers)
 	runtime.KeepAlive(b)
 
 	if ret != C.TILEDB_OK {
@@ -108,7 +108,7 @@ func (b *BufferList) NumBuffers() (uint64, error) {
 // GetBuffer returns a Buffer at the given index in the list.
 func (b *BufferList) GetBuffer(bufferIndex uint) (*Buffer, error) {
 	var bufferPtr *C.tiledb_buffer_t
-	ret := C.tiledb_buffer_list_get_buffer(b.context.tiledbContext, b.tiledbBufferList.Get(), C.uint64_t(bufferIndex), &bufferPtr)
+	ret := C.tiledb_buffer_list_get_buffer(b.context.tiledbContext.Get(), b.tiledbBufferList.Get(), C.uint64_t(bufferIndex), &bufferPtr)
 	runtime.KeepAlive(b)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb buffer index %d from buffer list: %w", bufferIndex, b.context.LastError())
@@ -120,7 +120,7 @@ func (b *BufferList) GetBuffer(bufferIndex uint) (*Buffer, error) {
 // TotalSize returns the total number of bytes in the buffers in the list.
 func (b *BufferList) TotalSize() (uint64, error) {
 	var totalSize C.uint64_t
-	ret := C.tiledb_buffer_list_get_total_size(b.context.tiledbContext, b.tiledbBufferList.Get(), &totalSize)
+	ret := C.tiledb_buffer_list_get_total_size(b.context.tiledbContext.Get(), b.tiledbBufferList.Get(), &totalSize)
 	runtime.KeepAlive(b)
 
 	if ret != C.TILEDB_OK {
@@ -135,7 +135,7 @@ func (b *BufferList) TotalSize() (uint64, error) {
 // Deprecated: Use WriteTo instead for increased performance.
 func (b *BufferList) Flatten() (*Buffer, error) {
 	var bufferPtr *C.tiledb_buffer_t
-	ret := C.tiledb_buffer_list_flatten(b.context.tiledbContext, b.tiledbBufferList.Get(), &bufferPtr)
+	ret := C.tiledb_buffer_list_flatten(b.context.tiledbContext.Get(), b.tiledbBufferList.Get(), &bufferPtr)
 	runtime.KeepAlive(b)
 
 	if ret != C.TILEDB_OK {

--- a/capi_handle.go
+++ b/capi_handle.go
@@ -34,7 +34,7 @@ func (x *capiHandle) Free() {
 func (x *capiHandle) Get() (ptr unsafe.Pointer) {
 	ptr = atomic.LoadPointer(&x.ptr)
 	if ptr == nil {
-		panic("cannot use freed handle")
+		panic("capiHandle.Get: handle is freed")
 	}
 	return
 }

--- a/capi_handle.go
+++ b/capi_handle.go
@@ -1,0 +1,60 @@
+package tiledb
+
+/*
+#include <tiledb/tiledb.h>
+*/
+import "C"
+
+import (
+	"runtime"
+	"sync/atomic"
+)
+
+// capiHandle encapsulates and manages the lifetime of a TileDB C API handle.
+type capiHandle[T any] struct {
+	ptr      atomic.Pointer[T]
+	freeFunc func(*T)
+	cleanup  runtime.Cleanup
+}
+
+// Free releases the native handle held by the capiHandle.
+// This method is safe to call from multiple goroutines concurrently.
+// However, freeing the handle while it is being used by another goroutine is not safe and
+// will result in crashes. If you cannot ensure that only one goroutine will free the handle
+// after the others have finished using it, you should not use
+func (x *capiHandle[T]) Free() {
+	x.cleanup.Stop()
+	p := x.ptr.Swap(nil)
+	// Do not fail if a handle is freed multiple times.
+	if p != nil {
+		x.freeFunc(p)
+	}
+}
+
+// Get returns the native pointer contained in the capiHandle.
+// This function will panic if it is called after calling Free.
+func (x *capiHandle[T]) Get() (ptr *T) {
+	ptr = x.ptr.Load()
+	if ptr == nil {
+		panic("cannot use freed handle")
+	}
+	return
+}
+
+func newCapiHandle[T any](p *T, freeFunc func(*T)) *capiHandle[T] {
+	if p == nil {
+		return nil
+	}
+	handle := &capiHandle[T]{
+		freeFunc: freeFunc,
+	}
+	handle.ptr.Store(p)
+	handle.cleanup = runtime.AddCleanup(handle, freeFunc, p)
+	return handle
+}
+
+func freeCapiArray(c *C.tiledb_array_t) { C.tiledb_array_free(&c) }
+
+func newArrayHandle(ptr *C.tiledb_array_t) *capiHandle[C.tiledb_array_t] {
+	return newCapiHandle(ptr, freeCapiArray)
+}

--- a/capi_handle.go
+++ b/capi_handle.go
@@ -1,10 +1,5 @@
 package tiledb
 
-/*
-#include <tiledb/tiledb.h>
-*/
-import "C"
-
 import (
 	"runtime"
 	"sync/atomic"
@@ -12,7 +7,7 @@ import (
 )
 
 // capiHandle encapsulates and manages the lifetime of a TileDB C API handle.
-// Do not use directly; use one of the wrapper types for specialized handle kinds.
+// Do not use directly; use one of the wrapper types for specific handle kinds.
 type capiHandle struct {
 	ptr      unsafe.Pointer
 	freeFunc func(unsafe.Pointer)
@@ -53,16 +48,4 @@ func newCapiHandle(p unsafe.Pointer, freeFunc func(unsafe.Pointer)) *capiHandle 
 	atomic.StorePointer(&handle.ptr, unsafe.Pointer(p))
 	handle.cleanup = runtime.AddCleanup(handle, freeFunc, p)
 	return handle
-}
-
-type arrayHandle struct{ *capiHandle }
-
-func freeCapiArray(c unsafe.Pointer) { C.tiledb_array_free((**C.tiledb_array_t)(unsafe.Pointer(&c))) }
-
-func newArrayHandle(ptr *C.tiledb_array_t) arrayHandle {
-	return arrayHandle{newCapiHandle(unsafe.Pointer(ptr), freeCapiArray)}
-}
-
-func (x arrayHandle) Get() *C.tiledb_array_t {
-	return (*C.tiledb_array_t)(x.capiHandle.Get())
 }

--- a/capi_handle.go
+++ b/capi_handle.go
@@ -8,12 +8,14 @@ import "C"
 import (
 	"runtime"
 	"sync/atomic"
+	"unsafe"
 )
 
 // capiHandle encapsulates and manages the lifetime of a TileDB C API handle.
-type capiHandle[T any] struct {
-	ptr      atomic.Pointer[T]
-	freeFunc func(*T)
+// Do not use directly; use one of the wrapper types for specialized handle kinds.
+type capiHandle struct {
+	ptr      unsafe.Pointer
+	freeFunc func(unsafe.Pointer)
 	cleanup  runtime.Cleanup
 }
 
@@ -22,9 +24,9 @@ type capiHandle[T any] struct {
 // However, freeing the handle while it is being used by another goroutine is not safe and
 // will result in crashes. If you cannot ensure that only one goroutine will free the handle
 // after the others have finished using it, you should not use
-func (x *capiHandle[T]) Free() {
+func (x *capiHandle) Free() {
 	x.cleanup.Stop()
-	p := x.ptr.Swap(nil)
+	p := atomic.SwapPointer(&x.ptr, nil)
 	// Do not fail if a handle is freed multiple times.
 	if p != nil {
 		x.freeFunc(p)
@@ -33,28 +35,34 @@ func (x *capiHandle[T]) Free() {
 
 // Get returns the native pointer contained in the capiHandle.
 // This function will panic if it is called after calling Free.
-func (x *capiHandle[T]) Get() (ptr *T) {
-	ptr = x.ptr.Load()
+func (x *capiHandle) Get() (ptr unsafe.Pointer) {
+	ptr = atomic.LoadPointer(&x.ptr)
 	if ptr == nil {
 		panic("cannot use freed handle")
 	}
 	return
 }
 
-func newCapiHandle[T any](p *T, freeFunc func(*T)) *capiHandle[T] {
+func newCapiHandle(p unsafe.Pointer, freeFunc func(unsafe.Pointer)) *capiHandle {
 	if p == nil {
 		return nil
 	}
-	handle := &capiHandle[T]{
+	handle := &capiHandle{
 		freeFunc: freeFunc,
 	}
-	handle.ptr.Store(p)
+	atomic.StorePointer(&handle.ptr, unsafe.Pointer(p))
 	handle.cleanup = runtime.AddCleanup(handle, freeFunc, p)
 	return handle
 }
 
-func freeCapiArray(c *C.tiledb_array_t) { C.tiledb_array_free(&c) }
+type arrayHandle struct{ *capiHandle }
 
-func newArrayHandle(ptr *C.tiledb_array_t) *capiHandle[C.tiledb_array_t] {
-	return newCapiHandle(ptr, freeCapiArray)
+func freeCapiArray(c unsafe.Pointer) { C.tiledb_array_free((**C.tiledb_array_t)(unsafe.Pointer(&c))) }
+
+func newArrayHandle(ptr *C.tiledb_array_t) arrayHandle {
+	return arrayHandle{newCapiHandle(unsafe.Pointer(ptr), freeCapiArray)}
+}
+
+func (x arrayHandle) Get() *C.tiledb_array_t {
+	return (*C.tiledb_array_t)(x.capiHandle.Get())
 }

--- a/config_iter.go
+++ b/config_iter.go
@@ -43,7 +43,7 @@ func NewConfigIter(config *Config, prefix string) (*ConfigIter, error) {
 	cprefix := C.CString(prefix)
 	defer C.free(unsafe.Pointer(cprefix))
 	var configIterPtr *C.tiledb_config_iter_t
-	C.tiledb_config_iter_alloc(config.tiledbConfig, cprefix, &configIterPtr, &err)
+	C.tiledb_config_iter_alloc(config.tiledbConfig.Get(), cprefix, &configIterPtr, &err)
 	runtime.KeepAlive(config)
 	if err != nil {
 		defer C.tiledb_error_free(&err)
@@ -121,7 +121,7 @@ func (ci *ConfigIter) Reset(prefix string) error {
 	var err *C.tiledb_error_t
 	cprefix := C.CString(prefix)
 	defer C.free(unsafe.Pointer(cprefix))
-	C.tiledb_config_iter_reset(ci.config.tiledbConfig, ci.tiledbConfigIter.Get(), cprefix, &err)
+	C.tiledb_config_iter_reset(ci.config.tiledbConfig.Get(), ci.tiledbConfigIter.Get(), cprefix, &err)
 	runtime.KeepAlive(ci)
 	if err != nil {
 		defer C.tiledb_error_free(&err)

--- a/config_iter.go
+++ b/config_iter.go
@@ -12,28 +12,45 @@ import (
 	"unsafe"
 )
 
+type configIterHandle struct{ *capiHandle }
+
+func freeCapiConfigIter(c unsafe.Pointer) {
+	C.tiledb_config_iter_free((**C.tiledb_config_iter_t)(unsafe.Pointer(&c)))
+}
+
+func newConfigIterHandle(ptr *C.tiledb_config_iter_t) configIterHandle {
+	return configIterHandle{newCapiHandle(unsafe.Pointer(ptr), freeCapiConfigIter)}
+}
+
+func (x configIterHandle) Get() *C.tiledb_config_iter_t {
+	return (*C.tiledb_config_iter_t)(x.capiHandle.Get())
+}
+
 // ConfigIter creates a config iterator object.
 type ConfigIter struct {
 	config           *Config
-	tiledbConfigIter *C.tiledb_config_iter_t
+	tiledbConfigIter configIterHandle
+}
+
+func newConfigIterFromHandle(config *Config, handle configIterHandle) *ConfigIter {
+	return &ConfigIter{config: config, tiledbConfigIter: handle}
 }
 
 // NewConfigIter creates an iterator for configuration. This can be used
 // only for reading. This sets the pointer to the first search item.
 func NewConfigIter(config *Config, prefix string) (*ConfigIter, error) {
-	ci := ConfigIter{config: config}
 	var err *C.tiledb_error_t
 	cprefix := C.CString(prefix)
 	defer C.free(unsafe.Pointer(cprefix))
-	C.tiledb_config_iter_alloc(config.tiledbConfig, cprefix, &ci.tiledbConfigIter, &err)
+	var configIterPtr *C.tiledb_config_iter_t
+	C.tiledb_config_iter_alloc(config.tiledbConfig, cprefix, &configIterPtr, &err)
 	runtime.KeepAlive(config)
 	if err != nil {
 		defer C.tiledb_error_free(&err)
 		return nil, fmt.Errorf("error creating tiledb config iter: %w", cError(err))
 	}
-	freeOnGC(&ci)
 
-	return &ci, nil
+	return newConfigIterFromHandle(config, newConfigIterHandle(configIterPtr)), nil
 }
 
 // Free releases the internal TileDB core data that was allocated on the C heap.
@@ -42,9 +59,7 @@ func NewConfigIter(config *Config, prefix string) (*ConfigIter, error) {
 // can safely be called many times on the same object; if it has already
 // been freed, it will not be freed again.
 func (ci *ConfigIter) Free() {
-	if ci.tiledbConfigIter != nil {
-		C.tiledb_config_iter_free(&ci.tiledbConfigIter)
-	}
+	ci.tiledbConfigIter.Free()
 }
 
 // Here retrieves the param and value for the item currently pointed to by the
@@ -52,7 +67,7 @@ func (ci *ConfigIter) Free() {
 func (ci *ConfigIter) Here() (*string, *string, error) {
 	var err *C.tiledb_error_t
 	var cparam, cvalue *C.char // ci must be kept alive while these are being accessed.
-	C.tiledb_config_iter_here(ci.tiledbConfigIter, &cparam, &cvalue, &err)
+	C.tiledb_config_iter_here(ci.tiledbConfigIter.Get(), &cparam, &cvalue, &err)
 	if err != nil {
 		defer C.tiledb_error_free(&err)
 		return nil, nil, fmt.Errorf("error getting param, value from config iter: %w", cError(err))
@@ -66,7 +81,7 @@ func (ci *ConfigIter) Here() (*string, *string, error) {
 // Next moves the iterator to the next item.
 func (ci *ConfigIter) Next() error {
 	var err *C.tiledb_error_t
-	C.tiledb_config_iter_next(ci.tiledbConfigIter, &err)
+	C.tiledb_config_iter_next(ci.tiledbConfigIter.Get(), &err)
 	runtime.KeepAlive(ci)
 	if err != nil {
 		defer C.tiledb_error_free(&err)
@@ -79,7 +94,7 @@ func (ci *ConfigIter) Next() error {
 func (ci *ConfigIter) Done() (bool, error) {
 	var err *C.tiledb_error_t
 	var cDone C.int32_t
-	C.tiledb_config_iter_done(ci.tiledbConfigIter, &cDone, &err)
+	C.tiledb_config_iter_done(ci.tiledbConfigIter.Get(), &cDone, &err)
 	runtime.KeepAlive(ci)
 	if err != nil {
 		defer C.tiledb_error_free(&err)
@@ -92,7 +107,7 @@ func (ci *ConfigIter) Done() (bool, error) {
 func (ci *ConfigIter) IsDone() bool {
 	var err *C.tiledb_error_t
 	var cDone C.int32_t
-	C.tiledb_config_iter_done(ci.tiledbConfigIter, &cDone, &err)
+	C.tiledb_config_iter_done(ci.tiledbConfigIter.Get(), &cDone, &err)
 	runtime.KeepAlive(ci)
 	if err != nil {
 		C.tiledb_error_free(&err)
@@ -106,7 +121,7 @@ func (ci *ConfigIter) Reset(prefix string) error {
 	var err *C.tiledb_error_t
 	cprefix := C.CString(prefix)
 	defer C.free(unsafe.Pointer(cprefix))
-	C.tiledb_config_iter_reset(ci.config.tiledbConfig, ci.tiledbConfigIter, cprefix, &err)
+	C.tiledb_config_iter_reset(ci.config.tiledbConfig, ci.tiledbConfigIter.Get(), cprefix, &err)
 	runtime.KeepAlive(ci)
 	if err != nil {
 		defer C.tiledb_error_free(&err)

--- a/context.go
+++ b/context.go
@@ -14,24 +14,42 @@ import (
 	"unsafe"
 )
 
+type contextHandle struct{ *capiHandle }
+
+func freeCapiContext(c unsafe.Pointer) {
+	C.tiledb_ctx_free((**C.tiledb_ctx_t)(unsafe.Pointer(&c)))
+}
+
+func newContextHandle(ptr *C.tiledb_ctx_t) contextHandle {
+	return contextHandle{newCapiHandle(unsafe.Pointer(ptr), freeCapiContext)}
+}
+
+func (x contextHandle) Get() *C.tiledb_ctx_t {
+	return (*C.tiledb_ctx_t)(x.capiHandle.Get())
+}
+
 // Context A TileDB context wraps a TileDB storage manager “instance.” Most
 // objects and functions will require a Context.
 // Internal error handling is also defined by the Context;
 // the default error handler throws a TileDBError with a specific message.
 type Context struct {
-	tiledbContext *C.tiledb_ctx_t
+	tiledbContext contextHandle
+}
+
+func newContextFromHandle(handle contextHandle) *Context {
+	return &Context{tiledbContext: handle}
 }
 
 // NewContext creates a TileDB context with the given configuration.
 // If the configuration passed is nil, it is created with the default config.
 func NewContext(config *Config) (*Context, error) {
-	var context Context
+	var contextPtr *C.tiledb_ctx_t
 	var ret C.int32_t
 	var tdbErr *C.tiledb_error_t
 	if config != nil {
-		ret = C.tiledb_ctx_alloc_with_error(config.tiledbConfig.Get(), &context.tiledbContext, &tdbErr)
+		ret = C.tiledb_ctx_alloc_with_error(config.tiledbConfig.Get(), &contextPtr, &tdbErr)
 	} else {
-		ret = C.tiledb_ctx_alloc_with_error(nil, &context.tiledbContext, &tdbErr)
+		ret = C.tiledb_ctx_alloc_with_error(nil, &contextPtr, &tdbErr)
 	}
 	runtime.KeepAlive(config)
 	if ret != C.TILEDB_OK {
@@ -42,20 +60,16 @@ func NewContext(config *Config) (*Context, error) {
 			defer C.tiledb_error_free(&tdbErr)
 			return nil, fmt.Errorf("error creating tiledb context: %s", C.GoString(msg))
 		}
-		// If the context is not null see if the error exists there
-		if context.tiledbContext != nil {
-			return nil, fmt.Errorf("error creating tiledb context: %w", context.LastError())
-		}
 		return nil, fmt.Errorf("error creating tiledb context: unknown error")
 	}
-	freeOnGC(&context)
+	context := newContextFromHandle(newContextHandle(contextPtr))
 
 	err := context.setDefaultTags()
 	if err != nil {
 		return nil, fmt.Errorf("error creating tiledb context: %w", err)
 	}
 
-	return &context, nil
+	return context, nil
 }
 
 // NewContextFromMap creates a TileDB context with the given configuration.
@@ -87,14 +101,12 @@ func NewContextFromMap(cfgMap map[string]string) (*Context, error) {
 // can safely be called many times on the same object; if it has already
 // been freed, it will not be freed again.
 func (c *Context) Free() {
-	if c.tiledbContext != nil {
-		C.tiledb_ctx_free(&c.tiledbContext)
-	}
+	c.tiledbContext.Free()
 }
 
 // CancelAllTasks cancels all currently executing tasks on the context.
 func (c *Context) CancelAllTasks() error {
-	ret := C.tiledb_ctx_cancel_tasks(c.tiledbContext)
+	ret := C.tiledb_ctx_cancel_tasks(c.tiledbContext.Get())
 	if ret != C.TILEDB_OK {
 		return errors.New("failed to cancel tasks")
 	}
@@ -104,7 +116,7 @@ func (c *Context) CancelAllTasks() error {
 // Config retrieves a copy of the config from context.
 func (c *Context) Config() (*Config, error) {
 	var configPtr *C.tiledb_config_t
-	ret := C.tiledb_ctx_get_config(c.tiledbContext, &configPtr)
+	ret := C.tiledb_ctx_get_config(c.tiledbContext.Get(), &configPtr)
 	runtime.KeepAlive(c)
 
 	if ret == C.TILEDB_OOM {
@@ -119,7 +131,7 @@ func (c *Context) Config() (*Config, error) {
 // LastError returns the last error from this context.
 func (c *Context) LastError() error {
 	var err *C.tiledb_error_t
-	ret := C.tiledb_ctx_get_last_error(c.tiledbContext, &err)
+	ret := C.tiledb_ctx_get_last_error(c.tiledbContext.Get(), &err)
 	runtime.KeepAlive(c)
 	if ret == C.TILEDB_OOM {
 		return errors.New("out of Memory error in tiledb_ctx_get_last_error")
@@ -137,7 +149,7 @@ func (c *Context) LastError() error {
 // IsSupportedFS returns true if the given filesystem backend is supported.
 func (c *Context) IsSupportedFS(fs FS) (bool, error) {
 	var isSupported C.int32_t
-	ret := C.tiledb_ctx_is_supported_fs(c.tiledbContext, C.tiledb_filesystem_t(fs), &isSupported)
+	ret := C.tiledb_ctx_is_supported_fs(c.tiledbContext.Get(), C.tiledb_filesystem_t(fs), &isSupported)
 	runtime.KeepAlive(c)
 
 	if ret != C.TILEDB_OK {
@@ -154,7 +166,7 @@ func (c *Context) SetTag(key string, value string) error {
 	cvalue := C.CString(value)
 	defer C.free(unsafe.Pointer(cvalue))
 
-	ret := C.tiledb_ctx_set_tag(c.tiledbContext, ckey, cvalue)
+	ret := C.tiledb_ctx_set_tag(c.tiledbContext.Get(), ckey, cvalue)
 	runtime.KeepAlive(c)
 
 	if ret != C.TILEDB_OK {
@@ -186,7 +198,7 @@ func (c *Context) setDefaultTags() error {
 // Stats gets stats for a context as json bytes.
 func (c *Context) Stats() ([]byte, error) {
 	var stats *C.char
-	if ret := C.tiledb_ctx_get_stats(c.tiledbContext, &stats); ret != C.TILEDB_OK {
+	if ret := C.tiledb_ctx_get_stats(c.tiledbContext.Get(), &stats); ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting stats from context: %w", c.LastError())
 	}
 	runtime.KeepAlive(c)

--- a/dimension.go
+++ b/dimension.go
@@ -15,17 +15,34 @@ import (
 	"unsafe"
 )
 
+type dimensionHandle struct{ *capiHandle }
+
+func freeCapiDimension(c unsafe.Pointer) {
+	C.tiledb_dimension_free((**C.tiledb_dimension_t)(unsafe.Pointer(&c)))
+}
+
+func newDimensionHandle(ptr *C.tiledb_dimension_t) dimensionHandle {
+	return dimensionHandle{newCapiHandle(unsafe.Pointer(ptr), freeCapiDimension)}
+}
+
+func (x dimensionHandle) Get() *C.tiledb_dimension_t {
+	return (*C.tiledb_dimension_t)(x.capiHandle.Get())
+}
+
 // Dimension Describes one dimension of an Array.
 // The dimension consists of a type, lower and upper bound, and tile-extent
 // describing the memory ordering. Dimensions are added to a Domain.
 type Dimension struct {
-	tiledbDimension *C.tiledb_dimension_t
+	tiledbDimension dimensionHandle
 	context         *Context
+}
+
+func newDimensionFromHandle(context *Context, handle dimensionHandle) *Dimension {
+	return &Dimension{tiledbDimension: handle, context: context}
 }
 
 // NewDimension allocates a new dimension.
 func NewDimension(context *Context, name string, datatype Datatype, domain interface{}, extent interface{}) (*Dimension, error) {
-	dimension := Dimension{context: context}
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 
@@ -232,20 +249,19 @@ func NewDimension(context *Context, name string, datatype Datatype, domain inter
 		return nil, fmt.Errorf("domain and datatype do not have the same data types. Domain: %s, Datatype: %s", domainType.String(), datatype.String())
 	}
 
-	ret = C.tiledb_dimension_alloc(context.tiledbContext.Get(), cname, C.tiledb_datatype_t(datatype), cdomain, cextent, &dimension.tiledbDimension)
+	var dimensionPtr *C.tiledb_dimension_t
+	ret = C.tiledb_dimension_alloc(context.tiledbContext.Get(), cname, C.tiledb_datatype_t(datatype), cdomain, cextent, &dimensionPtr)
 	runtime.KeepAlive(context)
 
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb dimension: %w", context.LastError())
 	}
-	freeOnGC(&dimension)
 
-	return &dimension, nil
+	return newDimensionFromHandle(context, newDimensionHandle(dimensionPtr)), nil
 }
 
 // NewStringDimension allocates a new string dimension.
 func NewStringDimension(context *Context, name string) (*Dimension, error) {
-	dimension := Dimension{context: context}
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 
@@ -253,15 +269,15 @@ func NewStringDimension(context *Context, name string) (*Dimension, error) {
 	var ret C.int32_t
 
 	datatype = TILEDB_STRING_ASCII
-	ret = C.tiledb_dimension_alloc(context.tiledbContext.Get(), cname, C.tiledb_datatype_t(datatype), nil, nil, &dimension.tiledbDimension)
+	var dimensionPtr *C.tiledb_dimension_t
+	ret = C.tiledb_dimension_alloc(context.tiledbContext.Get(), cname, C.tiledb_datatype_t(datatype), nil, nil, &dimensionPtr)
 	runtime.KeepAlive(context)
 
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb dimension: %w", context.LastError())
 	}
-	freeOnGC(&dimension)
 
-	return &dimension, nil
+	return newDimensionFromHandle(context, newDimensionHandle(dimensionPtr)), nil
 }
 
 // Free releases the internal TileDB core data that was allocated on the C heap.
@@ -270,9 +286,7 @@ func NewStringDimension(context *Context, name string) (*Dimension, error) {
 // can safely be called many times on the same object; if it has already
 // been freed, it will not be freed again.
 func (d *Dimension) Free() {
-	if d.tiledbDimension != nil {
-		C.tiledb_dimension_free(&d.tiledbDimension)
-	}
+	d.tiledbDimension.Free()
 }
 
 // Context exposes the internal TileDB context used to initialize the dimension.
@@ -282,7 +296,7 @@ func (d *Dimension) Context() *Context {
 
 // SetFilterList sets the dimension filterList.
 func (d *Dimension) SetFilterList(filterlist *FilterList) error {
-	ret := C.tiledb_dimension_set_filter_list(d.context.tiledbContext.Get(), d.tiledbDimension, filterlist.tiledbFilterList)
+	ret := C.tiledb_dimension_set_filter_list(d.context.tiledbContext.Get(), d.tiledbDimension.Get(), filterlist.tiledbFilterList.Get())
 	runtime.KeepAlive(d)
 	runtime.KeepAlive(filterlist)
 	if ret != C.TILEDB_OK {
@@ -293,15 +307,14 @@ func (d *Dimension) SetFilterList(filterlist *FilterList) error {
 
 // FilterList returns a copy of the filter list for attribute.
 func (d *Dimension) FilterList() (*FilterList, error) {
-	filterList := FilterList{context: d.context}
-	ret := C.tiledb_dimension_get_filter_list(d.context.tiledbContext.Get(), d.tiledbDimension, &filterList.tiledbFilterList)
+	var filterListPtr *C.tiledb_filter_list_t
+	ret := C.tiledb_dimension_get_filter_list(d.context.tiledbContext.Get(), d.tiledbDimension.Get(), &filterListPtr)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb dimension filter list: %w", d.context.LastError())
 	}
-	freeOnGC(&filterList)
 
-	return &filterList, nil
+	return newFilterListFromHandle(d.context, newFilterListHandle(filterListPtr)), nil
 }
 
 // SetCellValNum sets the number of values per cell for a dimension.
@@ -310,7 +323,7 @@ func (d *Dimension) FilterList() (*FilterList, error) {
 // function, but can also be set manually.
 func (d *Dimension) SetCellValNum(val uint32) error {
 	ret := C.tiledb_dimension_set_cell_val_num(d.context.tiledbContext.Get(),
-		d.tiledbDimension, C.uint32_t(val))
+		d.tiledbDimension.Get(), C.uint32_t(val))
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting tiledb dimension cell val num: %w", d.context.LastError())
@@ -322,7 +335,7 @@ func (d *Dimension) SetCellValNum(val uint32) error {
 // For variable-sized attributes returns TILEDB_VAR_NUM.
 func (d *Dimension) CellValNum() (uint32, error) {
 	var cellValNum C.uint32_t
-	ret := C.tiledb_dimension_get_cell_val_num(d.context.tiledbContext.Get(), d.tiledbDimension, &cellValNum)
+	ret := C.tiledb_dimension_get_cell_val_num(d.context.tiledbContext.Get(), d.tiledbDimension.Get(), &cellValNum)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb dimension cell val num: %w", d.context.LastError())
@@ -334,7 +347,7 @@ func (d *Dimension) CellValNum() (uint32, error) {
 // Name returns the name of the dimension.
 func (d *Dimension) Name() (string, error) {
 	var cName *C.char // d must be kept alive while cName is being accessed.
-	ret := C.tiledb_dimension_get_name(d.context.tiledbContext.Get(), d.tiledbDimension, &cName)
+	ret := C.tiledb_dimension_get_name(d.context.tiledbContext.Get(), d.tiledbDimension.Get(), &cName)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting tiledb dimension name: %w", d.context.LastError())
 	}
@@ -347,7 +360,7 @@ func (d *Dimension) Name() (string, error) {
 // Type returns the type of the dimension.
 func (d *Dimension) Type() (Datatype, error) {
 	var cType C.tiledb_datatype_t
-	ret := C.tiledb_dimension_get_type(d.context.tiledbContext.Get(), d.tiledbDimension, &cType)
+	ret := C.tiledb_dimension_get_type(d.context.tiledbContext.Get(), d.tiledbDimension.Get(), &cType)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb dimension type: %w", d.context.LastError())
@@ -400,7 +413,7 @@ func (d *Dimension) Domain() (interface{}, error) {
 
 func domainInternal[T any](d *Dimension) ([]T, error) {
 	var cDomain unsafe.Pointer // d must be kept alive while cDomain is being accessed.
-	ret := C.tiledb_dimension_get_domain(d.context.tiledbContext.Get(), d.tiledbDimension, &cDomain)
+	ret := C.tiledb_dimension_get_domain(d.context.tiledbContext.Get(), d.tiledbDimension.Get(), &cDomain)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb dimension's domain: %w", d.context.LastError())
 	}
@@ -449,7 +462,7 @@ func (d *Dimension) Extent() (interface{}, error) {
 func extentInternal[T any](d *Dimension) (T, error) {
 	var cExtent unsafe.Pointer // d must be kept alive while cExtent is being accessed.
 	var output T
-	cRet := C.tiledb_dimension_get_tile_extent(d.context.tiledbContext.Get(), d.tiledbDimension, &cExtent)
+	cRet := C.tiledb_dimension_get_tile_extent(d.context.tiledbContext.Get(), d.tiledbDimension.Get(), &cExtent)
 	if cRet != C.TILEDB_OK {
 		return output, fmt.Errorf("could not get TileDB dimension's extent: %w", d.context.LastError())
 	}
@@ -460,7 +473,7 @@ func extentInternal[T any](d *Dimension) (T, error) {
 
 // DumpSTDOUT dumps the dimension in ASCII format to stdout.
 func (d *Dimension) DumpSTDOUT() error {
-	ret := C.tiledb_dimension_dump(d.context.tiledbContext.Get(), d.tiledbDimension, C.stdout)
+	ret := C.tiledb_dimension_dump(d.context.tiledbContext.Get(), d.tiledbDimension.Get(), C.stdout)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping dimension to stdout: %w", d.context.LastError())
@@ -488,7 +501,7 @@ func (d *Dimension) Dump(path string) error {
 	defer C.fclose(cFile)
 
 	// Dump dimension to file
-	ret := C.tiledb_dimension_dump(d.context.tiledbContext.Get(), d.tiledbDimension, cFile)
+	ret := C.tiledb_dimension_dump(d.context.tiledbContext.Get(), d.tiledbDimension.Get(), cFile)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping dimension to file %s: %w", path, d.context.LastError())

--- a/dimension_label_experimental.go
+++ b/dimension_label_experimental.go
@@ -32,7 +32,7 @@ func (d *DimensionLabel) Free() {
 // DimensionIndex returns the index of the dimension the dimension label provides labels for.
 func (d *DimensionLabel) DimensionIndex() (uint32, error) {
 	var dimensionIndex C.uint32_t
-	ret := C.tiledb_dimension_label_get_dimension_index(d.context.tiledbContext, d.tiledbDimensionLabel, &dimensionIndex)
+	ret := C.tiledb_dimension_label_get_dimension_index(d.context.tiledbContext.Get(), d.tiledbDimensionLabel, &dimensionIndex)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching dimension index for dimension label: %w", d.context.LastError())
@@ -44,7 +44,7 @@ func (d *DimensionLabel) DimensionIndex() (uint32, error) {
 // AttributeName returns the name of the attribute the label data is stored under.
 func (d *DimensionLabel) AttributeName() (string, error) {
 	var cLabelAttrName *C.char // d must be kept alive while cLabelAttrName is being accessed.
-	ret := C.tiledb_dimension_label_get_label_attr_name(d.context.tiledbContext, d.tiledbDimensionLabel, &cLabelAttrName)
+	ret := C.tiledb_dimension_label_get_label_attr_name(d.context.tiledbContext.Get(), d.tiledbDimensionLabel, &cLabelAttrName)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting dimension label attribute name: %w", d.context.LastError())
 	}
@@ -58,7 +58,7 @@ func (d *DimensionLabel) AttributeName() (string, error) {
 // For variable-sized labels the result is TILEDB_VAR_NUM.
 func (d *DimensionLabel) CellValNum() (uint32, error) {
 	var labelCellValNum C.uint32_t
-	ret := C.tiledb_dimension_label_get_label_cell_val_num(d.context.tiledbContext, d.tiledbDimensionLabel, &labelCellValNum)
+	ret := C.tiledb_dimension_label_get_label_cell_val_num(d.context.tiledbContext.Get(), d.tiledbDimensionLabel, &labelCellValNum)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching cell val num for dimension label: %w", d.context.LastError())
@@ -70,7 +70,7 @@ func (d *DimensionLabel) CellValNum() (uint32, error) {
 // Order returns the order of the labels on the dimension label.
 func (d *DimensionLabel) Order() (DataOrder, error) {
 	var labelOrder C.tiledb_data_order_t
-	ret := C.tiledb_dimension_label_get_label_order(d.context.tiledbContext, d.tiledbDimensionLabel, &labelOrder)
+	ret := C.tiledb_dimension_label_get_label_order(d.context.tiledbContext.Get(), d.tiledbDimensionLabel, &labelOrder)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching label order for dimension label: %w", d.context.LastError())
@@ -82,7 +82,7 @@ func (d *DimensionLabel) Order() (DataOrder, error) {
 // Type returns the underlying Datatype for the dimension label.
 func (d *DimensionLabel) Type() (Datatype, error) {
 	var dataType C.tiledb_datatype_t
-	ret := C.tiledb_dimension_label_get_label_type(d.context.tiledbContext, d.tiledbDimensionLabel, &dataType)
+	ret := C.tiledb_dimension_label_get_label_type(d.context.tiledbContext.Get(), d.tiledbDimensionLabel, &dataType)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching dimension label type: %w", d.context.LastError())
@@ -94,7 +94,7 @@ func (d *DimensionLabel) Type() (Datatype, error) {
 // Name returns the name for the dimension label.
 func (d *DimensionLabel) Name() (string, error) {
 	var cLabelName *C.char // d must be kept alive while cLabelName is being accessed.
-	ret := C.tiledb_dimension_label_get_name(d.context.tiledbContext, d.tiledbDimensionLabel, &cLabelName)
+	ret := C.tiledb_dimension_label_get_name(d.context.tiledbContext.Get(), d.tiledbDimensionLabel, &cLabelName)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting dimension label name: %w", d.context.LastError())
 	}
@@ -107,7 +107,7 @@ func (d *DimensionLabel) Name() (string, error) {
 // Uri Returns the Uri for the dimension label array.
 func (d *DimensionLabel) URI() (string, error) {
 	var cLabelUri *C.char // d must be kept alive while cLabelUri is being accessed.
-	ret := C.tiledb_dimension_label_get_uri(d.context.tiledbContext, d.tiledbDimensionLabel, &cLabelUri)
+	ret := C.tiledb_dimension_label_get_uri(d.context.tiledbContext.Get(), d.tiledbDimensionLabel, &cLabelUri)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting dimension label URI: %w", d.context.LastError())
 	}
@@ -120,7 +120,7 @@ func (d *DimensionLabel) URI() (string, error) {
 // AddDimensionLabel adds a dimension label to the array schema.
 func (a *ArraySchema) AddDimensionLabel(dimIndex uint32, name string, order DataOrder, labelType Datatype) error {
 	cLabelName := C.CString(name)
-	ret := C.tiledb_array_schema_add_dimension_label(a.context.tiledbContext, a.tiledbArraySchema.Get(),
+	ret := C.tiledb_array_schema_add_dimension_label(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(),
 		C.uint32_t(dimIndex), cLabelName, C.tiledb_data_order_t(order), C.tiledb_datatype_t(labelType))
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
@@ -133,7 +133,7 @@ func (a *ArraySchema) AddDimensionLabel(dimIndex uint32, name string, order Data
 // DimensionLabelFromName retrieves a dimension label from an array schema with the requested index.
 func (a *ArraySchema) DimensionLabelFromIndex(labelIdx uint64) (*DimensionLabel, error) {
 	dimLabel := DimensionLabel{context: a.context}
-	ret := C.tiledb_array_schema_get_dimension_label_from_index(a.context.tiledbContext, a.tiledbArraySchema.Get(),
+	ret := C.tiledb_array_schema_get_dimension_label_from_index(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(),
 		C.uint64_t(labelIdx), &dimLabel.tiledbDimensionLabel)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
@@ -149,7 +149,7 @@ func (a *ArraySchema) DimensionLabelFromName(name string) (*DimensionLabel, erro
 	cAttrName := C.CString(name)
 	defer C.free(unsafe.Pointer(cAttrName))
 	dimLabel := DimensionLabel{context: a.context}
-	ret := C.tiledb_array_schema_get_dimension_label_from_name(a.context.tiledbContext, a.tiledbArraySchema.Get(),
+	ret := C.tiledb_array_schema_get_dimension_label_from_name(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(),
 		cAttrName, &dimLabel.tiledbDimensionLabel)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
@@ -166,7 +166,7 @@ func (a *ArraySchema) HasDimensionLabel(name string) (bool, error) {
 	defer C.free(unsafe.Pointer(cLabelName))
 
 	var hasLabel C.int32_t
-	ret := C.tiledb_array_schema_has_dimension_label(a.context.tiledbContext, a.tiledbArraySchema.Get(),
+	ret := C.tiledb_array_schema_has_dimension_label(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(),
 		cLabelName, &hasLabel)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
@@ -180,7 +180,7 @@ func (a *ArraySchema) HasDimensionLabel(name string) (bool, error) {
 func (a *ArraySchema) DimensionLabelsNum() (uint64, error) {
 	var labelNum C.uint64_t
 
-	ret := C.tiledb_array_schema_get_dimension_label_num(a.context.tiledbContext, a.tiledbArraySchema.Get(), &labelNum)
+	ret := C.tiledb_array_schema_get_dimension_label_num(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &labelNum)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching dimension label number: %w", a.context.LastError())
@@ -194,7 +194,7 @@ func (a *ArraySchema) SetDimensionLabelFilterList(name string, filterList Filter
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
-	ret := C.tiledb_array_schema_set_dimension_label_filter_list(a.context.tiledbContext, a.tiledbArraySchema.Get(),
+	ret := C.tiledb_array_schema_set_dimension_label_filter_list(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(),
 		cName, filterList.tiledbFilterList)
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(filterList)
@@ -246,7 +246,7 @@ func (a *ArraySchema) SetDimensionLabelTileExtent(labelName string, dimType Data
 			dimType.String())
 	}
 
-	ret := C.tiledb_array_schema_set_dimension_label_tile_extent(a.context.tiledbContext, a.tiledbArraySchema.Get(),
+	ret := C.tiledb_array_schema_set_dimension_label_tile_extent(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(),
 		cName, C.tiledb_datatype_t(dimType), cExtent)
 	runtime.KeepAlive(a)
 	// cExtent is being kept alive by passing it to cgo call.
@@ -286,7 +286,7 @@ func (sa *Subarray) GetDimensionLabelRangeNum(labelName string) (uint64, error) 
 	cLabelName := C.CString(labelName)
 	defer C.free(unsafe.Pointer(cLabelName))
 
-	ret := C.tiledb_subarray_get_label_range_num(sa.context.tiledbContext, sa.subarray, cLabelName, &rangeNum)
+	ret := C.tiledb_subarray_get_label_range_num(sa.context.tiledbContext.Get(), sa.subarray, cLabelName, &rangeNum)
 	runtime.KeepAlive(sa)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error retrieving subarray label range num: %w", sa.context.LastError())
@@ -313,12 +313,12 @@ func (sa *Subarray) AddDimensionLabelRange(labelName string, r Range) error {
 	if isVar {
 		startSlice := []byte(r.start.(string))
 		endSlice := []byte(r.end.(string))
-		ret = C.tiledb_subarray_add_label_range_var(sa.context.tiledbContext, sa.subarray, cLabelName,
+		ret = C.tiledb_subarray_add_label_range_var(sa.context.tiledbContext.Get(), sa.subarray, cLabelName,
 			slicePtr(startSlice), C.uint64_t(len(startSlice)), slicePtr(endSlice), C.uint64_t(len(endSlice)))
 	} else {
 		startValue := addressableValue(r.start)
 		endValue := addressableValue(r.end)
-		ret = C.tiledb_subarray_add_label_range(sa.context.tiledbContext, sa.subarray, cLabelName,
+		ret = C.tiledb_subarray_add_label_range(sa.context.tiledbContext.Get(), sa.subarray, cLabelName,
 			startValue.UnsafePointer(), endValue.UnsafePointer(), nil)
 	}
 	runtime.KeepAlive(sa)
@@ -344,7 +344,7 @@ func (sa *Subarray) GetDimensionLabelRange(labelName string, rangeNum uint64) (R
 	var ret C.int32_t
 	if isVar {
 		var startSize, endSize uint64
-		ret = C.tiledb_subarray_get_label_range_var_size(sa.context.tiledbContext, sa.subarray, cLabelName, C.uint64_t(rangeNum),
+		ret = C.tiledb_subarray_get_label_range_var_size(sa.context.tiledbContext.Get(), sa.subarray, cLabelName, C.uint64_t(rangeNum),
 			(*C.uint64_t)(unsafe.Pointer(&startSize)), (*C.uint64_t)(unsafe.Pointer(&endSize)))
 		if ret == C.TILEDB_OK {
 			var sp, ep unsafe.Pointer
@@ -357,7 +357,7 @@ func (sa *Subarray) GetDimensionLabelRange(labelName string, rangeNum uint64) (R
 				endData = make([]byte, int(endSize))
 				ep = slicePtr(endData)
 			}
-			ret = C.tiledb_subarray_get_label_range_var(sa.context.tiledbContext, sa.subarray,
+			ret = C.tiledb_subarray_get_label_range_var(sa.context.tiledbContext.Get(), sa.subarray,
 				cLabelName, C.uint64_t(rangeNum), sp, ep)
 			if ret == C.TILEDB_OK {
 				r.start = string(startData)
@@ -366,7 +366,7 @@ func (sa *Subarray) GetDimensionLabelRange(labelName string, rangeNum uint64) (R
 		}
 	} else {
 		var startPointer, endPointer, stridePointer unsafe.Pointer
-		ret = C.tiledb_subarray_get_label_range(sa.context.tiledbContext, sa.subarray,
+		ret = C.tiledb_subarray_get_label_range(sa.context.tiledbContext.Get(), sa.subarray,
 			cLabelName, C.uint64_t(rangeNum), &startPointer, &endPointer, &stridePointer)
 		typ := dt.ReflectType()
 		if ret == C.TILEDB_OK {

--- a/dimension_label_experimental.go
+++ b/dimension_label_experimental.go
@@ -120,7 +120,7 @@ func (d *DimensionLabel) URI() (string, error) {
 // AddDimensionLabel adds a dimension label to the array schema.
 func (a *ArraySchema) AddDimensionLabel(dimIndex uint32, name string, order DataOrder, labelType Datatype) error {
 	cLabelName := C.CString(name)
-	ret := C.tiledb_array_schema_add_dimension_label(a.context.tiledbContext, a.tiledbArraySchema,
+	ret := C.tiledb_array_schema_add_dimension_label(a.context.tiledbContext, a.tiledbArraySchema.Get(),
 		C.uint32_t(dimIndex), cLabelName, C.tiledb_data_order_t(order), C.tiledb_datatype_t(labelType))
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
@@ -133,7 +133,7 @@ func (a *ArraySchema) AddDimensionLabel(dimIndex uint32, name string, order Data
 // DimensionLabelFromName retrieves a dimension label from an array schema with the requested index.
 func (a *ArraySchema) DimensionLabelFromIndex(labelIdx uint64) (*DimensionLabel, error) {
 	dimLabel := DimensionLabel{context: a.context}
-	ret := C.tiledb_array_schema_get_dimension_label_from_index(a.context.tiledbContext, a.tiledbArraySchema,
+	ret := C.tiledb_array_schema_get_dimension_label_from_index(a.context.tiledbContext, a.tiledbArraySchema.Get(),
 		C.uint64_t(labelIdx), &dimLabel.tiledbDimensionLabel)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
@@ -149,7 +149,7 @@ func (a *ArraySchema) DimensionLabelFromName(name string) (*DimensionLabel, erro
 	cAttrName := C.CString(name)
 	defer C.free(unsafe.Pointer(cAttrName))
 	dimLabel := DimensionLabel{context: a.context}
-	ret := C.tiledb_array_schema_get_dimension_label_from_name(a.context.tiledbContext, a.tiledbArraySchema,
+	ret := C.tiledb_array_schema_get_dimension_label_from_name(a.context.tiledbContext, a.tiledbArraySchema.Get(),
 		cAttrName, &dimLabel.tiledbDimensionLabel)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
@@ -166,7 +166,7 @@ func (a *ArraySchema) HasDimensionLabel(name string) (bool, error) {
 	defer C.free(unsafe.Pointer(cLabelName))
 
 	var hasLabel C.int32_t
-	ret := C.tiledb_array_schema_has_dimension_label(a.context.tiledbContext, a.tiledbArraySchema,
+	ret := C.tiledb_array_schema_has_dimension_label(a.context.tiledbContext, a.tiledbArraySchema.Get(),
 		cLabelName, &hasLabel)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
@@ -180,7 +180,7 @@ func (a *ArraySchema) HasDimensionLabel(name string) (bool, error) {
 func (a *ArraySchema) DimensionLabelsNum() (uint64, error) {
 	var labelNum C.uint64_t
 
-	ret := C.tiledb_array_schema_get_dimension_label_num(a.context.tiledbContext, a.tiledbArraySchema, &labelNum)
+	ret := C.tiledb_array_schema_get_dimension_label_num(a.context.tiledbContext, a.tiledbArraySchema.Get(), &labelNum)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching dimension label number: %w", a.context.LastError())
@@ -194,7 +194,7 @@ func (a *ArraySchema) SetDimensionLabelFilterList(name string, filterList Filter
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
-	ret := C.tiledb_array_schema_set_dimension_label_filter_list(a.context.tiledbContext, a.tiledbArraySchema,
+	ret := C.tiledb_array_schema_set_dimension_label_filter_list(a.context.tiledbContext, a.tiledbArraySchema.Get(),
 		cName, filterList.tiledbFilterList)
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(filterList)
@@ -246,7 +246,7 @@ func (a *ArraySchema) SetDimensionLabelTileExtent(labelName string, dimType Data
 			dimType.String())
 	}
 
-	ret := C.tiledb_array_schema_set_dimension_label_tile_extent(a.context.tiledbContext, a.tiledbArraySchema,
+	ret := C.tiledb_array_schema_set_dimension_label_tile_extent(a.context.tiledbContext, a.tiledbArraySchema.Get(),
 		cName, C.tiledb_datatype_t(dimType), cExtent)
 	runtime.KeepAlive(a)
 	// cExtent is being kept alive by passing it to cgo call.

--- a/dimension_label_experimental.go
+++ b/dimension_label_experimental.go
@@ -13,9 +13,27 @@ import (
 	"unsafe"
 )
 
+type dimensionLabelHandle struct{ *capiHandle }
+
+func freeCapiDimensionLabel(c unsafe.Pointer) {
+	C.tiledb_dimension_label_free((**C.tiledb_dimension_label_t)(unsafe.Pointer(&c)))
+}
+
+func newDimensionLabelHandle(ptr *C.tiledb_dimension_label_t) dimensionLabelHandle {
+	return dimensionLabelHandle{newCapiHandle(unsafe.Pointer(ptr), freeCapiDimensionLabel)}
+}
+
+func (x dimensionLabelHandle) Get() *C.tiledb_dimension_label_t {
+	return (*C.tiledb_dimension_label_t)(x.capiHandle.Get())
+}
+
 type DimensionLabel struct {
-	tiledbDimensionLabel *C.tiledb_dimension_label_t
+	tiledbDimensionLabel dimensionLabelHandle
 	context              *Context
+}
+
+func newDimensionLabelFromHandle(context *Context, handle dimensionLabelHandle) *DimensionLabel {
+	return &DimensionLabel{tiledbDimensionLabel: handle, context: context}
 }
 
 // Free releases the internal TileDB core data that was allocated on the C heap.
@@ -24,15 +42,13 @@ type DimensionLabel struct {
 // can safely be called many times on the same object; if it has already
 // been freed, it will not be freed again.
 func (d *DimensionLabel) Free() {
-	if d.tiledbDimensionLabel != nil {
-		C.tiledb_dimension_label_free(&d.tiledbDimensionLabel)
-	}
+	d.tiledbDimensionLabel.Free()
 }
 
 // DimensionIndex returns the index of the dimension the dimension label provides labels for.
 func (d *DimensionLabel) DimensionIndex() (uint32, error) {
 	var dimensionIndex C.uint32_t
-	ret := C.tiledb_dimension_label_get_dimension_index(d.context.tiledbContext.Get(), d.tiledbDimensionLabel, &dimensionIndex)
+	ret := C.tiledb_dimension_label_get_dimension_index(d.context.tiledbContext.Get(), d.tiledbDimensionLabel.Get(), &dimensionIndex)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching dimension index for dimension label: %w", d.context.LastError())
@@ -44,7 +60,7 @@ func (d *DimensionLabel) DimensionIndex() (uint32, error) {
 // AttributeName returns the name of the attribute the label data is stored under.
 func (d *DimensionLabel) AttributeName() (string, error) {
 	var cLabelAttrName *C.char // d must be kept alive while cLabelAttrName is being accessed.
-	ret := C.tiledb_dimension_label_get_label_attr_name(d.context.tiledbContext.Get(), d.tiledbDimensionLabel, &cLabelAttrName)
+	ret := C.tiledb_dimension_label_get_label_attr_name(d.context.tiledbContext.Get(), d.tiledbDimensionLabel.Get(), &cLabelAttrName)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting dimension label attribute name: %w", d.context.LastError())
 	}
@@ -58,7 +74,7 @@ func (d *DimensionLabel) AttributeName() (string, error) {
 // For variable-sized labels the result is TILEDB_VAR_NUM.
 func (d *DimensionLabel) CellValNum() (uint32, error) {
 	var labelCellValNum C.uint32_t
-	ret := C.tiledb_dimension_label_get_label_cell_val_num(d.context.tiledbContext.Get(), d.tiledbDimensionLabel, &labelCellValNum)
+	ret := C.tiledb_dimension_label_get_label_cell_val_num(d.context.tiledbContext.Get(), d.tiledbDimensionLabel.Get(), &labelCellValNum)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching cell val num for dimension label: %w", d.context.LastError())
@@ -70,7 +86,7 @@ func (d *DimensionLabel) CellValNum() (uint32, error) {
 // Order returns the order of the labels on the dimension label.
 func (d *DimensionLabel) Order() (DataOrder, error) {
 	var labelOrder C.tiledb_data_order_t
-	ret := C.tiledb_dimension_label_get_label_order(d.context.tiledbContext.Get(), d.tiledbDimensionLabel, &labelOrder)
+	ret := C.tiledb_dimension_label_get_label_order(d.context.tiledbContext.Get(), d.tiledbDimensionLabel.Get(), &labelOrder)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching label order for dimension label: %w", d.context.LastError())
@@ -82,7 +98,7 @@ func (d *DimensionLabel) Order() (DataOrder, error) {
 // Type returns the underlying Datatype for the dimension label.
 func (d *DimensionLabel) Type() (Datatype, error) {
 	var dataType C.tiledb_datatype_t
-	ret := C.tiledb_dimension_label_get_label_type(d.context.tiledbContext.Get(), d.tiledbDimensionLabel, &dataType)
+	ret := C.tiledb_dimension_label_get_label_type(d.context.tiledbContext.Get(), d.tiledbDimensionLabel.Get(), &dataType)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching dimension label type: %w", d.context.LastError())
@@ -94,7 +110,7 @@ func (d *DimensionLabel) Type() (Datatype, error) {
 // Name returns the name for the dimension label.
 func (d *DimensionLabel) Name() (string, error) {
 	var cLabelName *C.char // d must be kept alive while cLabelName is being accessed.
-	ret := C.tiledb_dimension_label_get_name(d.context.tiledbContext.Get(), d.tiledbDimensionLabel, &cLabelName)
+	ret := C.tiledb_dimension_label_get_name(d.context.tiledbContext.Get(), d.tiledbDimensionLabel.Get(), &cLabelName)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting dimension label name: %w", d.context.LastError())
 	}
@@ -107,7 +123,7 @@ func (d *DimensionLabel) Name() (string, error) {
 // Uri Returns the Uri for the dimension label array.
 func (d *DimensionLabel) URI() (string, error) {
 	var cLabelUri *C.char // d must be kept alive while cLabelUri is being accessed.
-	ret := C.tiledb_dimension_label_get_uri(d.context.tiledbContext.Get(), d.tiledbDimensionLabel, &cLabelUri)
+	ret := C.tiledb_dimension_label_get_uri(d.context.tiledbContext.Get(), d.tiledbDimensionLabel.Get(), &cLabelUri)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting dimension label URI: %w", d.context.LastError())
 	}
@@ -132,32 +148,30 @@ func (a *ArraySchema) AddDimensionLabel(dimIndex uint32, name string, order Data
 
 // DimensionLabelFromName retrieves a dimension label from an array schema with the requested index.
 func (a *ArraySchema) DimensionLabelFromIndex(labelIdx uint64) (*DimensionLabel, error) {
-	dimLabel := DimensionLabel{context: a.context}
+	var dimLabelPtr *C.tiledb_dimension_label_t
 	ret := C.tiledb_array_schema_get_dimension_label_from_index(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(),
-		C.uint64_t(labelIdx), &dimLabel.tiledbDimensionLabel)
+		C.uint64_t(labelIdx), &dimLabelPtr)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting dimension label '%d' for ArraySchema: %w", labelIdx, a.context.LastError())
 	}
 
-	freeOnGC(&dimLabel)
-	return &dimLabel, nil
+	return newDimensionLabelFromHandle(a.context, newDimensionLabelHandle(dimLabelPtr)), nil
 }
 
 // DimensionLabelFromName retrieves a dimension label from an array schema with the requested name.
 func (a *ArraySchema) DimensionLabelFromName(name string) (*DimensionLabel, error) {
 	cAttrName := C.CString(name)
 	defer C.free(unsafe.Pointer(cAttrName))
-	dimLabel := DimensionLabel{context: a.context}
+	var dimLabelPtr *C.tiledb_dimension_label_t
 	ret := C.tiledb_array_schema_get_dimension_label_from_name(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(),
-		cAttrName, &dimLabel.tiledbDimensionLabel)
+		cAttrName, &dimLabelPtr)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting dimension label '%s' for ArraySchema: %w", name, a.context.LastError())
 	}
 
-	freeOnGC(&dimLabel)
-	return &dimLabel, nil
+	return newDimensionLabelFromHandle(a.context, newDimensionLabelHandle(dimLabelPtr)), nil
 }
 
 // HasDimensionLabel checks whether the array schema has a dimension label of the given name.
@@ -195,7 +209,7 @@ func (a *ArraySchema) SetDimensionLabelFilterList(name string, filterList Filter
 	defer C.free(unsafe.Pointer(cName))
 
 	ret := C.tiledb_array_schema_set_dimension_label_filter_list(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(),
-		cName, filterList.tiledbFilterList)
+		cName, filterList.tiledbFilterList.Get())
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(filterList)
 	if ret != C.TILEDB_OK {

--- a/dimension_label_experimental.go
+++ b/dimension_label_experimental.go
@@ -300,7 +300,7 @@ func (sa *Subarray) GetDimensionLabelRangeNum(labelName string) (uint64, error) 
 	cLabelName := C.CString(labelName)
 	defer C.free(unsafe.Pointer(cLabelName))
 
-	ret := C.tiledb_subarray_get_label_range_num(sa.context.tiledbContext.Get(), sa.subarray, cLabelName, &rangeNum)
+	ret := C.tiledb_subarray_get_label_range_num(sa.context.tiledbContext.Get(), sa.subarray.Get(), cLabelName, &rangeNum)
 	runtime.KeepAlive(sa)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error retrieving subarray label range num: %w", sa.context.LastError())
@@ -327,12 +327,12 @@ func (sa *Subarray) AddDimensionLabelRange(labelName string, r Range) error {
 	if isVar {
 		startSlice := []byte(r.start.(string))
 		endSlice := []byte(r.end.(string))
-		ret = C.tiledb_subarray_add_label_range_var(sa.context.tiledbContext.Get(), sa.subarray, cLabelName,
+		ret = C.tiledb_subarray_add_label_range_var(sa.context.tiledbContext.Get(), sa.subarray.Get(), cLabelName,
 			slicePtr(startSlice), C.uint64_t(len(startSlice)), slicePtr(endSlice), C.uint64_t(len(endSlice)))
 	} else {
 		startValue := addressableValue(r.start)
 		endValue := addressableValue(r.end)
-		ret = C.tiledb_subarray_add_label_range(sa.context.tiledbContext.Get(), sa.subarray, cLabelName,
+		ret = C.tiledb_subarray_add_label_range(sa.context.tiledbContext.Get(), sa.subarray.Get(), cLabelName,
 			startValue.UnsafePointer(), endValue.UnsafePointer(), nil)
 	}
 	runtime.KeepAlive(sa)
@@ -358,7 +358,7 @@ func (sa *Subarray) GetDimensionLabelRange(labelName string, rangeNum uint64) (R
 	var ret C.int32_t
 	if isVar {
 		var startSize, endSize uint64
-		ret = C.tiledb_subarray_get_label_range_var_size(sa.context.tiledbContext.Get(), sa.subarray, cLabelName, C.uint64_t(rangeNum),
+		ret = C.tiledb_subarray_get_label_range_var_size(sa.context.tiledbContext.Get(), sa.subarray.Get(), cLabelName, C.uint64_t(rangeNum),
 			(*C.uint64_t)(unsafe.Pointer(&startSize)), (*C.uint64_t)(unsafe.Pointer(&endSize)))
 		if ret == C.TILEDB_OK {
 			var sp, ep unsafe.Pointer
@@ -371,7 +371,7 @@ func (sa *Subarray) GetDimensionLabelRange(labelName string, rangeNum uint64) (R
 				endData = make([]byte, int(endSize))
 				ep = slicePtr(endData)
 			}
-			ret = C.tiledb_subarray_get_label_range_var(sa.context.tiledbContext.Get(), sa.subarray,
+			ret = C.tiledb_subarray_get_label_range_var(sa.context.tiledbContext.Get(), sa.subarray.Get(),
 				cLabelName, C.uint64_t(rangeNum), sp, ep)
 			if ret == C.TILEDB_OK {
 				r.start = string(startData)
@@ -380,7 +380,7 @@ func (sa *Subarray) GetDimensionLabelRange(labelName string, rangeNum uint64) (R
 		}
 	} else {
 		var startPointer, endPointer, stridePointer unsafe.Pointer
-		ret = C.tiledb_subarray_get_label_range(sa.context.tiledbContext.Get(), sa.subarray,
+		ret = C.tiledb_subarray_get_label_range(sa.context.tiledbContext.Get(), sa.subarray.Get(),
 			cLabelName, C.uint64_t(rangeNum), &startPointer, &endPointer, &stridePointer)
 		typ := dt.ReflectType()
 		if ret == C.TILEDB_OK {

--- a/dimension_label_experimental_test.go
+++ b/dimension_label_experimental_test.go
@@ -57,7 +57,7 @@ func TestDimensionLabelQuery(t *testing.T) {
 	require.NoError(t, err)
 	sa, err = array.NewSubarray()
 	require.NoError(t, err)
-	require.NoError(t, sa.AddDimensionLabelRange("d0_label0", MakeRange[float64](0, 0.2)))
+	require.NoError(t, sa.AddDimensionLabelRange("d0_label0", MakeRange(0, 0.2)))
 	require.NoError(t, sa.AddDimensionLabelRange("d1_label0", MakeRange[float32](-0.4, -0.2)))
 	require.NoError(t, q.SetSubarray(sa))
 	for i := range vBuffer {

--- a/domain.go
+++ b/domain.go
@@ -25,7 +25,7 @@ type Domain struct {
 // NewDomain allocates a new domain.
 func NewDomain(tdbCtx *Context) (*Domain, error) {
 	domain := Domain{context: tdbCtx}
-	ret := C.tiledb_domain_alloc(domain.context.tiledbContext, &domain.tiledbDomain)
+	ret := C.tiledb_domain_alloc(domain.context.tiledbContext.Get(), &domain.tiledbDomain)
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb domain: %w", domain.context.LastError())
@@ -54,7 +54,7 @@ func (d *Domain) Context() *Context {
 // Type returns a domain's type deduced from dimensions.
 func (d *Domain) Type() (Datatype, error) {
 	var datatype C.tiledb_datatype_t
-	ret := C.tiledb_domain_get_type(d.context.tiledbContext, d.tiledbDomain, &datatype)
+	ret := C.tiledb_domain_get_type(d.context.tiledbContext.Get(), d.tiledbDomain, &datatype)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return -1, fmt.Errorf("error getting tiledb domain type: %w", d.context.LastError())
@@ -65,7 +65,7 @@ func (d *Domain) Type() (Datatype, error) {
 // NDim returns the number of dimensions.
 func (d *Domain) NDim() (uint, error) {
 	var ndim C.uint32_t
-	ret := C.tiledb_domain_get_ndim(d.context.tiledbContext, d.tiledbDomain, &ndim)
+	ret := C.tiledb_domain_get_ndim(d.context.tiledbContext.Get(), d.tiledbDomain, &ndim)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb domain number of dimensions: %w", d.context.LastError())
@@ -76,7 +76,7 @@ func (d *Domain) NDim() (uint, error) {
 // DimensionFromIndex retrieves a dimension object from a domain by index.
 func (d *Domain) DimensionFromIndex(index uint) (*Dimension, error) {
 	var dim *C.tiledb_dimension_t
-	ret := C.tiledb_domain_get_dimension_from_index(d.context.tiledbContext,
+	ret := C.tiledb_domain_get_dimension_from_index(d.context.tiledbContext.Get(),
 		d.tiledbDomain, C.uint32_t(index), &dim)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
@@ -94,7 +94,7 @@ func (d *Domain) DimensionFromName(name string) (*Dimension, error) {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 	var dim *C.tiledb_dimension_t
-	ret := C.tiledb_domain_get_dimension_from_name(d.context.tiledbContext, d.tiledbDomain, cname, &dim)
+	ret := C.tiledb_domain_get_dimension_from_name(d.context.tiledbContext.Get(), d.tiledbDomain, cname, &dim)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb dimension by name for domain: %w", d.context.LastError())
@@ -107,7 +107,7 @@ func (d *Domain) DimensionFromName(name string) (*Dimension, error) {
 // AddDimensions adds one or more dimensions to a domain.
 func (d *Domain) AddDimensions(dimensions ...*Dimension) error {
 	for _, dimension := range dimensions {
-		ret := C.tiledb_domain_add_dimension(d.context.tiledbContext, d.tiledbDomain, dimension.tiledbDimension)
+		ret := C.tiledb_domain_add_dimension(d.context.tiledbContext.Get(), d.tiledbDomain, dimension.tiledbDimension)
 		runtime.KeepAlive(dimension)
 		if ret != C.TILEDB_OK {
 			return fmt.Errorf("error adding dimension to domain: %w", d.context.LastError())
@@ -121,7 +121,7 @@ func (d *Domain) HasDimension(dimName string) (bool, error) {
 	var hasDim C.int32_t
 	cDimName := C.CString(dimName)
 	defer C.free(unsafe.Pointer(cDimName))
-	ret := C.tiledb_domain_has_dimension(d.context.tiledbContext, d.tiledbDomain, cDimName, &hasDim)
+	ret := C.tiledb_domain_has_dimension(d.context.tiledbContext.Get(), d.tiledbDomain, cDimName, &hasDim)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error finding dimension %s in domain: %w", dimName, d.context.LastError())
@@ -136,7 +136,7 @@ func (d *Domain) HasDimension(dimName string) (bool, error) {
 
 // DumpSTDOUT dumps the domain in ASCII format to stdout.
 func (d *Domain) DumpSTDOUT() error {
-	ret := C.tiledb_domain_dump(d.context.tiledbContext, d.tiledbDomain, C.stdout)
+	ret := C.tiledb_domain_dump(d.context.tiledbContext.Get(), d.tiledbDomain, C.stdout)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping domain to stdout: %w", d.context.LastError())
@@ -164,7 +164,7 @@ func (d *Domain) Dump(path string) error {
 	defer C.fclose(cFile)
 
 	// Dump domain to file
-	ret := C.tiledb_domain_dump(d.context.tiledbContext, d.tiledbDomain, cFile)
+	ret := C.tiledb_domain_dump(d.context.tiledbContext.Get(), d.tiledbDomain, cFile)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping domain to file %s: %w", path, d.context.LastError())

--- a/domain.go
+++ b/domain.go
@@ -13,26 +13,43 @@ import (
 	"unsafe"
 )
 
+type domainHandle struct{ *capiHandle }
+
+func freeCapiDomain(c unsafe.Pointer) {
+	C.tiledb_domain_free((**C.tiledb_domain_t)(unsafe.Pointer(&c)))
+}
+
+func newDomainHandle(ptr *C.tiledb_domain_t) domainHandle {
+	return domainHandle{newCapiHandle(unsafe.Pointer(ptr), freeCapiDomain)}
+}
+
+func (x domainHandle) Get() *C.tiledb_domain_t {
+	return (*C.tiledb_domain_t)(x.capiHandle.Get())
+}
+
 // Domain represents the domain of an array.
 // A Domain defines the set of Dimension objects for a given array.
 // The properties of a Domain derive from the underlying dimensions.
 // A Domain is a component of an ArraySchema.
 type Domain struct {
-	tiledbDomain *C.tiledb_domain_t
+	tiledbDomain domainHandle
 	context      *Context
+}
+
+func newDomainFromHandle(context *Context, handle domainHandle) *Domain {
+	return &Domain{tiledbDomain: handle, context: context}
 }
 
 // NewDomain allocates a new domain.
 func NewDomain(tdbCtx *Context) (*Domain, error) {
-	domain := Domain{context: tdbCtx}
-	ret := C.tiledb_domain_alloc(domain.context.tiledbContext.Get(), &domain.tiledbDomain)
+	var domainPtr *C.tiledb_domain_t
+	ret := C.tiledb_domain_alloc(tdbCtx.tiledbContext.Get(), &domainPtr)
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error creating tiledb domain: %w", domain.context.LastError())
+		return nil, fmt.Errorf("error creating tiledb domain: %w", tdbCtx.LastError())
 	}
-	freeOnGC(&domain)
 
-	return &domain, nil
+	return newDomainFromHandle(tdbCtx, newDomainHandle(domainPtr)), nil
 }
 
 // Free releases the internal TileDB core data that was allocated on the C heap.
@@ -41,9 +58,7 @@ func NewDomain(tdbCtx *Context) (*Domain, error) {
 // can safely be called many times on the same object; if it has already
 // been freed, it will not be freed again.
 func (d *Domain) Free() {
-	if d.tiledbDomain != nil {
-		C.tiledb_domain_free(&d.tiledbDomain)
-	}
+	d.tiledbDomain.Free()
 }
 
 // Context exposes the internal TileDB context used to initialize the domain.
@@ -54,7 +69,7 @@ func (d *Domain) Context() *Context {
 // Type returns a domain's type deduced from dimensions.
 func (d *Domain) Type() (Datatype, error) {
 	var datatype C.tiledb_datatype_t
-	ret := C.tiledb_domain_get_type(d.context.tiledbContext.Get(), d.tiledbDomain, &datatype)
+	ret := C.tiledb_domain_get_type(d.context.tiledbContext.Get(), d.tiledbDomain.Get(), &datatype)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return -1, fmt.Errorf("error getting tiledb domain type: %w", d.context.LastError())
@@ -65,7 +80,7 @@ func (d *Domain) Type() (Datatype, error) {
 // NDim returns the number of dimensions.
 func (d *Domain) NDim() (uint, error) {
 	var ndim C.uint32_t
-	ret := C.tiledb_domain_get_ndim(d.context.tiledbContext.Get(), d.tiledbDomain, &ndim)
+	ret := C.tiledb_domain_get_ndim(d.context.tiledbContext.Get(), d.tiledbDomain.Get(), &ndim)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb domain number of dimensions: %w", d.context.LastError())
@@ -77,16 +92,13 @@ func (d *Domain) NDim() (uint, error) {
 func (d *Domain) DimensionFromIndex(index uint) (*Dimension, error) {
 	var dim *C.tiledb_dimension_t
 	ret := C.tiledb_domain_get_dimension_from_index(d.context.tiledbContext.Get(),
-		d.tiledbDomain, C.uint32_t(index), &dim)
+		d.tiledbDomain.Get(), C.uint32_t(index), &dim)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb dimension by index for domain: %w", d.context.LastError())
 	}
 
-	dimension := Dimension{tiledbDimension: dim, context: d.context}
-	freeOnGC(&dimension)
-
-	return &dimension, nil
+	return newDimensionFromHandle(d.context, newDimensionHandle(dim)), nil
 }
 
 // DimensionFromName retrieves a dimension object from a domain by name (key).
@@ -94,20 +106,19 @@ func (d *Domain) DimensionFromName(name string) (*Dimension, error) {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 	var dim *C.tiledb_dimension_t
-	ret := C.tiledb_domain_get_dimension_from_name(d.context.tiledbContext.Get(), d.tiledbDomain, cname, &dim)
+	ret := C.tiledb_domain_get_dimension_from_name(d.context.tiledbContext.Get(), d.tiledbDomain.Get(), cname, &dim)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb dimension by name for domain: %w", d.context.LastError())
 	}
-	dimension := Dimension{tiledbDimension: dim, context: d.context}
-	freeOnGC(&dimension)
-	return &dimension, nil
+
+	return newDimensionFromHandle(d.context, newDimensionHandle(dim)), nil
 }
 
 // AddDimensions adds one or more dimensions to a domain.
 func (d *Domain) AddDimensions(dimensions ...*Dimension) error {
 	for _, dimension := range dimensions {
-		ret := C.tiledb_domain_add_dimension(d.context.tiledbContext.Get(), d.tiledbDomain, dimension.tiledbDimension)
+		ret := C.tiledb_domain_add_dimension(d.context.tiledbContext.Get(), d.tiledbDomain.Get(), dimension.tiledbDimension.Get())
 		runtime.KeepAlive(dimension)
 		if ret != C.TILEDB_OK {
 			return fmt.Errorf("error adding dimension to domain: %w", d.context.LastError())
@@ -121,7 +132,7 @@ func (d *Domain) HasDimension(dimName string) (bool, error) {
 	var hasDim C.int32_t
 	cDimName := C.CString(dimName)
 	defer C.free(unsafe.Pointer(cDimName))
-	ret := C.tiledb_domain_has_dimension(d.context.tiledbContext.Get(), d.tiledbDomain, cDimName, &hasDim)
+	ret := C.tiledb_domain_has_dimension(d.context.tiledbContext.Get(), d.tiledbDomain.Get(), cDimName, &hasDim)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error finding dimension %s in domain: %w", dimName, d.context.LastError())
@@ -136,7 +147,7 @@ func (d *Domain) HasDimension(dimName string) (bool, error) {
 
 // DumpSTDOUT dumps the domain in ASCII format to stdout.
 func (d *Domain) DumpSTDOUT() error {
-	ret := C.tiledb_domain_dump(d.context.tiledbContext.Get(), d.tiledbDomain, C.stdout)
+	ret := C.tiledb_domain_dump(d.context.tiledbContext.Get(), d.tiledbDomain.Get(), C.stdout)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping domain to stdout: %w", d.context.LastError())
@@ -164,7 +175,7 @@ func (d *Domain) Dump(path string) error {
 	defer C.fclose(cFile)
 
 	// Dump domain to file
-	ret := C.tiledb_domain_dump(d.context.tiledbContext.Get(), d.tiledbDomain, cFile)
+	ret := C.tiledb_domain_dump(d.context.tiledbContext.Get(), d.tiledbDomain.Get(), cFile)
 	runtime.KeepAlive(d)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping domain to file %s: %w", path, d.context.LastError())

--- a/enumeration_experimental.go
+++ b/enumeration_experimental.go
@@ -383,7 +383,7 @@ func ExtendEnumeration[T EnumerationType](tdbCtx *Context, e *Enumeration, value
 
 // AddEnumeration adds the Enumeration to the schema. It must be added before we add it to an attribute.
 func (a *ArraySchema) AddEnumeration(e *Enumeration) error {
-	ret := C.tiledb_array_schema_add_enumeration(a.context.tiledbContext, a.tiledbArraySchema, e.tiledbEnum)
+	ret := C.tiledb_array_schema_add_enumeration(a.context.tiledbContext, a.tiledbArraySchema.Get(), e.tiledbEnum)
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
@@ -398,7 +398,7 @@ func (a *ArraySchema) EnumerationFromName(name string) (*Enumeration, error) {
 	enum := &Enumeration{context: a.context}
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	ret := C.tiledb_array_schema_get_enumeration_from_name(a.context.tiledbContext, a.tiledbArraySchema, cName, &enum.tiledbEnum)
+	ret := C.tiledb_array_schema_get_enumeration_from_name(a.context.tiledbContext, a.tiledbArraySchema.Get(), cName, &enum.tiledbEnum)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting enumeration from name: %w", a.context.LastError())
@@ -412,7 +412,7 @@ func (a *ArraySchema) EnumerationFromAttributeName(name string) (*Enumeration, e
 	enum := &Enumeration{context: a.context}
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	ret := C.tiledb_array_schema_get_enumeration_from_attribute_name(a.context.tiledbContext, a.tiledbArraySchema, cName, &enum.tiledbEnum)
+	ret := C.tiledb_array_schema_get_enumeration_from_attribute_name(a.context.tiledbContext, a.tiledbArraySchema.Get(), cName, &enum.tiledbEnum)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting enumeration from attribute name: %w", a.context.LastError())

--- a/enumeration_experimental.go
+++ b/enumeration_experimental.go
@@ -424,7 +424,7 @@ func (a *ArraySchema) EnumerationFromAttributeName(name string) (*Enumeration, e
 // LoadAllEnumeration is for use with TileDB cloud arrays. It fetches the enumeration values from the server.
 // The method is called ondemand if the client tries to fetch enumeration values for a tiledb:// array.
 func (a *Array) LoadAllEnumerations() error {
-	ret := C.tiledb_array_load_all_enumerations(a.context.tiledbContext, a.tiledbArray)
+	ret := C.tiledb_array_load_all_enumerations(a.context.tiledbContext, a.tiledbArray.Get())
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error loading all enumerations: %w", a.context.LastError())
@@ -435,7 +435,7 @@ func (a *Array) LoadAllEnumerations() error {
 
 // LoadEnumerationsAllSchemas is for use with TileDB cloud arrays. It fetches the enumeration values from the server for all array schemas, past and present.
 func (a *Array) LoadEnumerationsAllSchemas() error {
-	ret := C.tiledb_array_load_enumerations_all_schemas(a.context.tiledbContext, a.tiledbArray)
+	ret := C.tiledb_array_load_enumerations_all_schemas(a.context.tiledbContext, a.tiledbArray.Get())
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error loading enumerations for all schemas: %w", a.context.LastError())
@@ -450,7 +450,7 @@ func (a *Array) GetEnumeration(name string) (*Enumeration, error) {
 	defer C.free(unsafe.Pointer(cName))
 
 	var tiledbEnum *C.tiledb_enumeration_t
-	ret := C.tiledb_array_get_enumeration(a.context.tiledbContext, a.tiledbArray, cName, &tiledbEnum)
+	ret := C.tiledb_array_get_enumeration(a.context.tiledbContext, a.tiledbArray.Get(), cName, &tiledbEnum)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting enumeration %s: %w", name, a.context.LastError())

--- a/enumeration_experimental.go
+++ b/enumeration_experimental.go
@@ -465,7 +465,7 @@ func (a *Attribute) SetEnumerationName(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
-	ret := C.tiledb_attribute_set_enumeration_name(a.context.tiledbContext, a.tiledbAttribute, cName)
+	ret := C.tiledb_attribute_set_enumeration_name(a.context.tiledbContext, a.tiledbAttribute.Get(), cName)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting enumeration name: %w", a.context.LastError())
@@ -478,7 +478,7 @@ func (a *Attribute) SetEnumerationName(name string) error {
 func (a *Attribute) GetEnumerationName() (string, error) {
 	var str *C.tiledb_string_t
 
-	ret := C.tiledb_attribute_get_enumeration_name(a.context.tiledbContext, a.tiledbAttribute, &str)
+	ret := C.tiledb_attribute_get_enumeration_name(a.context.tiledbContext, a.tiledbAttribute.Get(), &str)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting enumeration name: %w", a.context.LastError())
@@ -518,7 +518,7 @@ func (ase *ArraySchemaEvolution) AddEnumeration(e *Enumeration) error {
 		return fmt.Errorf("error getting enumeration name: %w", e.context.LastError())
 	}
 
-	ret := C.tiledb_array_schema_evolution_add_enumeration(ase.context.tiledbContext, ase.tiledbArraySchemaEvolution, e.tiledbEnum)
+	ret := C.tiledb_array_schema_evolution_add_enumeration(ase.context.tiledbContext, ase.tiledbArraySchemaEvolution.Get(), e.tiledbEnum)
 	runtime.KeepAlive(ase)
 	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
@@ -533,7 +533,7 @@ func (ase *ArraySchemaEvolution) DropEnumeration(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
-	ret := C.tiledb_array_schema_evolution_drop_enumeration(ase.context.tiledbContext, ase.tiledbArraySchemaEvolution, cName)
+	ret := C.tiledb_array_schema_evolution_drop_enumeration(ase.context.tiledbContext, ase.tiledbArraySchemaEvolution.Get(), cName)
 	runtime.KeepAlive(ase)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dropping enumeration %s from tiledb arraySchemaEvolution: %w", name, ase.context.LastError())
@@ -544,7 +544,7 @@ func (ase *ArraySchemaEvolution) DropEnumeration(name string) error {
 
 // ApplyExtendedEnumeration applies to the schema evolution the result of ExtendEnumeration.
 func (ase *ArraySchemaEvolution) ApplyExtendedEnumeration(e *Enumeration) error {
-	ret := C.tiledb_array_schema_evolution_extend_enumeration(ase.context.tiledbContext, ase.tiledbArraySchemaEvolution, e.tiledbEnum)
+	ret := C.tiledb_array_schema_evolution_extend_enumeration(ase.context.tiledbContext, ase.tiledbArraySchemaEvolution.Get(), e.tiledbEnum)
 	runtime.KeepAlive(ase)
 	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {

--- a/enumeration_experimental.go
+++ b/enumeration_experimental.go
@@ -498,7 +498,7 @@ func (qc *QueryCondition) UseEnumeration(useEnum bool) error {
 		cUseEnum = 1
 	}
 
-	ret := C.tiledb_query_condition_set_use_enumeration(qc.context.tiledbContext.Get(), qc.cond, cUseEnum)
+	ret := C.tiledb_query_condition_set_use_enumeration(qc.context.tiledbContext.Get(), qc.cond.Get(), cUseEnum)
 	runtime.KeepAlive(qc)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error toggling enumerations use: %w", qc.context.LastError())

--- a/enumeration_experimental.go
+++ b/enumeration_experimental.go
@@ -157,14 +157,7 @@ func (e *Enumeration) Name() (string, error) {
 	}
 	defer C.tiledb_string_free(&str)
 
-	var cName *C.char
-	var cNameSize C.size_t
-	ret = C.tiledb_string_view(str, &cName, &cNameSize)
-	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("error getting name: %w", e.context.LastError())
-	}
-
-	return C.GoStringN(cName, C.int(cNameSize)), nil
+	return stringHandleToString(str)
 }
 
 // Type returns the TileDB type of the enumeration.
@@ -485,14 +478,7 @@ func (a *Attribute) GetEnumerationName() (string, error) {
 	}
 	defer C.tiledb_string_free(&str)
 
-	var cName *C.char
-	var cNameSize C.size_t
-	ret = C.tiledb_string_view(str, &cName, &cNameSize)
-	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("error getting name: %w", a.context.LastError())
-	}
-
-	return C.GoStringN(cName, C.int(cNameSize)), nil
+	return stringHandleToString(str)
 }
 
 // UseEnumerations set true to allow query conditions with enumeration literals.

--- a/enumeration_experimental.go
+++ b/enumeration_experimental.go
@@ -121,7 +121,7 @@ func newEnumeration[T EnumerationType](tdbCtx *Context, name string, ordered boo
 	}
 
 	var tiledbEnum *C.tiledb_enumeration_t
-	ret := C.tiledb_enumeration_alloc(tdbCtx.tiledbContext, cName, C.tiledb_datatype_t(tiledbType), cCellNum, cOrdered,
+	ret := C.tiledb_enumeration_alloc(tdbCtx.tiledbContext.Get(), cName, C.tiledb_datatype_t(tiledbType), cCellNum, cOrdered,
 		cData, cDataLen, cOffsets, cOffsetsLen, &tiledbEnum)
 	// cData and cOffsets are kept alive by passing them to cgo call.
 	runtime.KeepAlive(tdbCtx)
@@ -150,7 +150,7 @@ func (e *Enumeration) Free() {
 func (e *Enumeration) Name() (string, error) {
 	var str *C.tiledb_string_t
 
-	ret := C.tiledb_enumeration_get_name(e.context.tiledbContext, e.tiledbEnum, &str)
+	ret := C.tiledb_enumeration_get_name(e.context.tiledbContext.Get(), e.tiledbEnum, &str)
 	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting name: %w", e.context.LastError())
@@ -171,7 +171,7 @@ func (e *Enumeration) Name() (string, error) {
 func (e *Enumeration) Type() (Datatype, error) {
 	var attrType C.tiledb_datatype_t
 
-	ret := C.tiledb_enumeration_get_type(e.context.tiledbContext, e.tiledbEnum, &attrType)
+	ret := C.tiledb_enumeration_get_type(e.context.tiledbContext.Get(), e.tiledbEnum, &attrType)
 	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting tiledb enumeration type: %w", e.context.LastError())
@@ -184,7 +184,7 @@ func (e *Enumeration) Type() (Datatype, error) {
 func (e *Enumeration) CellValNum() (uint32, error) {
 	var cellValNum C.uint32_t
 
-	ret := C.tiledb_enumeration_get_cell_val_num(e.context.tiledbContext, e.tiledbEnum, &cellValNum)
+	ret := C.tiledb_enumeration_get_cell_val_num(e.context.tiledbContext.Get(), e.tiledbEnum, &cellValNum)
 	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting enumeration cell val num: %w", e.context.LastError())
@@ -198,7 +198,7 @@ func (e *Enumeration) CellValNum() (uint32, error) {
 func (e *Enumeration) IsOrdered() (bool, error) {
 	var ordered C.int
 
-	ret := C.tiledb_enumeration_get_ordered(e.context.tiledbContext, e.tiledbEnum, &ordered)
+	ret := C.tiledb_enumeration_get_ordered(e.context.tiledbContext.Get(), e.tiledbEnum, &ordered)
 	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error getting ordered: %w", e.context.LastError())
@@ -209,7 +209,7 @@ func (e *Enumeration) IsOrdered() (bool, error) {
 
 // DumpSTDOUT writes a human-readable description of the enumeration to os.Stdout.
 func (e *Enumeration) DumpSTDOUT() error {
-	ret := C.tiledb_enumeration_dump(e.context.tiledbContext, e.tiledbEnum, C.stdout)
+	ret := C.tiledb_enumeration_dump(e.context.tiledbContext.Get(), e.tiledbEnum, C.stdout)
 	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping enumeration to stdout: %w", e.context.LastError())
@@ -233,7 +233,7 @@ func (e *Enumeration) Dump(path string) error {
 	cFile := C.fopen(cPath, cMode)
 	defer C.fclose(cFile)
 
-	ret := C.tiledb_enumeration_dump(e.context.tiledbContext, e.tiledbEnum, cFile)
+	ret := C.tiledb_enumeration_dump(e.context.tiledbContext.Get(), e.tiledbEnum, cFile)
 	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping enumeration to file %s: %w", path, e.context.LastError())
@@ -251,7 +251,7 @@ func (e *Enumeration) Values() (interface{}, error) {
 
 	var cData unsafe.Pointer
 	var cDataSize C.uint64_t
-	ret := C.tiledb_enumeration_get_data(e.context.tiledbContext, e.tiledbEnum, &cData, &cDataSize)
+	ret := C.tiledb_enumeration_get_data(e.context.tiledbContext.Get(), e.tiledbEnum, &cData, &cDataSize)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting data: %w", e.context.LastError())
 	}
@@ -287,7 +287,7 @@ func (e *Enumeration) Values() (interface{}, error) {
 
 	var cOffsets unsafe.Pointer
 	var cOffsetsSize C.uint64_t
-	ret = C.tiledb_enumeration_get_offsets(e.context.tiledbContext, e.tiledbEnum, &cOffsets, &cOffsetsSize)
+	ret = C.tiledb_enumeration_get_offsets(e.context.tiledbContext.Get(), e.tiledbEnum, &cOffsets, &cOffsetsSize)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting data offsets: %w", e.context.LastError())
 	}
@@ -367,7 +367,7 @@ func ExtendEnumeration[T EnumerationType](tdbCtx *Context, e *Enumeration, value
 
 	var extEnum *C.tiledb_enumeration_t
 
-	ret := C.tiledb_enumeration_extend(tdbCtx.tiledbContext, e.tiledbEnum, cData, cDataLen, cOffsets, cOffsetsLen, &extEnum)
+	ret := C.tiledb_enumeration_extend(tdbCtx.tiledbContext.Get(), e.tiledbEnum, cData, cDataLen, cOffsets, cOffsetsLen, &extEnum)
 	runtime.KeepAlive(tdbCtx)
 	runtime.KeepAlive(e)
 	// cData and cOffsets are being kept alive by passing them to cgo call.
@@ -383,7 +383,7 @@ func ExtendEnumeration[T EnumerationType](tdbCtx *Context, e *Enumeration, value
 
 // AddEnumeration adds the Enumeration to the schema. It must be added before we add it to an attribute.
 func (a *ArraySchema) AddEnumeration(e *Enumeration) error {
-	ret := C.tiledb_array_schema_add_enumeration(a.context.tiledbContext, a.tiledbArraySchema.Get(), e.tiledbEnum)
+	ret := C.tiledb_array_schema_add_enumeration(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), e.tiledbEnum)
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
@@ -398,7 +398,7 @@ func (a *ArraySchema) EnumerationFromName(name string) (*Enumeration, error) {
 	enum := &Enumeration{context: a.context}
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	ret := C.tiledb_array_schema_get_enumeration_from_name(a.context.tiledbContext, a.tiledbArraySchema.Get(), cName, &enum.tiledbEnum)
+	ret := C.tiledb_array_schema_get_enumeration_from_name(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), cName, &enum.tiledbEnum)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting enumeration from name: %w", a.context.LastError())
@@ -412,7 +412,7 @@ func (a *ArraySchema) EnumerationFromAttributeName(name string) (*Enumeration, e
 	enum := &Enumeration{context: a.context}
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	ret := C.tiledb_array_schema_get_enumeration_from_attribute_name(a.context.tiledbContext, a.tiledbArraySchema.Get(), cName, &enum.tiledbEnum)
+	ret := C.tiledb_array_schema_get_enumeration_from_attribute_name(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), cName, &enum.tiledbEnum)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting enumeration from attribute name: %w", a.context.LastError())
@@ -424,7 +424,7 @@ func (a *ArraySchema) EnumerationFromAttributeName(name string) (*Enumeration, e
 // LoadAllEnumeration is for use with TileDB cloud arrays. It fetches the enumeration values from the server.
 // The method is called ondemand if the client tries to fetch enumeration values for a tiledb:// array.
 func (a *Array) LoadAllEnumerations() error {
-	ret := C.tiledb_array_load_all_enumerations(a.context.tiledbContext, a.tiledbArray.Get())
+	ret := C.tiledb_array_load_all_enumerations(a.context.tiledbContext.Get(), a.tiledbArray.Get())
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error loading all enumerations: %w", a.context.LastError())
@@ -435,7 +435,7 @@ func (a *Array) LoadAllEnumerations() error {
 
 // LoadEnumerationsAllSchemas is for use with TileDB cloud arrays. It fetches the enumeration values from the server for all array schemas, past and present.
 func (a *Array) LoadEnumerationsAllSchemas() error {
-	ret := C.tiledb_array_load_enumerations_all_schemas(a.context.tiledbContext, a.tiledbArray.Get())
+	ret := C.tiledb_array_load_enumerations_all_schemas(a.context.tiledbContext.Get(), a.tiledbArray.Get())
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error loading enumerations for all schemas: %w", a.context.LastError())
@@ -450,7 +450,7 @@ func (a *Array) GetEnumeration(name string) (*Enumeration, error) {
 	defer C.free(unsafe.Pointer(cName))
 
 	var tiledbEnum *C.tiledb_enumeration_t
-	ret := C.tiledb_array_get_enumeration(a.context.tiledbContext, a.tiledbArray.Get(), cName, &tiledbEnum)
+	ret := C.tiledb_array_get_enumeration(a.context.tiledbContext.Get(), a.tiledbArray.Get(), cName, &tiledbEnum)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting enumeration %s: %w", name, a.context.LastError())
@@ -465,7 +465,7 @@ func (a *Attribute) SetEnumerationName(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
-	ret := C.tiledb_attribute_set_enumeration_name(a.context.tiledbContext, a.tiledbAttribute.Get(), cName)
+	ret := C.tiledb_attribute_set_enumeration_name(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), cName)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting enumeration name: %w", a.context.LastError())
@@ -478,7 +478,7 @@ func (a *Attribute) SetEnumerationName(name string) error {
 func (a *Attribute) GetEnumerationName() (string, error) {
 	var str *C.tiledb_string_t
 
-	ret := C.tiledb_attribute_get_enumeration_name(a.context.tiledbContext, a.tiledbAttribute.Get(), &str)
+	ret := C.tiledb_attribute_get_enumeration_name(a.context.tiledbContext.Get(), a.tiledbAttribute.Get(), &str)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting enumeration name: %w", a.context.LastError())
@@ -502,7 +502,7 @@ func (qc *QueryCondition) UseEnumeration(useEnum bool) error {
 		cUseEnum = 1
 	}
 
-	ret := C.tiledb_query_condition_set_use_enumeration(qc.context.tiledbContext, qc.cond, cUseEnum)
+	ret := C.tiledb_query_condition_set_use_enumeration(qc.context.tiledbContext.Get(), qc.cond, cUseEnum)
 	runtime.KeepAlive(qc)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error toggling enumerations use: %w", qc.context.LastError())
@@ -518,7 +518,7 @@ func (ase *ArraySchemaEvolution) AddEnumeration(e *Enumeration) error {
 		return fmt.Errorf("error getting enumeration name: %w", e.context.LastError())
 	}
 
-	ret := C.tiledb_array_schema_evolution_add_enumeration(ase.context.tiledbContext, ase.tiledbArraySchemaEvolution.Get(), e.tiledbEnum)
+	ret := C.tiledb_array_schema_evolution_add_enumeration(ase.context.tiledbContext.Get(), ase.tiledbArraySchemaEvolution.Get(), e.tiledbEnum)
 	runtime.KeepAlive(ase)
 	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {
@@ -533,7 +533,7 @@ func (ase *ArraySchemaEvolution) DropEnumeration(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
-	ret := C.tiledb_array_schema_evolution_drop_enumeration(ase.context.tiledbContext, ase.tiledbArraySchemaEvolution.Get(), cName)
+	ret := C.tiledb_array_schema_evolution_drop_enumeration(ase.context.tiledbContext.Get(), ase.tiledbArraySchemaEvolution.Get(), cName)
 	runtime.KeepAlive(ase)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dropping enumeration %s from tiledb arraySchemaEvolution: %w", name, ase.context.LastError())
@@ -544,7 +544,7 @@ func (ase *ArraySchemaEvolution) DropEnumeration(name string) error {
 
 // ApplyExtendedEnumeration applies to the schema evolution the result of ExtendEnumeration.
 func (ase *ArraySchemaEvolution) ApplyExtendedEnumeration(e *Enumeration) error {
-	ret := C.tiledb_array_schema_evolution_extend_enumeration(ase.context.tiledbContext, ase.tiledbArraySchemaEvolution.Get(), e.tiledbEnum)
+	ret := C.tiledb_array_schema_evolution_extend_enumeration(ase.context.tiledbContext.Get(), ase.tiledbArraySchemaEvolution.Get(), e.tiledbEnum)
 	runtime.KeepAlive(ase)
 	runtime.KeepAlive(e)
 	if ret != C.TILEDB_OK {

--- a/examples/array_metadata_test.go
+++ b/examples/array_metadata_test.go
@@ -42,9 +42,9 @@ import (
 	"github.com/TileDB-Inc/TileDB-Go/examples_lib"
 )
 
-// ExampleArrayMetadataArray shows and example creation, writing and reading of a
+// ExampleRunArrayMetadataArray shows and example creation, writing and reading of a
 // sparse array
-func ExampleArrayMetadataArray() {
+func ExampleRunArrayMetadataArray() {
 	examples_lib.RunArrayMetadataArray()
 
 	// Output: Datatype: 0

--- a/examples/config_test.go
+++ b/examples/config_test.go
@@ -39,6 +39,6 @@ import (
 	"github.com/TileDB-Inc/TileDB-Go/examples_lib"
 )
 
-func ExampleConfig() {
+func ExampleRunConfig() {
 	examples_lib.RunConfig()
 }

--- a/examples/deserialize_sparse_layouts_test.go
+++ b/examples/deserialize_sparse_layouts_test.go
@@ -34,7 +34,7 @@ package examples
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
 // ToDo: Add proper test for deserialization
-func ExampleDeserializeSparseLayouts() {
+func ExampleRunDeserializeSparseLayouts() {
 	examples_lib.RunDeserializeSparseLayouts()
 
 	// Output: [1 2]

--- a/examples/dimension_labels_test.go
+++ b/examples/dimension_labels_test.go
@@ -2,7 +2,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleDimensionLabels() {
+func ExampleRunDimensionLabels() {
 	examples_lib.RunDimensionLabels()
 
 	// Output: 33 34 65 66 0

--- a/examples/encryption_test.go
+++ b/examples/encryption_test.go
@@ -39,7 +39,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleEncryptedArray() {
+func ExampleRunEncryptedArray() {
 	examples_lib.RunEncryptedArray()
 
 	// Output: [2 3 4 6 7 8]

--- a/examples/error_check.go
+++ b/examples/error_check.go
@@ -1,7 +1,0 @@
-package examples
-
-func checkError(err error) {
-	if err != nil {
-		panic(err)
-	}
-}

--- a/examples/filestore_test.go
+++ b/examples/filestore_test.go
@@ -2,7 +2,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleFilestore() {
+func ExampleRunFilestore() {
 	examples_lib.RunFilestore()
 
 	// Output: Hello World

--- a/examples/filters_test.go
+++ b/examples/filters_test.go
@@ -41,9 +41,9 @@ import (
 	"github.com/TileDB-Inc/TileDB-Go/examples_lib"
 )
 
-// ExampleSparseArray shows and example creation, writing and reading of a
+// ExampleRunSparseArray shows and example creation, writing and reading of a
 // sparse array
-func ExampleFiltersArray() {
+func ExampleRunFiltersArray() {
 	examples_lib.RunFiltersArray()
 
 	// Output: Cell (2, 3) has data 3

--- a/examples/fragments_consolidation_test.go
+++ b/examples/fragments_consolidation_test.go
@@ -39,7 +39,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleFragmentsConsolidationArray() {
+func ExampleRunFragmentsConsolidationArray() {
 	examples_lib.RunFragmentsConsolidationArray()
 
 	// Output: Num of fragments: 1

--- a/examples/multi_attribute_test.go
+++ b/examples/multi_attribute_test.go
@@ -40,7 +40,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleMultiAttributeArray() {
+func ExampleRunMultiAttributeArray() {
 	examples_lib.RunMultiAttributeArray()
 
 	// Output: Reading both attributes a1 and a2:

--- a/examples/quickstart_dense_test.go
+++ b/examples/quickstart_dense_test.go
@@ -42,9 +42,9 @@ import (
 	"github.com/TileDB-Inc/TileDB-Go/examples_lib"
 )
 
-// ExampleDenseArray shows and example creation, writing and reading of a dense
+// ExampleRunDenseArray shows and example creation, writing and reading of a dense
 // array
-func ExampleDenseArray() {
+func ExampleRunDenseArray() {
 	examples_lib.RunDenseArray()
 
 	// Output: [2 3 4 6 7 8]

--- a/examples/quickstart_sparse_test.go
+++ b/examples/quickstart_sparse_test.go
@@ -40,9 +40,9 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-// ExampleSparseArray shows and example creation, writing and reading of a
+// ExampleRunSparseArray shows and example creation, writing and reading of a
 // sparse array
-func ExampleSparseArray() {
+func ExampleRunSparseArray() {
 	examples_lib.RunSparseArray()
 
 	// Output: Estimated query size in bytes for attribute 'a': 12

--- a/examples/range_test.go
+++ b/examples/range_test.go
@@ -40,9 +40,9 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-// ExampleRange shows an example of creation, writing of a dense array
+// ExampleRunRange shows an example of creation, writing of a dense array
 // and usage of range functions
-func ExampleRange() {
+func ExampleRunRange() {
 	examples_lib.RunRange()
 
 	// Error adding query range: [TileDB::Dimension] Error: Cannot add range to dimension; Lower range bound 1065353216 cannot be larger than the higher bound 4

--- a/examples/reading_dense_layouts_test.go
+++ b/examples/reading_dense_layouts_test.go
@@ -40,7 +40,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleReadingDenseLayouts() {
+func ExampleRunReadingDenseLayouts() {
 	examples_lib.RunReadingDenseLayouts()
 
 	// Output: Non-empty domain: [1,4], [1,4]

--- a/examples/reading_incomplete_test.go
+++ b/examples/reading_incomplete_test.go
@@ -38,7 +38,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleReadingIncompleteArray() {
+func ExampleRunReadingIncompleteArray() {
 	examples_lib.RunReadingIncompleteArray()
 
 	// Output: Printing results...

--- a/examples/reading_query_conditions_test.go
+++ b/examples/reading_query_conditions_test.go
@@ -41,8 +41,8 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-// ExampleQueryConditionsArray shows how query conditions work
-func ExampleQueryConditionsArray() {
+// ExampleRunQueryConditionsArray shows how query conditions work
+func ExampleRunQueryConditionsArray() {
 	examples_lib.RunQueryConditionsArray()
 	// Output: Non-empty domain: [1,2], [1,4]
 	// Cell (1, 2) has data 2

--- a/examples/reading_range_test.go
+++ b/examples/reading_range_test.go
@@ -40,9 +40,9 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-// ExampleReadRangeArray shows and example creation, writing and range reading
+// ExampleRunReadRangeArray shows and example creation, writing and range reading
 // of a dense array
-func ExampleReadRangeArray() {
+func ExampleRunReadRangeArray() {
 	examples_lib.RunReadRangeArray()
 
 	// Output: Num of Ranges: 2

--- a/examples/reading_sparse_layouts_test.go
+++ b/examples/reading_sparse_layouts_test.go
@@ -40,7 +40,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleReadingSparseLayouts() {
+func ExampleRunReadingSparseLayouts() {
 	examples_lib.RunReadingSparseLayouts()
 
 	// Output: Non-empty domain: [1,2], [1,4]

--- a/examples/reading_timestamp_test.go
+++ b/examples/reading_timestamp_test.go
@@ -41,8 +41,8 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-// ExampleTimestampArray shows timestamp correlation of written data and metadata
-func ExampleTimestampArray() {
+// ExampleRunTimestampArray shows timestamp correlation of written data and metadata
+func ExampleRunTimestampArray() {
 	examples_lib.RunTimestampArray()
 
 	// Output: Writing meta_key: Write1

--- a/examples/string_dim_test.go
+++ b/examples/string_dim_test.go
@@ -36,9 +36,9 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-// ExampleStringDimArray shows an example of creation, writing and reading of a
+// ExampleRunStringDimArray shows an example of creation, writing and reading of a
 // sparse array with string dim
-func ExampleStringDimArray() {
+func ExampleRunStringDimArray() {
 	examples_lib.RunStringDimArray()
 
 	// Output: NonEmptyDomain Dimension Name: d

--- a/examples/using_tiledb_stats_test.go
+++ b/examples/using_tiledb_stats_test.go
@@ -39,6 +39,6 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleUsingTileDBStats() {
+func ExampleRunUsingTileDBStats() {
 	examples_lib.RunUsingTileDBStats()
 }

--- a/examples/vacuum_test.go
+++ b/examples/vacuum_test.go
@@ -39,8 +39,8 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-// ExampleVacuumSparseArray shows ysage of array vacuum function
-func ExampleVacuumSparseArray() {
+// ExampleRunVacuumSparseArray shows ysage of array vacuum function
+func ExampleRunVacuumSparseArray() {
 	examples_lib.RunVacuumSparseArray()
 
 	// Output: Estimated query size in bytes for attribute 'a': 12

--- a/examples/variable_length_test.go
+++ b/examples/variable_length_test.go
@@ -40,7 +40,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleVariableLengthArray() {
+func ExampleRunVariableLengthArray() {
 	examples_lib.RunVariableLengthArray()
 
 	// Output:

--- a/examples/vfs_test.go
+++ b/examples/vfs_test.go
@@ -2,7 +2,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleVfs() {
+func ExampleRunVfs() {
 	examples_lib.RunVfs()
 
 	// Output: Created 'dir_A'

--- a/examples/writing_dense_global_expansion_test.go
+++ b/examples/writing_dense_global_expansion_test.go
@@ -40,7 +40,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleWritingDenseGlobalExpansion() {
+func ExampleRunWritingDenseGlobalExpansion() {
 	examples_lib.RunWritingDenseGlobalExpansion()
 
 	// Output: [1 2 9 3 4 10 5 6 11 7 8 12]

--- a/examples/writing_dense_global_test.go
+++ b/examples/writing_dense_global_test.go
@@ -38,7 +38,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleWritingDenseGlobal() {
+func ExampleRunWritingDenseGlobal() {
 	examples_lib.RunWritingDenseGlobal()
 
 	// Output: [1 2 -2147483648 -2147483648 3 4 -2147483648 -2147483648 5 6 -2147483648 -2147483648 7 8 -2147483648 -2147483648]

--- a/examples/writing_dense_multiple_test.go
+++ b/examples/writing_dense_multiple_test.go
@@ -38,7 +38,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleWritingDenseMultiple() {
+func ExampleRunWritingDenseMultiple() {
 	examples_lib.RunWritingDenseMultiple()
 
 	// Output: [1 2 -2147483648 -2147483648 5 6 7 8 9 10 11 12 -2147483648 -2147483648 -2147483648 -2147483648]

--- a/examples/writing_dense_padding_test.go
+++ b/examples/writing_dense_padding_test.go
@@ -38,7 +38,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleWritingDensePadding() {
+func ExampleRunWritingDensePadding() {
 	examples_lib.RunWritingDensePadding()
 
 	// Output: [-2147483648 -2147483648 -2147483648 -2147483648 1 2 -2147483648 -2147483648 3 4 -2147483648 -2147483648 -2147483648 -2147483648 -2147483648 -2147483648]

--- a/examples/writing_dense_sparse_test.go
+++ b/examples/writing_dense_sparse_test.go
@@ -39,7 +39,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleWritingDenseSparse() {
+func ExampleRunWritingDenseSparse() {
 	examples_lib.RunWritingDenseSparse()
 
 	// Output: Cell (1, 2) has data 1

--- a/examples/writing_sparse_global_test.go
+++ b/examples/writing_sparse_global_test.go
@@ -39,7 +39,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleWritingSparseGlobal() {
+func ExampleRunWritingSparseGlobal() {
 	examples_lib.RunWritingSparseGlobal()
 
 	// Output: Cell (1, 1) has data 1

--- a/examples/writing_sparse_heter_dim_test.go
+++ b/examples/writing_sparse_heter_dim_test.go
@@ -36,9 +36,9 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-// ExampleSparseHeterDimArray shows and example creation, writing and reading of
+// ExampleRunSparseHeterDimArray shows and example creation, writing and reading of
 // a sparse array using heterogeneus dimensions
-func ExampleSparseHeterDimArray() {
+func ExampleRunSparseHeterDimArray() {
 	examples_lib.RunSparseHeterDimArray()
 
 	// Output: Non-empty domain: [1.100000,1.400000], [1,4]

--- a/examples/writing_sparse_multiple_test.go
+++ b/examples/writing_sparse_multiple_test.go
@@ -39,7 +39,7 @@ package examples
 
 import "github.com/TileDB-Inc/TileDB-Go/examples_lib"
 
-func ExampleWritingSparseMultiple() {
+func ExampleRunWritingSparseMultiple() {
 	examples_lib.RunWritingSparseMultiple()
 
 	// Output: Cell (1, 1) has data 1

--- a/filestore_experimental.go
+++ b/filestore_experimental.go
@@ -164,15 +164,14 @@ func NewArraySchemaForFile(tdbCtx *Context, filePath string) (*ArraySchema, erro
 		defer C.free(unsafe.Pointer(fileURI))
 	}
 
-	arraySchema := ArraySchema{context: tdbCtx}
-	ret := C.tiledb_filestore_schema_create(tdbCtx.tiledbContext, fileURI, &arraySchema.tiledbArraySchema)
+	var arraySchemaPtr *C.tiledb_array_schema_t
+	ret := C.tiledb_filestore_schema_create(tdbCtx.tiledbContext, fileURI, &arraySchemaPtr)
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating schema: %w", tdbCtx.LastError())
 	}
-	freeOnGC(&arraySchema)
 
-	return &arraySchema, nil
+	return newArraySchemaFromHandle(tdbCtx, newArraySchemaHandle(arraySchemaPtr)), nil
 }
 
 // bufferExport reads len(p) bytes into p starting at array offset off

--- a/filestore_experimental.go
+++ b/filestore_experimental.go
@@ -20,7 +20,7 @@ func FileSize(tdbCtx *Context, arrayURI string) (int64, error) {
 	defer C.free(unsafe.Pointer(cArrayURI))
 
 	var size C.size_t
-	ret := C.tiledb_filestore_size(tdbCtx.tiledbContext, cArrayURI, &size)
+	ret := C.tiledb_filestore_size(tdbCtx.tiledbContext.Get(), cArrayURI, &size)
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting file size: %w", tdbCtx.LastError())
@@ -37,7 +37,7 @@ func ExportFile(tdbCtx *Context, filePath, arrayURI string) error {
 	cFileURI := C.CString(filePath)
 	defer C.free(unsafe.Pointer(cFileURI))
 
-	ret := C.tiledb_filestore_uri_export(tdbCtx.tiledbContext, cFileURI, cArrayURI)
+	ret := C.tiledb_filestore_uri_export(tdbCtx.tiledbContext.Get(), cFileURI, cArrayURI)
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error exporting file: %w", tdbCtx.LastError())
@@ -53,7 +53,7 @@ func ImportFile(tdbCtx *Context, arrayURI, filePath string, mimeType FileStoreMi
 	cFileURI := C.CString(filePath)
 	defer C.free(unsafe.Pointer(cFileURI))
 
-	ret := C.tiledb_filestore_uri_import(tdbCtx.tiledbContext, cArrayURI, cFileURI, C.tiledb_mime_type_t(mimeType))
+	ret := C.tiledb_filestore_uri_import(tdbCtx.tiledbContext.Get(), cArrayURI, cFileURI, C.tiledb_mime_type_t(mimeType))
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error importing file: %w", tdbCtx.LastError())
@@ -165,7 +165,7 @@ func NewArraySchemaForFile(tdbCtx *Context, filePath string) (*ArraySchema, erro
 	}
 
 	var arraySchemaPtr *C.tiledb_array_schema_t
-	ret := C.tiledb_filestore_schema_create(tdbCtx.tiledbContext, fileURI, &arraySchemaPtr)
+	ret := C.tiledb_filestore_schema_create(tdbCtx.tiledbContext.Get(), fileURI, &arraySchemaPtr)
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating schema: %w", tdbCtx.LastError())
@@ -182,7 +182,7 @@ func bufferExport(tdbCtx *Context, uri *C.char, off int64, p []byte) error {
 		return nil
 	}
 
-	ret := C.tiledb_filestore_buffer_export(tdbCtx.tiledbContext, uri, C.size_t(off), slicePtr(p), C.size_t(len(p)))
+	ret := C.tiledb_filestore_buffer_export(tdbCtx.tiledbContext.Get(), uri, C.size_t(off), slicePtr(p), C.size_t(len(p)))
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error exporting buffer data: %w", tdbCtx.LastError())
@@ -198,7 +198,7 @@ func bufferImport(tdbCtx *Context, uri *C.char, data []byte, mimeType FileStoreM
 		return errors.New("error importing buffer data: empty data")
 	}
 
-	ret := C.tiledb_filestore_buffer_import(tdbCtx.tiledbContext, uri, slicePtr(data), C.size_t(len(data)), C.tiledb_mime_type_t(mimeType))
+	ret := C.tiledb_filestore_buffer_import(tdbCtx.tiledbContext.Get(), uri, slicePtr(data), C.size_t(len(data)), C.tiledb_mime_type_t(mimeType))
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error importing buffer data: %w", tdbCtx.LastError())

--- a/filter.go
+++ b/filter.go
@@ -23,7 +23,7 @@ type Filter struct {
 func NewFilter(context *Context, filterType FilterType) (*Filter, error) {
 	filter := Filter{context: context}
 
-	ret := C.tiledb_filter_alloc(filter.context.tiledbContext, C.tiledb_filter_type_t(filterType), &filter.tiledbFilter)
+	ret := C.tiledb_filter_alloc(filter.context.tiledbContext.Get(), C.tiledb_filter_type_t(filterType), &filter.tiledbFilter)
 	runtime.KeepAlive(context)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb filter: %w", filter.context.LastError())
@@ -52,7 +52,7 @@ func (f *Filter) Context() *Context {
 // Type returns the filter type.
 func (f *Filter) Type() (FilterType, error) {
 	var filterType C.tiledb_filter_type_t
-	ret := C.tiledb_filter_get_type(f.context.tiledbContext, f.tiledbFilter, &filterType)
+	ret := C.tiledb_filter_get_type(f.context.tiledbContext.Get(), f.tiledbFilter, &filterType)
 	runtime.KeepAlive(f)
 
 	if ret != C.TILEDB_OK {
@@ -75,7 +75,7 @@ func (f *Filter) SetOption(filterOption FilterOption, valueInterface interface{}
 			return errors.New("error setting tiledb filter option TILEDB_COMPRESSION_LEVEL, passed data is not int32")
 		}
 		cvalue = unsafe.Pointer(&value)
-		ret := C.tiledb_filter_set_option(f.context.tiledbContext, f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
+		ret := C.tiledb_filter_set_option(f.context.tiledbContext.Get(), f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
 		if ret != C.TILEDB_OK {
 			return fmt.Errorf("error setting tiledb filter option: %w", f.context.LastError())
 		}
@@ -85,7 +85,7 @@ func (f *Filter) SetOption(filterOption FilterOption, valueInterface interface{}
 			return errors.New("error setting tiledb filter option TILEDB_BIT_WIDTH_MAX_WINDOW, passed data is not uint32")
 		}
 		cvalue = unsafe.Pointer(&value)
-		ret := C.tiledb_filter_set_option(f.context.tiledbContext, f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
+		ret := C.tiledb_filter_set_option(f.context.tiledbContext.Get(), f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
 		if ret != C.TILEDB_OK {
 			return fmt.Errorf("error setting tiledb filter option: %w", f.context.LastError())
 		}
@@ -95,7 +95,7 @@ func (f *Filter) SetOption(filterOption FilterOption, valueInterface interface{}
 			return errors.New("error setting tiledb filter option TILEDB_POSITIVE_DELTA_MAX_WINDOW, passed data is not uint32")
 		}
 		cvalue = unsafe.Pointer(&value)
-		ret := C.tiledb_filter_set_option(f.context.tiledbContext, f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
+		ret := C.tiledb_filter_set_option(f.context.tiledbContext.Get(), f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
 		if ret != C.TILEDB_OK {
 			return fmt.Errorf("error setting tiledb filter option: %w", f.context.LastError())
 		}
@@ -118,7 +118,7 @@ func (f *Filter) Option(filterOption FilterOption) (interface{}, error) {
 	case TILEDB_COMPRESSION_LEVEL:
 		var val int32
 		cvalue = unsafe.Pointer(&val)
-		ret := C.tiledb_filter_get_option(f.context.tiledbContext, f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
+		ret := C.tiledb_filter_get_option(f.context.tiledbContext.Get(), f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
 		if ret != C.TILEDB_OK {
 			return nil, fmt.Errorf("error getting tiledb filter option: %w", f.context.LastError())
 		}
@@ -126,7 +126,7 @@ func (f *Filter) Option(filterOption FilterOption) (interface{}, error) {
 	case TILEDB_BIT_WIDTH_MAX_WINDOW:
 		var val uint32
 		cvalue = unsafe.Pointer(&val)
-		ret := C.tiledb_filter_get_option(f.context.tiledbContext, f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
+		ret := C.tiledb_filter_get_option(f.context.tiledbContext.Get(), f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
 		if ret != C.TILEDB_OK {
 			return nil, fmt.Errorf("error getting tiledb filter option: %w", f.context.LastError())
 		}
@@ -134,7 +134,7 @@ func (f *Filter) Option(filterOption FilterOption) (interface{}, error) {
 	case TILEDB_POSITIVE_DELTA_MAX_WINDOW:
 		var val uint32
 		cvalue = unsafe.Pointer(&val)
-		ret := C.tiledb_filter_get_option(f.context.tiledbContext, f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
+		ret := C.tiledb_filter_get_option(f.context.tiledbContext.Get(), f.tiledbFilter, C.tiledb_filter_option_t(filterOption), cvalue)
 		if ret != C.TILEDB_OK {
 			return nil, fmt.Errorf("error getting tiledb filter option: %w", f.context.LastError())
 		}

--- a/filter_list.go
+++ b/filter_list.go
@@ -21,7 +21,7 @@ type FilterList struct {
 func NewFilterList(context *Context) (*FilterList, error) {
 	filterList := FilterList{context: context}
 
-	ret := C.tiledb_filter_list_alloc(filterList.context.tiledbContext, &filterList.tiledbFilterList)
+	ret := C.tiledb_filter_list_alloc(filterList.context.tiledbContext.Get(), &filterList.tiledbFilterList)
 	runtime.KeepAlive(context)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb FilterList: %w", filterList.context.LastError())
@@ -50,7 +50,7 @@ func (f *FilterList) Context() *Context {
 // AddFilter appends a filter to a filter list. Data is processed through
 // each filter in the order the filters were added.
 func (f *FilterList) AddFilter(filter *Filter) error {
-	ret := C.tiledb_filter_list_add_filter(f.context.tiledbContext, f.tiledbFilterList, filter.tiledbFilter)
+	ret := C.tiledb_filter_list_add_filter(f.context.tiledbContext.Get(), f.tiledbFilterList, filter.tiledbFilter)
 	runtime.KeepAlive(f)
 	runtime.KeepAlive(filter)
 	if ret != C.TILEDB_OK {
@@ -61,7 +61,7 @@ func (f *FilterList) AddFilter(filter *Filter) error {
 
 // SetMaxChunkSize sets the maximum tile chunk size for a filter list.
 func (f *FilterList) SetMaxChunkSize(maxChunkSize uint32) error {
-	ret := C.tiledb_filter_list_set_max_chunk_size(f.context.tiledbContext, f.tiledbFilterList, C.uint32_t(maxChunkSize))
+	ret := C.tiledb_filter_list_set_max_chunk_size(f.context.tiledbContext.Get(), f.tiledbFilterList, C.uint32_t(maxChunkSize))
 	runtime.KeepAlive(f)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting max chunk size on tiledb FilterList: %w", f.context.LastError())
@@ -72,7 +72,7 @@ func (f *FilterList) SetMaxChunkSize(maxChunkSize uint32) error {
 // MaxChunkSize Gets the maximum tile chunk size for a filter list.
 func (f *FilterList) MaxChunkSize() (uint32, error) {
 	var cMaxChunkSize C.uint32_t
-	ret := C.tiledb_filter_list_get_max_chunk_size(f.context.tiledbContext, f.tiledbFilterList, &cMaxChunkSize)
+	ret := C.tiledb_filter_list_get_max_chunk_size(f.context.tiledbContext.Get(), f.tiledbFilterList, &cMaxChunkSize)
 	runtime.KeepAlive(f)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching max chunk size from tiledb FilterList: %w", f.context.LastError())
@@ -83,7 +83,7 @@ func (f *FilterList) MaxChunkSize() (uint32, error) {
 // NFilters Retrieves the number of filters in a filter list.
 func (f *FilterList) NFilters() (uint32, error) {
 	var cNFilters C.uint32_t
-	ret := C.tiledb_filter_list_get_nfilters(f.context.tiledbContext, f.tiledbFilterList, &cNFilters)
+	ret := C.tiledb_filter_list_get_nfilters(f.context.tiledbContext.Get(), f.tiledbFilterList, &cNFilters)
 	runtime.KeepAlive(f)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting number of filter for tiledb FilterList: %w", f.context.LastError())
@@ -94,7 +94,7 @@ func (f *FilterList) NFilters() (uint32, error) {
 // FilterFromIndex Retrieves a filter object from a filter list by index.
 func (f *FilterList) FilterFromIndex(index uint32) (*Filter, error) {
 	filter := Filter{context: f.context}
-	ret := C.tiledb_filter_list_get_filter_from_index(f.context.tiledbContext, f.tiledbFilterList, C.uint32_t(index), &filter.tiledbFilter)
+	ret := C.tiledb_filter_list_get_filter_from_index(f.context.tiledbContext.Get(), f.tiledbFilterList, C.uint32_t(index), &filter.tiledbFilter)
 	runtime.KeepAlive(f)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error fetching filter for index %d from tiledb FilterList: %w", index, f.context.LastError())

--- a/filter_list.go
+++ b/filter_list.go
@@ -9,26 +9,44 @@ import "C"
 import (
 	"fmt"
 	"runtime"
+	"unsafe"
 )
+
+type filterListHandle struct{ *capiHandle }
+
+func freeCapiFilterList(c unsafe.Pointer) {
+	C.tiledb_filter_list_free((**C.tiledb_filter_list_t)(unsafe.Pointer(&c)))
+}
+
+func newFilterListHandle(ptr *C.tiledb_filter_list_t) filterListHandle {
+	return filterListHandle{newCapiHandle(unsafe.Pointer(ptr), freeCapiFilterList)}
+}
+
+func (x filterListHandle) Get() *C.tiledb_filter_list_t {
+	return (*C.tiledb_filter_list_t)(x.capiHandle.Get())
+}
 
 // FilterList represents
 type FilterList struct {
-	tiledbFilterList *C.tiledb_filter_list_t
+	tiledbFilterList filterListHandle
 	context          *Context
+}
+
+func newFilterListFromHandle(context *Context, handle filterListHandle) *FilterList {
+	return &FilterList{tiledbFilterList: handle, context: context}
 }
 
 // Alloc a new FilterList
 func NewFilterList(context *Context) (*FilterList, error) {
-	filterList := FilterList{context: context}
+	var filterListPtr *C.tiledb_filter_list_t
 
-	ret := C.tiledb_filter_list_alloc(filterList.context.tiledbContext.Get(), &filterList.tiledbFilterList)
+	ret := C.tiledb_filter_list_alloc(context.tiledbContext.Get(), &filterListPtr)
 	runtime.KeepAlive(context)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error creating tiledb FilterList: %w", filterList.context.LastError())
+		return nil, fmt.Errorf("error creating tiledb FilterList: %w", context.LastError())
 	}
-	freeOnGC(&filterList)
 
-	return &filterList, nil
+	return newFilterListFromHandle(context, newFilterListHandle(filterListPtr)), nil
 }
 
 // Free releases the internal TileDB core data that was allocated on the C heap.
@@ -37,9 +55,7 @@ func NewFilterList(context *Context) (*FilterList, error) {
 // can safely be called many times on the same object; if it has already
 // been freed, it will not be freed again.
 func (f *FilterList) Free() {
-	if f.tiledbFilterList != nil {
-		C.tiledb_filter_list_free(&f.tiledbFilterList)
-	}
+	f.tiledbFilterList.Free()
 }
 
 // Context exposes the internal TileDB context used to initialize the filter list
@@ -50,7 +66,7 @@ func (f *FilterList) Context() *Context {
 // AddFilter appends a filter to a filter list. Data is processed through
 // each filter in the order the filters were added.
 func (f *FilterList) AddFilter(filter *Filter) error {
-	ret := C.tiledb_filter_list_add_filter(f.context.tiledbContext.Get(), f.tiledbFilterList, filter.tiledbFilter)
+	ret := C.tiledb_filter_list_add_filter(f.context.tiledbContext.Get(), f.tiledbFilterList.Get(), filter.tiledbFilter.Get())
 	runtime.KeepAlive(f)
 	runtime.KeepAlive(filter)
 	if ret != C.TILEDB_OK {
@@ -61,7 +77,7 @@ func (f *FilterList) AddFilter(filter *Filter) error {
 
 // SetMaxChunkSize sets the maximum tile chunk size for a filter list.
 func (f *FilterList) SetMaxChunkSize(maxChunkSize uint32) error {
-	ret := C.tiledb_filter_list_set_max_chunk_size(f.context.tiledbContext.Get(), f.tiledbFilterList, C.uint32_t(maxChunkSize))
+	ret := C.tiledb_filter_list_set_max_chunk_size(f.context.tiledbContext.Get(), f.tiledbFilterList.Get(), C.uint32_t(maxChunkSize))
 	runtime.KeepAlive(f)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting max chunk size on tiledb FilterList: %w", f.context.LastError())
@@ -72,7 +88,7 @@ func (f *FilterList) SetMaxChunkSize(maxChunkSize uint32) error {
 // MaxChunkSize Gets the maximum tile chunk size for a filter list.
 func (f *FilterList) MaxChunkSize() (uint32, error) {
 	var cMaxChunkSize C.uint32_t
-	ret := C.tiledb_filter_list_get_max_chunk_size(f.context.tiledbContext.Get(), f.tiledbFilterList, &cMaxChunkSize)
+	ret := C.tiledb_filter_list_get_max_chunk_size(f.context.tiledbContext.Get(), f.tiledbFilterList.Get(), &cMaxChunkSize)
 	runtime.KeepAlive(f)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error fetching max chunk size from tiledb FilterList: %w", f.context.LastError())
@@ -83,7 +99,7 @@ func (f *FilterList) MaxChunkSize() (uint32, error) {
 // NFilters Retrieves the number of filters in a filter list.
 func (f *FilterList) NFilters() (uint32, error) {
 	var cNFilters C.uint32_t
-	ret := C.tiledb_filter_list_get_nfilters(f.context.tiledbContext.Get(), f.tiledbFilterList, &cNFilters)
+	ret := C.tiledb_filter_list_get_nfilters(f.context.tiledbContext.Get(), f.tiledbFilterList.Get(), &cNFilters)
 	runtime.KeepAlive(f)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting number of filter for tiledb FilterList: %w", f.context.LastError())
@@ -93,14 +109,14 @@ func (f *FilterList) NFilters() (uint32, error) {
 
 // FilterFromIndex Retrieves a filter object from a filter list by index.
 func (f *FilterList) FilterFromIndex(index uint32) (*Filter, error) {
-	filter := Filter{context: f.context}
-	ret := C.tiledb_filter_list_get_filter_from_index(f.context.tiledbContext.Get(), f.tiledbFilterList, C.uint32_t(index), &filter.tiledbFilter)
+	var filterPtr *C.tiledb_filter_t
+	ret := C.tiledb_filter_list_get_filter_from_index(f.context.tiledbContext.Get(), f.tiledbFilterList.Get(), C.uint32_t(index), &filterPtr)
 	runtime.KeepAlive(f)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error fetching filter for index %d from tiledb FilterList: %w", index, f.context.LastError())
 	}
-	freeOnGC(&filter)
-	return &filter, nil
+
+	return newFilterFromHandle(f.context, newFilterHandle(filterPtr)), nil
 }
 
 // Filters return slice of filters applied to filter list

--- a/fragment_info.go
+++ b/fragment_info.go
@@ -39,8 +39,8 @@ type FragmentInfo struct {
 	array              *Array
 }
 
-func newFragmentInfoFromHandle(context *Context, handle fragmentInfoHandle) *FragmentInfo {
-	return &FragmentInfo{context: context, tiledbFragmentInfo: handle}
+func newFragmentInfoFromHandle(context *Context, uri string, handle fragmentInfoHandle) *FragmentInfo {
+	return &FragmentInfo{context: context, uri: uri, tiledbFragmentInfo: handle}
 }
 
 // NewFragmentInfo allocates a new fragment info for a given array and fetches all
@@ -56,7 +56,7 @@ func NewFragmentInfo(tdbCtx *Context, uri string) (*FragmentInfo, error) {
 		return nil, fmt.Errorf("error creating tiledb fragment info: %w", tdbCtx.LastError())
 	}
 
-	return newFragmentInfoFromHandle(tdbCtx, newfragmentInfoHandle(fragmentInfoPtr)), nil
+	return newFragmentInfoFromHandle(tdbCtx, uri, newfragmentInfoHandle(fragmentInfoPtr)), nil
 }
 
 // Free releases the internal TileDB core data that was allocated on the C heap.

--- a/fragment_info.go
+++ b/fragment_info.go
@@ -32,7 +32,7 @@ func NewFragmentInfo(tdbCtx *Context, uri string) (*FragmentInfo, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	fI := FragmentInfo{context: tdbCtx, uri: uri}
-	ret := C.tiledb_fragment_info_alloc(fI.context.tiledbContext,
+	ret := C.tiledb_fragment_info_alloc(fI.context.tiledbContext.Get(),
 		curi, &fI.tiledbFragmentInfo)
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
@@ -61,7 +61,7 @@ func (fI *FragmentInfo) Context() *Context {
 
 // Load loads the fragment info.
 func (fI *FragmentInfo) Load() error {
-	ret := C.tiledb_fragment_info_load(fI.context.tiledbContext, fI.tiledbFragmentInfo)
+	ret := C.tiledb_fragment_info_load(fI.context.tiledbContext.Get(), fI.tiledbFragmentInfo)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error loading tiledb fragment info: %w", fI.context.LastError())
@@ -73,7 +73,7 @@ func (fI *FragmentInfo) Load() error {
 func (fI *FragmentInfo) GetFragmentNum() (uint32, error) {
 	var cNum C.uint32_t
 
-	ret := C.tiledb_fragment_info_get_fragment_num(fI.context.tiledbContext, fI.tiledbFragmentInfo, &cNum)
+	ret := C.tiledb_fragment_info_get_fragment_num(fI.context.tiledbContext.Get(), fI.tiledbFragmentInfo, &cNum)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting number of fragments from fragment info: %w", fI.context.LastError())
@@ -86,7 +86,7 @@ func (fI *FragmentInfo) GetFragmentNum() (uint32, error) {
 // fid is the index of the fragment of interest.
 func (fI *FragmentInfo) GetFragmentURI(fid uint32) (string, error) {
 	var curi *C.char // fI must be kept alive while curi is being accessed.
-	C.tiledb_fragment_info_get_fragment_uri(fI.context.tiledbContext,
+	C.tiledb_fragment_info_get_fragment_uri(fI.context.tiledbContext.Get(),
 		fI.tiledbFragmentInfo, C.uint32_t(fid), &curi)
 	uri := C.GoString(curi)
 	runtime.KeepAlive(fI)
@@ -100,7 +100,7 @@ func (fI *FragmentInfo) GetFragmentURI(fid uint32) (string, error) {
 func (fI *FragmentInfo) GetFragmentSize(fid uint32) (uint64, error) {
 	var cSize C.uint64_t
 
-	ret := C.tiledb_fragment_info_get_fragment_size(fI.context.tiledbContext,
+	ret := C.tiledb_fragment_info_get_fragment_size(fI.context.tiledbContext.Get(),
 		fI.tiledbFragmentInfo, C.uint32_t(fid), &cSize)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
@@ -114,7 +114,7 @@ func (fI *FragmentInfo) GetFragmentSize(fid uint32) (uint64, error) {
 func (fI *FragmentInfo) GetDense(fid uint32) (bool, error) {
 	var cDense C.int32_t
 
-	ret := C.tiledb_fragment_info_get_dense(fI.context.tiledbContext,
+	ret := C.tiledb_fragment_info_get_dense(fI.context.tiledbContext.Get(),
 		fI.tiledbFragmentInfo, C.uint32_t(fid), &cDense)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
@@ -128,7 +128,7 @@ func (fI *FragmentInfo) GetDense(fid uint32) (bool, error) {
 func (fI *FragmentInfo) GetSparse(fid uint32) (bool, error) {
 	var cSparse C.int32_t
 
-	ret := C.tiledb_fragment_info_get_sparse(fI.context.tiledbContext,
+	ret := C.tiledb_fragment_info_get_sparse(fI.context.tiledbContext.Get(),
 		fI.tiledbFragmentInfo, C.uint32_t(fid), &cSparse)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
@@ -143,7 +143,7 @@ func (fI *FragmentInfo) GetTimestampRange(fid uint32) (uint64, uint64, error) {
 	var cStart C.uint64_t
 	var cEnd C.uint64_t
 
-	ret := C.tiledb_fragment_info_get_timestamp_range(fI.context.tiledbContext,
+	ret := C.tiledb_fragment_info_get_timestamp_range(fI.context.tiledbContext.Get(),
 		fI.tiledbFragmentInfo, C.uint32_t(fid), &cStart, &cEnd)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
@@ -230,7 +230,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainFromIndex(fid uint32, did uint32) (*Non
 
 	var isEmpty C.int32_t
 	ret := C.tiledb_fragment_info_get_non_empty_domain_from_index(
-		fI.context.tiledbContext,
+		fI.context.tiledbContext.Get(),
 		fI.tiledbFragmentInfo,
 		(C.uint32_t)(fid),
 		(C.uint32_t)(did),
@@ -265,7 +265,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainFromName(fid uint32, did string) (*NonE
 	defer C.free(unsafe.Pointer(cDid))
 
 	ret := C.tiledb_fragment_info_get_non_empty_domain_from_name(
-		fI.context.tiledbContext,
+		fI.context.tiledbContext.Get(),
 		fI.tiledbFragmentInfo,
 		(C.uint32_t)(fid),
 		cDid,
@@ -292,7 +292,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainVarSizeFromIndex(fid uint32, did uint32
 	var cStart C.uint64_t
 	var cEnd C.uint64_t
 
-	ret := C.tiledb_fragment_info_get_non_empty_domain_var_size_from_index(fI.context.tiledbContext,
+	ret := C.tiledb_fragment_info_get_non_empty_domain_var_size_from_index(fI.context.tiledbContext.Get(),
 		fI.tiledbFragmentInfo, C.uint32_t(fid), C.uint32_t(did), &cStart, &cEnd)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
@@ -311,7 +311,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainVarSizeFromName(fid uint32, did string)
 	cDid := C.CString(did)
 	defer C.free(unsafe.Pointer(cDid))
 
-	ret := C.tiledb_fragment_info_get_non_empty_domain_var_size_from_name(fI.context.tiledbContext,
+	ret := C.tiledb_fragment_info_get_non_empty_domain_var_size_from_name(fI.context.tiledbContext.Get(),
 		fI.tiledbFragmentInfo, C.uint32_t(fid), cDid, &cStart, &cEnd)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
@@ -327,7 +327,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainVarFromIndex(fid uint32, did uint32) (*
 	var cStartSize C.uint64_t
 	var cEndSize C.uint64_t
 
-	ret := C.tiledb_fragment_info_get_non_empty_domain_var_size_from_index(fI.context.tiledbContext,
+	ret := C.tiledb_fragment_info_get_non_empty_domain_var_size_from_index(fI.context.tiledbContext.Get(),
 		fI.tiledbFragmentInfo, C.uint32_t(fid), C.uint32_t(did), &cStartSize, &cEndSize)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error retrieving the non-empty domain range sizes from fragment %d for a given dimension index %d: %w", fid, did, fI.context.LastError())
@@ -378,7 +378,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainVarFromIndex(fid uint32, did uint32) (*
 	bounds = append(bounds, end)
 
 	ret = C.tiledb_fragment_info_get_non_empty_domain_var_from_index(
-		fI.context.tiledbContext,
+		fI.context.tiledbContext.Get(),
 		fI.tiledbFragmentInfo,
 		(C.uint32_t)(fid),
 		(C.uint32_t)(did),
@@ -413,7 +413,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainVarFromName(fid uint32, did string) (*N
 	cDid := C.CString(did)
 	defer C.free(unsafe.Pointer(cDid))
 
-	ret := C.tiledb_fragment_info_get_non_empty_domain_var_size_from_name(fI.context.tiledbContext,
+	ret := C.tiledb_fragment_info_get_non_empty_domain_var_size_from_name(fI.context.tiledbContext.Get(),
 		fI.tiledbFragmentInfo, C.uint32_t(fid), cDid, &cStartSize, &cEndSize)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error retrieving the non-empty domain range sizes from fragment %d for a given dimension name %s: %w", fid, did, fI.context.LastError())
@@ -464,7 +464,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainVarFromName(fid uint32, did string) (*N
 	bounds = append(bounds, end)
 
 	ret = C.tiledb_fragment_info_get_non_empty_domain_var_from_name(
-		fI.context.tiledbContext,
+		fI.context.tiledbContext.Get(),
 		fI.tiledbFragmentInfo,
 		(C.uint32_t)(fid),
 		cDid,
@@ -501,7 +501,7 @@ func (fI *FragmentInfo) GetNonEmptyDomainVarFromName(fid uint32, did string) (*N
 func (fI *FragmentInfo) GetCellNum(fid uint32) (uint64, error) {
 	var cCellNum C.uint64_t
 
-	ret := C.tiledb_fragment_info_get_cell_num(fI.context.tiledbContext,
+	ret := C.tiledb_fragment_info_get_cell_num(fI.context.tiledbContext.Get(),
 		fI.tiledbFragmentInfo, C.uint32_t(fid), &cCellNum)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
@@ -515,7 +515,7 @@ func (fI *FragmentInfo) GetCellNum(fid uint32) (uint64, error) {
 func (fI *FragmentInfo) GetVersion(fid uint32) (uint32, error) {
 	var cVersion C.uint32_t
 
-	ret := C.tiledb_fragment_info_get_version(fI.context.tiledbContext,
+	ret := C.tiledb_fragment_info_get_version(fI.context.tiledbContext.Get(),
 		fI.tiledbFragmentInfo, C.uint32_t(fid), &cVersion)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
@@ -529,7 +529,7 @@ func (fI *FragmentInfo) GetVersion(fid uint32) (uint32, error) {
 func (fI *FragmentInfo) HasConsolidatedMetadata(fid uint32) (bool, error) {
 	var cHas C.int32_t
 
-	ret := C.tiledb_fragment_info_has_consolidated_metadata(fI.context.tiledbContext,
+	ret := C.tiledb_fragment_info_has_consolidated_metadata(fI.context.tiledbContext.Get(),
 		fI.tiledbFragmentInfo, C.uint32_t(fid), &cHas)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
@@ -544,7 +544,7 @@ func (fI *FragmentInfo) HasConsolidatedMetadata(fid uint32) (bool, error) {
 func (fI *FragmentInfo) GetUnconsolidatedMetadataNum() (uint32, error) {
 	var cNum C.uint32_t
 
-	ret := C.tiledb_fragment_info_get_unconsolidated_metadata_num(fI.context.tiledbContext, fI.tiledbFragmentInfo, &cNum)
+	ret := C.tiledb_fragment_info_get_unconsolidated_metadata_num(fI.context.tiledbContext.Get(), fI.tiledbFragmentInfo, &cNum)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting number of fragments with unconsolidated metadata: %w", fI.context.LastError())
@@ -557,7 +557,7 @@ func (fI *FragmentInfo) GetUnconsolidatedMetadataNum() (uint32, error) {
 func (fI *FragmentInfo) GetToVacuumNum() (uint32, error) {
 	var cNum C.uint32_t
 
-	ret := C.tiledb_fragment_info_get_to_vacuum_num(fI.context.tiledbContext, fI.tiledbFragmentInfo, &cNum)
+	ret := C.tiledb_fragment_info_get_to_vacuum_num(fI.context.tiledbContext.Get(), fI.tiledbFragmentInfo, &cNum)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting number of fragments to vacuum: %w", fI.context.LastError())
@@ -570,7 +570,7 @@ func (fI *FragmentInfo) GetToVacuumNum() (uint32, error) {
 // fid is the index of the fragment of interest.
 func (fI *FragmentInfo) GetToVacuumURI(fid uint32) (string, error) {
 	var curi *C.char
-	ret := C.tiledb_fragment_info_get_to_vacuum_uri(fI.context.tiledbContext, fI.tiledbFragmentInfo, C.uint32_t(fid), &curi)
+	ret := C.tiledb_fragment_info_get_to_vacuum_uri(fI.context.tiledbContext.Get(), fI.tiledbFragmentInfo, C.uint32_t(fid), &curi)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting URI uri for fragment to vacuum: %w", fI.context.LastError())
@@ -584,7 +584,7 @@ func (fI *FragmentInfo) GetToVacuumURI(fid uint32) (string, error) {
 
 // DumpSTDOUT dumps the fragment info in ASCII format in the selected output.
 func (fI *FragmentInfo) DumpSTDOUT() error {
-	ret := C.tiledb_fragment_info_dump(fI.context.tiledbContext, fI.tiledbFragmentInfo, C.stdout)
+	ret := C.tiledb_fragment_info_dump(fI.context.tiledbContext.Get(), fI.tiledbFragmentInfo, C.stdout)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error dumping fragment info to stdout: %w", fI.context.LastError())
@@ -596,7 +596,7 @@ func (fI *FragmentInfo) DumpSTDOUT() error {
 func (fI *FragmentInfo) String() (string, error) {
 	var tdbString *C.tiledb_string_t
 
-	ret := C.tiledb_fragment_info_dump_str(fI.context.tiledbContext, fI.tiledbFragmentInfo, &tdbString)
+	ret := C.tiledb_fragment_info_dump_str(fI.context.tiledbContext.Get(), fI.tiledbFragmentInfo, &tdbString)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error dumping fragment info to string: %w", fI.context.LastError())
@@ -612,7 +612,7 @@ func (fI *FragmentInfo) String() (string, error) {
 
 // SetConfig sets the fragment config.
 func (fI *FragmentInfo) SetConfig(config *Config) error {
-	ret := C.tiledb_fragment_info_set_config(fI.context.tiledbContext, fI.tiledbFragmentInfo, config.tiledbConfig.Get())
+	ret := C.tiledb_fragment_info_set_config(fI.context.tiledbContext.Get(), fI.tiledbFragmentInfo, config.tiledbConfig.Get())
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting config on group: %w", fI.context.LastError())
@@ -624,7 +624,7 @@ func (fI *FragmentInfo) SetConfig(config *Config) error {
 // Config gets the fragment config.
 func (fI *FragmentInfo) Config() (*Config, error) {
 	var configPtr *C.tiledb_config_t
-	ret := C.tiledb_fragment_info_get_config(fI.context.tiledbContext, fI.tiledbFragmentInfo, &configPtr)
+	ret := C.tiledb_fragment_info_get_config(fI.context.tiledbContext.Get(), fI.tiledbFragmentInfo, &configPtr)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting config from fragment info: %w", fI.context.LastError())

--- a/fragment_info.go
+++ b/fragment_info.go
@@ -612,7 +612,7 @@ func (fI *FragmentInfo) String() (string, error) {
 
 // SetConfig sets the fragment config.
 func (fI *FragmentInfo) SetConfig(config *Config) error {
-	ret := C.tiledb_fragment_info_set_config(fI.context.tiledbContext, fI.tiledbFragmentInfo, config.tiledbConfig)
+	ret := C.tiledb_fragment_info_set_config(fI.context.tiledbContext, fI.tiledbFragmentInfo, config.tiledbConfig.Get())
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting config on group: %w", fI.context.LastError())
@@ -623,17 +623,12 @@ func (fI *FragmentInfo) SetConfig(config *Config) error {
 
 // Config gets the fragment config.
 func (fI *FragmentInfo) Config() (*Config, error) {
-	var config Config
-	ret := C.tiledb_fragment_info_get_config(fI.context.tiledbContext, fI.tiledbFragmentInfo, &config.tiledbConfig)
+	var configPtr *C.tiledb_config_t
+	ret := C.tiledb_fragment_info_get_config(fI.context.tiledbContext, fI.tiledbFragmentInfo, &configPtr)
 	runtime.KeepAlive(fI)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting config from fragment info: %w", fI.context.LastError())
 	}
-	freeOnGC(&config)
 
-	if fI.config == nil {
-		fI.config = &config
-	}
-
-	return &config, nil
+	return newConfigFromHandle(newConfigHandle(configPtr)), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,4 @@ require (
 // Local triggered panic when referencing enums
 retract v0.30.1
 
-go 1.22
+go 1.24

--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,4 @@ require (
 // Local triggered panic when referencing enums
 retract v0.30.1
 
-go 1.24
+go 1.22

--- a/group.go
+++ b/group.go
@@ -35,8 +35,8 @@ type Group struct {
 	context *Context
 }
 
-func newGroupFromHandle(context *Context, group groupHandle) *Group {
-	return &Group{group: group, context: context}
+func newGroupFromHandle(context *Context, uri string, group groupHandle) *Group {
+	return &Group{group: group, uri: uri, context: context}
 }
 
 // NewGroup allocates an embedded group.
@@ -50,7 +50,7 @@ func NewGroup(tdbCtx *Context, uri string) (*Group, error) {
 		return nil, fmt.Errorf("error creating tiledb group: %w", tdbCtx.LastError())
 	}
 
-	return newGroupFromHandle(tdbCtx, newGroupHandle(groupPtr)), nil
+	return newGroupFromHandle(tdbCtx, uri, newGroupHandle(groupPtr)), nil
 }
 
 // Create creates a new TileDB group.

--- a/group.go
+++ b/group.go
@@ -75,7 +75,7 @@ func (g *Group) Close() error {
 }
 
 func (g *Group) SetConfig(config *Config) error {
-	ret := C.tiledb_group_set_config(g.context.tiledbContext, g.group, config.tiledbConfig)
+	ret := C.tiledb_group_set_config(g.context.tiledbContext, g.group, config.tiledbConfig.Get())
 	runtime.KeepAlive(g)
 	runtime.KeepAlive(config)
 	if ret != C.TILEDB_OK {
@@ -86,19 +86,14 @@ func (g *Group) SetConfig(config *Config) error {
 }
 
 func (g *Group) Config() (*Config, error) {
-	var config Config
-	ret := C.tiledb_group_get_config(g.context.tiledbContext, g.group, &config.tiledbConfig)
+	var configPtr *C.tiledb_config_t
+	ret := C.tiledb_group_get_config(g.context.tiledbContext, g.group, &configPtr)
 	runtime.KeepAlive(g)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting config from query: %w", g.context.LastError())
 	}
-	freeOnGC(&config)
 
-	if g.config == nil {
-		g.config = &config
-	}
-
-	return &config, nil
+	return newConfigFromHandle(newConfigHandle(configPtr)), nil
 }
 
 func (g *Group) AddMember(uri, name string, isRelativeURI bool) error {

--- a/memory.go
+++ b/memory.go
@@ -30,6 +30,8 @@ type Freeable interface {
 //	  freeOnGC(&thingy)  // <-- put this here
 //	  return &thingy, nil
 //	}
+//
+// Deprecated: Use capiHandle.
 func freeOnGC(obj Freeable) {
 	runtime.SetFinalizer(obj, freeFreeable)
 }

--- a/memory.go
+++ b/memory.go
@@ -1,12 +1,9 @@
 package tiledb
 
 import (
-	"runtime"
 	"unsafe"
 
 	// Much of this package relies on the fact that the Go GC is non-moving.
-	// When we move to a new Go version, this dependency should be updated
-	// to ensure that the new version is still a non-moving GC.
 	_ "go4.org/unsafe/assume-no-moving-gc"
 )
 
@@ -15,30 +12,6 @@ import (
 type Freeable interface {
 	Free() // Releases non–garbage-collected resources held by this object.
 }
-
-// freeOnGC sets a finalizer on the provided object that will cause it to
-// automatically be Free'd when it is collected by the garbage collecter.
-// It should be included immediately after the err-check of the code which
-// creates it:
-//
-//	func NewThingy() (*Thingy, error) {
-//	  thingy := Thingy{}
-//	  ret := C.tiledb_make_thingy(&thingy)
-//	  if ret != C.TILEDB_OK {
-//	    return nil, errors.New("whatever")
-//	  }
-//	  freeOnGC(&thingy)  // <-- put this here
-//	  return &thingy, nil
-//	}
-//
-// Deprecated: Use capiHandle.
-func freeOnGC(obj Freeable) {
-	runtime.SetFinalizer(obj, freeFreeable)
-}
-
-// freeFreeable frees the Freeable. It's free-floating to avoid capturing
-// anything in a closure.
-func freeFreeable(obj Freeable) { obj.Free() }
 
 // unsafeSlice creates a slice pointing at the given memory.
 func unsafeSlice[T any](ptr unsafe.Pointer, length uint) []T {

--- a/object.go
+++ b/object.go
@@ -25,7 +25,7 @@ func ObjectType(tdbCtx *Context, path string) (ObjectTypeEnum, error) {
 	var objectTypeEnum C.tiledb_object_t
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
-	ret := C.tiledb_object_type(tdbCtx.tiledbContext, cpath, &objectTypeEnum)
+	ret := C.tiledb_object_type(tdbCtx.tiledbContext.Get(), cpath, &objectTypeEnum)
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return TILEDB_INVALID, fmt.Errorf("cannot get object type from path %s: %w",
@@ -79,7 +79,7 @@ func ObjectWalk(tdbCtx *Context, path string, walkOrder WalkOrder) (*ObjectList,
 	data := pointer.Save(&objectList)
 	defer pointer.Unref(data)
 
-	ret := C._tiledb_object_walk(tdbCtx.tiledbContext, cpath,
+	ret := C._tiledb_object_walk(tdbCtx.tiledbContext.Get(), cpath,
 		C.tiledb_walk_order_t(walkOrder), unsafe.Pointer(data))
 	runtime.KeepAlive(tdbCtx)
 
@@ -108,7 +108,7 @@ func ObjectLs(tdbCtx *Context, path string) (*ObjectList, error) {
 	data := pointer.Save(&objectList)
 	defer pointer.Unref(data)
 
-	ret := C._tiledb_object_ls(tdbCtx.tiledbContext, cpath,
+	ret := C._tiledb_object_ls(tdbCtx.tiledbContext.Get(), cpath,
 		unsafe.Pointer(data))
 	runtime.KeepAlive(tdbCtx)
 
@@ -130,7 +130,7 @@ func ObjectMove(tdbCtx *Context, path string, newPath string) error {
 	defer C.free(unsafe.Pointer(cpath))
 	cnewPath := C.CString(newPath)
 	defer C.free(unsafe.Pointer(cnewPath))
-	ret := C.tiledb_object_move(tdbCtx.tiledbContext, cpath, cnewPath)
+	ret := C.tiledb_object_move(tdbCtx.tiledbContext.Get(), cpath, cnewPath)
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("cannot move object from %s to %s: %w", path,
@@ -148,7 +148,7 @@ func ObjectRemove(tdbCtx *Context, path string) error {
 
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
-	ret := C.tiledb_object_remove(tdbCtx.tiledbContext, cpath)
+	ret := C.tiledb_object_remove(tdbCtx.tiledbContext.Get(), cpath)
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("cannot delete object %s: %w", path, tdbCtx.LastError())

--- a/query.go
+++ b/query.go
@@ -67,7 +67,7 @@ func NewQuery(tdbCtx *Context, array *Array) (*Query, error) {
 	}
 
 	query := Query{context: tdbCtx, array: array}
-	ret := C.tiledb_query_alloc(query.context.tiledbContext, array.tiledbArray.Get(), C.tiledb_query_type_t(queryType), &query.tiledbQuery)
+	ret := C.tiledb_query_alloc(query.context.tiledbContext.Get(), array.tiledbArray.Get(), C.tiledb_query_type_t(queryType), &query.tiledbQuery)
 	runtime.KeepAlive(tdbCtx)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb query: %w", query.context.LastError())
@@ -282,7 +282,7 @@ func (q *Query) ResultBufferElements() (map[string][3]uint64, error) {
 
 // SetLayout sets the layout of the cells to be written or read.
 func (q *Query) SetLayout(layout Layout) error {
-	ret := C.tiledb_query_set_layout(q.context.tiledbContext, q.tiledbQuery, C.tiledb_layout_t(layout))
+	ret := C.tiledb_query_set_layout(q.context.tiledbContext.Get(), q.tiledbQuery, C.tiledb_layout_t(layout))
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting query layout: %w", q.context.LastError())
 	}
@@ -292,7 +292,7 @@ func (q *Query) SetLayout(layout Layout) error {
 
 // SetQueryCondition sets a query condition on a read query.
 func (q *Query) SetQueryCondition(cond *QueryCondition) error {
-	if ret := C.tiledb_query_set_condition(q.context.tiledbContext, q.tiledbQuery, cond.cond); ret != C.TILEDB_OK {
+	if ret := C.tiledb_query_set_condition(q.context.tiledbContext.Get(), q.tiledbQuery, cond.cond); ret != C.TILEDB_OK {
 		return fmt.Errorf("error getting config from query: %w", q.context.LastError())
 	}
 	runtime.KeepAlive(q)
@@ -303,7 +303,7 @@ func (q *Query) SetQueryCondition(cond *QueryCondition) error {
 // query. This is applicable only to global layout writes. It has no effect
 // for any other query type.
 func (q *Query) Finalize() error {
-	ret := C.tiledb_query_finalize(q.context.tiledbContext, q.tiledbQuery)
+	ret := C.tiledb_query_finalize(q.context.tiledbContext.Get(), q.tiledbQuery)
 	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error finalizing query: %w", q.context.LastError())
@@ -330,7 +330,7 @@ to proceed. In this case, the users must reallocate their buffers
 and resubmit the query.
 */
 func (q *Query) Submit() error {
-	ret := C.tiledb_query_submit(q.context.tiledbContext, q.tiledbQuery)
+	ret := C.tiledb_query_submit(q.context.tiledbContext.Get(), q.tiledbQuery)
 	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error submitting query: %w", q.context.LastError())
@@ -342,7 +342,7 @@ func (q *Query) Submit() error {
 // Status returns the status of a query.
 func (q *Query) Status() (QueryStatus, error) {
 	var status C.tiledb_query_status_t
-	ret := C.tiledb_query_get_status(q.context.tiledbContext, q.tiledbQuery, &status)
+	ret := C.tiledb_query_get_status(q.context.tiledbContext.Get(), q.tiledbQuery, &status)
 	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return -1, fmt.Errorf("error getting query status: %w", q.context.LastError())
@@ -353,7 +353,7 @@ func (q *Query) Status() (QueryStatus, error) {
 // Type returns the query type.
 func (q *Query) Type() (QueryType, error) {
 	var queryType C.tiledb_query_type_t
-	ret := C.tiledb_query_get_type(q.context.tiledbContext, q.tiledbQuery, &queryType)
+	ret := C.tiledb_query_get_type(q.context.tiledbContext.Get(), q.tiledbQuery, &queryType)
 	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return -1, fmt.Errorf("error getting query type: %w", q.context.LastError())
@@ -365,7 +365,7 @@ func (q *Query) Type() (QueryType, error) {
 // Applicable only to read queries (it returns false for write queries).
 func (q *Query) HasResults() (bool, error) {
 	var hasResults C.int32_t
-	ret := C.tiledb_query_has_results(q.context.tiledbContext, q.tiledbQuery, &hasResults)
+	ret := C.tiledb_query_has_results(q.context.tiledbContext.Get(), q.tiledbQuery, &hasResults)
 	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return false, fmt.Errorf("error checking if query has results: %w", q.context.LastError())
@@ -381,7 +381,7 @@ func (q *Query) EstResultSize(attributeName string) (*uint64, error) {
 	var size uint64
 
 	ret := C.tiledb_query_get_est_result_size(
-		q.context.tiledbContext,
+		q.context.tiledbContext.Get(),
 		q.tiledbQuery,
 		cAttributeName,
 		(*C.uint64_t)(unsafe.Pointer(&size)))
@@ -401,7 +401,7 @@ func (q *Query) EstResultSizeVar(attributeName string) (*uint64, *uint64, error)
 	var sizeOff, sizeVal uint64
 
 	ret := C.tiledb_query_get_est_result_size_var(
-		q.context.tiledbContext,
+		q.context.tiledbContext.Get(),
 		q.tiledbQuery,
 		cAttributeName,
 		(*C.uint64_t)(unsafe.Pointer(&sizeOff)),
@@ -422,7 +422,7 @@ func (q *Query) EstResultSizeNullable(attributeName string) (*uint64, *uint64, e
 	var size, sizeValidity uint64
 
 	ret := C.tiledb_query_get_est_result_size_nullable(
-		q.context.tiledbContext,
+		q.context.tiledbContext.Get(),
 		q.tiledbQuery,
 		cAttributeName,
 		(*C.uint64_t)(unsafe.Pointer(&size)),
@@ -443,7 +443,7 @@ func (q *Query) EstResultSizeVarNullable(attributeName string) (*uint64, *uint64
 	var sizeOff, sizeVal, sizeValidity uint64
 
 	ret := C.tiledb_query_get_est_result_size_var_nullable(
-		q.context.tiledbContext,
+		q.context.tiledbContext.Get(),
 		q.tiledbQuery,
 		cAttributeName,
 		(*C.uint64_t)(unsafe.Pointer(&sizeOff)),
@@ -630,7 +630,7 @@ func (q *Query) GetFragmentNum() (*uint32, error) {
 	var num uint32
 
 	ret := C.tiledb_query_get_fragment_num(
-		q.context.tiledbContext,
+		q.context.tiledbContext.Get(),
 		q.tiledbQuery,
 		(*C.uint32_t)(unsafe.Pointer(&num)))
 	runtime.KeepAlive(q)
@@ -646,7 +646,7 @@ func (q *Query) GetFragmentURI(num uint64) (*string, error) {
 	var cURI *C.char // q must be kept alive while cURI is being accessed.
 
 	ret := C.tiledb_query_get_fragment_uri(
-		q.context.tiledbContext,
+		q.context.tiledbContext.Get(),
 		q.tiledbQuery,
 		(C.uint64_t)(num),
 		&cURI)
@@ -666,7 +666,7 @@ func (q *Query) GetFragmentTimestampRange(num uint64) (*uint64, *uint64, error) 
 	var t1, t2 uint64
 
 	ret := C.tiledb_query_get_fragment_timestamp_range(
-		q.context.tiledbContext,
+		q.context.tiledbContext.Get(),
 		q.tiledbQuery,
 		(C.uint64_t)(num),
 		(*C.uint64_t)(unsafe.Pointer(&t1)),
@@ -682,7 +682,7 @@ func (q *Query) GetFragmentTimestampRange(num uint64) (*uint64, *uint64, error) 
 // Array returns array used by query.
 func (q *Query) Array() (*Array, error) {
 	var arrayPtr *C.tiledb_array_t
-	ret := C.tiledb_query_get_array(q.context.tiledbContext, q.tiledbQuery, &arrayPtr)
+	ret := C.tiledb_query_get_array(q.context.tiledbContext.Get(), q.tiledbQuery, &arrayPtr)
 	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting array from query: %w", q.context.LastError())
@@ -694,7 +694,7 @@ func (q *Query) Array() (*Array, error) {
 func (q *Query) SetConfig(config *Config) error {
 	q.config = config
 
-	ret := C.tiledb_query_set_config(q.context.tiledbContext, q.tiledbQuery, q.config.tiledbConfig.Get())
+	ret := C.tiledb_query_set_config(q.context.tiledbContext.Get(), q.tiledbQuery, q.config.tiledbConfig.Get())
 	runtime.KeepAlive(q)
 	runtime.KeepAlive(config)
 	if ret != C.TILEDB_OK {
@@ -707,7 +707,7 @@ func (q *Query) SetConfig(config *Config) error {
 // Config gets the config of query.
 func (q *Query) Config() (*Config, error) {
 	var configPtr *C.tiledb_config_t
-	ret := C.tiledb_query_get_config(q.context.tiledbContext, q.tiledbQuery, &configPtr)
+	ret := C.tiledb_query_get_config(q.context.tiledbContext.Get(), q.tiledbQuery, &configPtr)
 	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting config from query: %w", q.context.LastError())
@@ -719,7 +719,7 @@ func (q *Query) Config() (*Config, error) {
 // Stats gets stats for a query as json bytes.
 func (q *Query) Stats() ([]byte, error) {
 	var stats *C.char
-	if ret := C.tiledb_query_get_stats(q.context.tiledbContext, q.tiledbQuery, &stats); ret != C.TILEDB_OK {
+	if ret := C.tiledb_query_get_stats(q.context.tiledbContext.Get(), q.tiledbQuery, &stats); ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting stats from query: %w", q.context.LastError())
 	}
 	runtime.KeepAlive(q)
@@ -761,7 +761,7 @@ func (q *Query) SetDataBufferUnsafe(attribute string, buffer unsafe.Pointer, buf
 	q.pinner.Pin(&bufferSize)
 
 	ret := C.tiledb_query_set_data_buffer(
-		q.context.tiledbContext,
+		q.context.tiledbContext.Get(),
 		q.tiledbQuery,
 		cAttribute,
 		buffer,
@@ -933,7 +933,7 @@ func (q *Query) SetDataBuffer(attributeOrDimension string, buffer interface{}) (
 	defer C.free(unsafe.Pointer(cAttributeOrDimension))
 
 	ret := C.tiledb_query_set_data_buffer(
-		q.context.tiledbContext,
+		q.context.tiledbContext.Get(),
 		q.tiledbQuery,
 		cAttributeOrDimension,
 		cbuffer,
@@ -1044,7 +1044,7 @@ func (q *Query) getDataBufferAndSize(attributeOrDimension string) (interface{}, 
 	var cbuffer unsafe.Pointer
 	var buffer interface{}
 
-	ret = C.tiledb_query_get_data_buffer(q.context.tiledbContext, q.tiledbQuery, cAttributeOrDimension, &cbuffer, &cbufferSize)
+	ret = C.tiledb_query_get_data_buffer(q.context.tiledbContext.Get(), q.tiledbQuery, cAttributeOrDimension, &cbuffer, &cbufferSize)
 	runtime.KeepAlive(q)
 	// cbuffer and cbufferSize are in Go-owned memory and don't need a KeepAlive.
 	if ret != C.TILEDB_OK {
@@ -1156,7 +1156,7 @@ func (q *Query) SetValidityBufferUnsafe(attribute string, buffer unsafe.Pointer,
 	q.pinner.Pin(&bufferSize)
 
 	ret := C.tiledb_query_set_validity_buffer(
-		q.context.tiledbContext,
+		q.context.tiledbContext.Get(),
 		q.tiledbQuery,
 		cAttribute,
 		(*C.uint8_t)(buffer),
@@ -1190,7 +1190,7 @@ func (q *Query) SetValidityBuffer(attributeOrDimension string, buffer []uint8) (
 	q.pinner.Pin(&bufferSize)
 
 	ret := C.tiledb_query_set_validity_buffer(
-		q.context.tiledbContext,
+		q.context.tiledbContext.Get(),
 		q.tiledbQuery,
 		cAttributeOrDimension,
 		(*C.uint8_t)(cbuffer),
@@ -1232,7 +1232,7 @@ func (q *Query) getValidityBufferAndSize(attributeOrDimension string) ([]uint8, 
 	var cvalidityByteMapSize *C.uint64_t
 	var cvalidityByteMap *C.uint8_t
 
-	ret := C.tiledb_query_get_validity_buffer(q.context.tiledbContext, q.tiledbQuery, cattributeNameOrDimension, &cvalidityByteMap, &cvalidityByteMapSize)
+	ret := C.tiledb_query_get_validity_buffer(q.context.tiledbContext.Get(), q.tiledbQuery, cattributeNameOrDimension, &cvalidityByteMap, &cvalidityByteMapSize)
 	runtime.KeepAlive(q)
 	// cvalidityByteMapSize and cvalidityByteMap are in Go-owned memory and do not need a KeepAlive.
 	if ret != C.TILEDB_OK {
@@ -1269,7 +1269,7 @@ func (q *Query) SetOffsetsBufferUnsafe(attribute string, offset unsafe.Pointer, 
 	q.pinner.Pin(&offsetSize)
 
 	ret := C.tiledb_query_set_offsets_buffer(
-		q.context.tiledbContext,
+		q.context.tiledbContext.Get(),
 		q.tiledbQuery,
 		cAttribute,
 		(*C.uint64_t)(offset),
@@ -1303,7 +1303,7 @@ func (q *Query) SetOffsetsBuffer(attributeOrDimension string, offset []uint64) (
 	q.pinner.Pin(&offsetSize)
 
 	ret := C.tiledb_query_set_offsets_buffer(
-		q.context.tiledbContext,
+		q.context.tiledbContext.Get(),
 		q.tiledbQuery,
 		cAttributeOrDimension,
 		(*C.uint64_t)(unsafe.Pointer(&offset[0])),
@@ -1345,7 +1345,7 @@ func (q *Query) getOffsetsBufferAndSize(attributeOrDimension string) ([]uint64, 
 	var coffsetsSize *C.uint64_t
 	var coffsets *C.uint64_t
 
-	ret := C.tiledb_query_get_offsets_buffer(q.context.tiledbContext, q.tiledbQuery, cattributeNameOrDimension, &coffsets, &coffsetsSize)
+	ret := C.tiledb_query_get_offsets_buffer(q.context.tiledbContext.Get(), q.tiledbQuery, cattributeNameOrDimension, &coffsets, &coffsetsSize)
 	runtime.KeepAlive(q)
 	// coffsetsSize and coffsets point to Go-owned memory and do not need a KeepAlive
 	if ret != C.TILEDB_OK {
@@ -1371,7 +1371,7 @@ func (q *Query) getOffsetsBufferAndSize(attributeOrDimension string) ([]uint64, 
 
 // SetSubarray sets the subarray for the query.
 func (q *Query) SetSubarray(sa *Subarray) error {
-	ret := C.tiledb_query_set_subarray_t(q.context.tiledbContext, q.tiledbQuery, sa.subarray)
+	ret := C.tiledb_query_set_subarray_t(q.context.tiledbContext.Get(), q.tiledbQuery, sa.subarray)
 	runtime.KeepAlive(q)
 	runtime.KeepAlive(sa)
 	if ret != C.TILEDB_OK {
@@ -1384,7 +1384,7 @@ func (q *Query) SetSubarray(sa *Subarray) error {
 func (q *Query) GetSubarray() (*Subarray, error) {
 	var sa *C.tiledb_subarray_t
 
-	ret := C.tiledb_query_get_subarray_t(q.context.tiledbContext, q.tiledbQuery, &sa)
+	ret := C.tiledb_query_get_subarray_t(q.context.tiledbContext.Get(), q.tiledbQuery, &sa)
 	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting tiledb query subarray: %w", q.context.LastError())

--- a/query.go
+++ b/query.go
@@ -694,7 +694,7 @@ func (q *Query) Array() (*Array, error) {
 func (q *Query) SetConfig(config *Config) error {
 	q.config = config
 
-	ret := C.tiledb_query_set_config(q.context.tiledbContext, q.tiledbQuery, q.config.tiledbConfig)
+	ret := C.tiledb_query_set_config(q.context.tiledbContext, q.tiledbQuery, q.config.tiledbConfig.Get())
 	runtime.KeepAlive(q)
 	runtime.KeepAlive(config)
 	if ret != C.TILEDB_OK {
@@ -706,19 +706,14 @@ func (q *Query) SetConfig(config *Config) error {
 
 // Config gets the config of query.
 func (q *Query) Config() (*Config, error) {
-	config := Config{}
-	ret := C.tiledb_query_get_config(q.context.tiledbContext, q.tiledbQuery, &config.tiledbConfig)
+	var configPtr *C.tiledb_config_t
+	ret := C.tiledb_query_get_config(q.context.tiledbContext, q.tiledbQuery, &configPtr)
 	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error getting config from query: %w", q.context.LastError())
 	}
-	freeOnGC(&config)
 
-	if q.config == nil {
-		q.config = &config
-	}
-
-	return &config, nil
+	return newConfigFromHandle(newConfigHandle(configPtr)), nil
 }
 
 // Stats gets stats for a query as json bytes.

--- a/query.go
+++ b/query.go
@@ -292,7 +292,7 @@ func (q *Query) SetLayout(layout Layout) error {
 
 // SetQueryCondition sets a query condition on a read query.
 func (q *Query) SetQueryCondition(cond *QueryCondition) error {
-	if ret := C.tiledb_query_set_condition(q.context.tiledbContext.Get(), q.tiledbQuery, cond.cond); ret != C.TILEDB_OK {
+	if ret := C.tiledb_query_set_condition(q.context.tiledbContext.Get(), q.tiledbQuery, cond.cond.Get()); ret != C.TILEDB_OK {
 		return fmt.Errorf("error getting config from query: %w", q.context.LastError())
 	}
 	runtime.KeepAlive(q)
@@ -1371,7 +1371,7 @@ func (q *Query) getOffsetsBufferAndSize(attributeOrDimension string) ([]uint64, 
 
 // SetSubarray sets the subarray for the query.
 func (q *Query) SetSubarray(sa *Subarray) error {
-	ret := C.tiledb_query_set_subarray_t(q.context.tiledbContext.Get(), q.tiledbQuery, sa.subarray)
+	ret := C.tiledb_query_set_subarray_t(q.context.tiledbContext.Get(), q.tiledbQuery, sa.subarray.Get())
 	runtime.KeepAlive(q)
 	runtime.KeepAlive(sa)
 	if ret != C.TILEDB_OK {
@@ -1390,5 +1390,5 @@ func (q *Query) GetSubarray() (*Subarray, error) {
 		return nil, fmt.Errorf("error getting tiledb query subarray: %w", q.context.LastError())
 	}
 
-	return &Subarray{array: q.array, subarray: sa, context: q.context}, nil
+	return newSubarrayFromHandle(q.context, q.array, newSubarrayHandle(sa)), nil
 }

--- a/query_condition.go
+++ b/query_condition.go
@@ -21,7 +21,7 @@ type QueryCondition struct {
 // NewQueryCondition allocates and initializes a new query condition.
 func NewQueryCondition(tdbCtx *Context, attributeName string, op QueryConditionOp, value interface{}) (*QueryCondition, error) {
 	qc := QueryCondition{context: tdbCtx}
-	if ret := C.tiledb_query_condition_alloc(qc.context.tiledbContext, &qc.cond); ret != C.TILEDB_OK {
+	if ret := C.tiledb_query_condition_alloc(qc.context.tiledbContext.Get(), &qc.cond); ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error allocating tiledb query condition: %w", qc.context.LastError())
 	}
 	runtime.KeepAlive(tdbCtx)
@@ -38,7 +38,7 @@ func NewQueryCondition(tdbCtx *Context, attributeName string, op QueryConditionO
 // are unchanged.
 func NewQueryConditionCombination(tdbCtx *Context, left *QueryCondition, op QueryConditionCombinationOp, right *QueryCondition) (*QueryCondition, error) {
 	qc := QueryCondition{context: tdbCtx}
-	if ret := C.tiledb_query_condition_combine(qc.context.tiledbContext, left.cond, right.cond, C.tiledb_query_condition_combination_op_t(op), &qc.cond); ret != C.TILEDB_OK {
+	if ret := C.tiledb_query_condition_combine(qc.context.tiledbContext.Get(), left.cond, right.cond, C.tiledb_query_condition_combination_op_t(op), &qc.cond); ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error allocating tiledb query condition: %w", qc.context.LastError())
 	}
 	runtime.KeepAlive(tdbCtx)
@@ -53,7 +53,7 @@ func NewQueryConditionCombination(tdbCtx *Context, left *QueryCondition, op Quer
 // is unchanged.
 func NewQueryConditionNegated(tdbCtx *Context, qc *QueryCondition) (*QueryCondition, error) {
 	nqc := QueryCondition{context: tdbCtx}
-	if ret := C.tiledb_query_condition_negate(qc.context.tiledbContext, qc.cond, &nqc.cond); ret != C.TILEDB_OK {
+	if ret := C.tiledb_query_condition_negate(qc.context.tiledbContext.Get(), qc.cond, &nqc.cond); ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error allocating tiledb query condition: %w", qc.context.LastError())
 	}
 	freeOnGC(&nqc)
@@ -155,7 +155,7 @@ func qcInitInternal(qc *QueryCondition, attributeName string, valuePtr unsafe.Po
 	cname := C.CString(attributeName)
 	defer C.free(unsafe.Pointer(cname))
 	ret := C.tiledb_query_condition_init(
-		qc.context.tiledbContext,
+		qc.context.tiledbContext.Get(),
 		qc.cond,
 		cname,
 		valuePtr,

--- a/query_condition.go
+++ b/query_condition.go
@@ -12,55 +12,71 @@ import (
 	"unsafe"
 )
 
+type queryConditionHandle struct{ *capiHandle }
+
+func freeCapiQueryCondition(c unsafe.Pointer) {
+	C.tiledb_query_condition_free((**C.tiledb_query_condition_t)(unsafe.Pointer(&c)))
+}
+
+func newQueryConditionHandle(ptr *C.tiledb_query_condition_t) queryConditionHandle {
+	return queryConditionHandle{newCapiHandle(unsafe.Pointer(ptr), freeCapiQueryCondition)}
+}
+
+func (x queryConditionHandle) Get() *C.tiledb_query_condition_t {
+	return (*C.tiledb_query_condition_t)(x.capiHandle.Get())
+}
+
 // QueryCondition defines a condition used for a query.
 type QueryCondition struct {
 	context *Context
-	cond    *C.tiledb_query_condition_t
+	cond    queryConditionHandle
+}
+
+func newQueryConditionFromHandle(tdbCtx *Context, handle queryConditionHandle) *QueryCondition {
+	return &QueryCondition{context: tdbCtx, cond: handle}
 }
 
 // NewQueryCondition allocates and initializes a new query condition.
 func NewQueryCondition(tdbCtx *Context, attributeName string, op QueryConditionOp, value interface{}) (*QueryCondition, error) {
-	qc := QueryCondition{context: tdbCtx}
-	if ret := C.tiledb_query_condition_alloc(qc.context.tiledbContext.Get(), &qc.cond); ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error allocating tiledb query condition: %w", qc.context.LastError())
+	var qcPtr *C.tiledb_query_condition_t
+	if ret := C.tiledb_query_condition_alloc(tdbCtx.tiledbContext.Get(), &qcPtr); ret != C.TILEDB_OK {
+		return nil, fmt.Errorf("error allocating tiledb query condition: %w", tdbCtx.LastError())
 	}
 	runtime.KeepAlive(tdbCtx)
-	freeOnGC(&qc)
 
+	qc := newQueryConditionFromHandle(tdbCtx, newQueryConditionHandle(qcPtr))
 	if err := qc.init(attributeName, value, op); err != nil {
 		return nil, err
 	}
 
-	return &qc, nil
+	return qc, nil
 }
 
 // NewQueryConditionCombination combines two query conditions to create a new query condition. The underlying conditions
 // are unchanged.
 func NewQueryConditionCombination(tdbCtx *Context, left *QueryCondition, op QueryConditionCombinationOp, right *QueryCondition) (*QueryCondition, error) {
-	qc := QueryCondition{context: tdbCtx}
-	if ret := C.tiledb_query_condition_combine(qc.context.tiledbContext.Get(), left.cond, right.cond, C.tiledb_query_condition_combination_op_t(op), &qc.cond); ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error allocating tiledb query condition: %w", qc.context.LastError())
+	var qcPtr *C.tiledb_query_condition_t
+	if ret := C.tiledb_query_condition_combine(tdbCtx.tiledbContext.Get(), left.cond.Get(), right.cond.Get(), C.tiledb_query_condition_combination_op_t(op), &qcPtr); ret != C.TILEDB_OK {
+		return nil, fmt.Errorf("error allocating tiledb query condition: %w", tdbCtx.LastError())
 	}
 	runtime.KeepAlive(tdbCtx)
 	runtime.KeepAlive(left)
 	runtime.KeepAlive(right)
-	freeOnGC(&qc)
 
-	return &qc, nil
+	return newQueryConditionFromHandle(tdbCtx, newQueryConditionHandle(qcPtr)), nil
 }
 
 // NewQueryConditionNegated returns the negation of the query condition. The initial condition
 // is unchanged.
 func NewQueryConditionNegated(tdbCtx *Context, qc *QueryCondition) (*QueryCondition, error) {
-	nqc := QueryCondition{context: tdbCtx}
-	if ret := C.tiledb_query_condition_negate(qc.context.tiledbContext.Get(), qc.cond, &nqc.cond); ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error allocating tiledb query condition: %w", qc.context.LastError())
+	var nqcPtr *C.tiledb_query_condition_t
+	if ret := C.tiledb_query_condition_negate(qc.context.tiledbContext.Get(), qc.cond.Get(), &nqcPtr); ret != C.TILEDB_OK {
+		return nil, fmt.Errorf("error allocating tiledb query condition: %w", tdbCtx.LastError())
 	}
-	freeOnGC(&nqc)
 	runtime.KeepAlive(tdbCtx)
 	runtime.KeepAlive(qc)
 
-	return &nqc, nil
+	return newQueryConditionFromHandle(tdbCtx, newQueryConditionHandle(nqcPtr)), nil
 }
 
 // Free releases the internal TileDB core data that was allocated on the C heap.
@@ -69,9 +85,7 @@ func NewQueryConditionNegated(tdbCtx *Context, qc *QueryCondition) (*QueryCondit
 // can safely be called many times on the same object; if it has already
 // been freed, it will not be freed again.
 func (qc *QueryCondition) Free() {
-	if qc.cond != nil {
-		C.tiledb_query_condition_free(&qc.cond)
-	}
+	qc.cond.Free()
 }
 
 // Context exposes the internal TileDB context used to initialize the query condition
@@ -156,7 +170,7 @@ func qcInitInternal(qc *QueryCondition, attributeName string, valuePtr unsafe.Po
 	defer C.free(unsafe.Pointer(cname))
 	ret := C.tiledb_query_condition_init(
 		qc.context.tiledbContext.Get(),
-		qc.cond,
+		qc.cond.Get(),
 		cname,
 		valuePtr,
 		C.uint64_t(valueSize),

--- a/query_experimental.go
+++ b/query_experimental.go
@@ -19,7 +19,7 @@ type QueryStatusDetails struct {
 
 func (q *Query) RelevantFragmentNum() (uint64, error) {
 	var num C.uint64_t
-	if ret := C.tiledb_query_get_relevant_fragment_num(q.context.tiledbContext, q.tiledbQuery, &num); ret != C.TILEDB_OK {
+	if ret := C.tiledb_query_get_relevant_fragment_num(q.context.tiledbContext.Get(), q.tiledbQuery, &num); ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting relevant fragment num from query: %w", q.context.LastError())
 	}
 	runtime.KeepAlive(q)
@@ -31,7 +31,7 @@ func (q *Query) RelevantFragmentNum() (uint64, error) {
 func (q *Query) StatusDetails() (QueryStatusDetails, error) {
 	var details QueryStatusDetails
 	var cDetails C.tiledb_query_status_details_t
-	if ret := C.tiledb_query_get_status_details(q.context.tiledbContext, q.tiledbQuery, &cDetails); ret != C.TILEDB_OK {
+	if ret := C.tiledb_query_get_status_details(q.context.tiledbContext.Get(), q.tiledbQuery, &cDetails); ret != C.TILEDB_OK {
 		return details, fmt.Errorf("error getting query status details: %w", q.context.LastError())
 	}
 	runtime.KeepAlive(q)
@@ -64,7 +64,7 @@ func (q *Query) StatusDetails() (QueryStatusDetails, error) {
 func (q *Query) GetPlan() (string, error) {
 	var plan *C.tiledb_string_t
 
-	ret := C.tiledb_query_get_plan(q.context.tiledbContext, q.tiledbQuery, &plan)
+	ret := C.tiledb_query_get_plan(q.context.tiledbContext.Get(), q.tiledbQuery, &plan)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting query plan: %w", q.context.LastError())
 	}

--- a/query_experimental.go
+++ b/query_experimental.go
@@ -19,7 +19,7 @@ type QueryStatusDetails struct {
 
 func (q *Query) RelevantFragmentNum() (uint64, error) {
 	var num C.uint64_t
-	if ret := C.tiledb_query_get_relevant_fragment_num(q.context.tiledbContext.Get(), q.tiledbQuery, &num); ret != C.TILEDB_OK {
+	if ret := C.tiledb_query_get_relevant_fragment_num(q.context.tiledbContext.Get(), q.tiledbQuery.Get(), &num); ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error getting relevant fragment num from query: %w", q.context.LastError())
 	}
 	runtime.KeepAlive(q)
@@ -31,7 +31,7 @@ func (q *Query) RelevantFragmentNum() (uint64, error) {
 func (q *Query) StatusDetails() (QueryStatusDetails, error) {
 	var details QueryStatusDetails
 	var cDetails C.tiledb_query_status_details_t
-	if ret := C.tiledb_query_get_status_details(q.context.tiledbContext.Get(), q.tiledbQuery, &cDetails); ret != C.TILEDB_OK {
+	if ret := C.tiledb_query_get_status_details(q.context.tiledbContext.Get(), q.tiledbQuery.Get(), &cDetails); ret != C.TILEDB_OK {
 		return details, fmt.Errorf("error getting query status details: %w", q.context.LastError())
 	}
 	runtime.KeepAlive(q)
@@ -64,7 +64,7 @@ func (q *Query) StatusDetails() (QueryStatusDetails, error) {
 func (q *Query) GetPlan() (string, error) {
 	var plan *C.tiledb_string_t
 
-	ret := C.tiledb_query_get_plan(q.context.tiledbContext.Get(), q.tiledbQuery, &plan)
+	ret := C.tiledb_query_get_plan(q.context.tiledbContext.Get(), q.tiledbQuery.Get(), &plan)
 	if ret != C.TILEDB_OK {
 		return "", fmt.Errorf("error getting query plan: %w", q.context.LastError())
 	}

--- a/query_experimental.go
+++ b/query_experimental.go
@@ -71,12 +71,5 @@ func (q *Query) GetPlan() (string, error) {
 	runtime.KeepAlive(q)
 	defer C.tiledb_string_free(&plan)
 
-	var sPlan *C.char
-	var sPlanSize C.size_t
-	ret = C.tiledb_string_view(plan, &sPlan, &sPlanSize)
-	if ret != C.TILEDB_OK {
-		return "", fmt.Errorf("error extracting query query: %w", q.context.LastError())
-	}
-
-	return C.GoStringN(sPlan, C.int(sPlanSize)), nil
+	return stringHandleToString(plan)
 }

--- a/serialize.go
+++ b/serialize.go
@@ -25,7 +25,7 @@ func SerializeArraySchemaToBuffer(schema *ArraySchema, serializationType Seriali
 	}
 
 	var bufferPtr *C.tiledb_buffer_t
-	ret := C.tiledb_serialize_array_schema(schema.context.tiledbContext, schema.tiledbArraySchema.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
+	ret := C.tiledb_serialize_array_schema(schema.context.tiledbContext.Get(), schema.tiledbArraySchema.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
 	runtime.KeepAlive(schema)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array schema: %w", schema.context.LastError())
@@ -56,7 +56,7 @@ func DeserializeArraySchema(buffer *Buffer, serializationType SerializationType,
 	}
 
 	var arraySchemaPtr *C.tiledb_array_schema_t
-	ret := C.tiledb_deserialize_array_schema(buffer.context.tiledbContext, buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, &arraySchemaPtr)
+	ret := C.tiledb_deserialize_array_schema(buffer.context.tiledbContext.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, &arraySchemaPtr)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error deserializing array schema: %w", buffer.context.LastError())
@@ -76,7 +76,7 @@ func SerializeArraySchemaEvolutionToBuffer(arraySchemaEvolution *ArraySchemaEvol
 
 	var bufferPtr *C.tiledb_buffer_t
 	ret := C.tiledb_serialize_array_schema_evolution(
-		arraySchemaEvolution.context.tiledbContext,
+		arraySchemaEvolution.context.tiledbContext.Get(),
 		arraySchemaEvolution.tiledbArraySchemaEvolution.Get(),
 		C.tiledb_serialization_type_t(serializationType),
 		cClientSide, &bufferPtr)
@@ -112,7 +112,7 @@ func DeserializeArraySchemaEvolution(buffer *Buffer, serializationType Serializa
 
 	var arraySchemaEvolutionPtr *C.tiledb_array_schema_evolution_t
 	ret := C.tiledb_deserialize_array_schema_evolution(
-		buffer.context.tiledbContext, buffer.tiledbBuffer.Get(),
+		buffer.context.tiledbContext.Get(), buffer.tiledbBuffer.Get(),
 		C.tiledb_serialization_type_t(serializationType),
 		cClientSide, &arraySchemaEvolutionPtr)
 	runtime.KeepAlive(buffer)
@@ -145,7 +145,7 @@ func SerializeArrayNonEmptyDomainToBuffer(a *Array, serializationType Serializat
 
 	var isEmpty C.int32_t
 	tmpDomain := make([]uint8, subarraySize)
-	ret := C.tiledb_array_get_non_empty_domain(a.context.tiledbContext, a.tiledbArray.Get(), slicePtr(tmpDomain), &isEmpty)
+	ret := C.tiledb_array_get_non_empty_domain(a.context.tiledbContext.Get(), a.tiledbArray.Get(), slicePtr(tmpDomain), &isEmpty)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array nonempty domain: %w", a.context.LastError())
 	}
@@ -155,7 +155,7 @@ func SerializeArrayNonEmptyDomainToBuffer(a *Array, serializationType Serializat
 
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
 	var bufferPtr *C.tiledb_buffer_t
-	ret = C.tiledb_serialize_array_nonempty_domain(a.context.tiledbContext, a.tiledbArray.Get(), slicePtr(tmpDomain), isEmpty, C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
+	ret = C.tiledb_serialize_array_nonempty_domain(a.context.tiledbContext.Get(), a.tiledbArray.Get(), slicePtr(tmpDomain), isEmpty, C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array nonempty domain: %w", a.context.LastError())
 	}
@@ -202,7 +202,7 @@ func DeserializeArrayNonEmptyDomain(a *Array, buffer *Buffer, serializationType 
 
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
 	var isEmpty C.int32_t
-	ret := C.tiledb_deserialize_array_nonempty_domain(a.context.tiledbContext, a.tiledbArray.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, tmpDomainPtr, &isEmpty)
+	ret := C.tiledb_deserialize_array_nonempty_domain(a.context.tiledbContext.Get(), a.tiledbArray.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, tmpDomainPtr, &isEmpty)
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
@@ -264,7 +264,7 @@ func DeserializeArrayNonEmptyDomain(a *Array, buffer *Buffer, serializationType 
 func SerializeArrayNonEmptyDomainAllDimensionsToBuffer(a *Array, serializationType SerializationType) (*Buffer, error) {
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
 	var bufferPtr *C.tiledb_buffer_t
-	ret := C.tiledb_serialize_array_non_empty_domain_all_dimensions(a.context.tiledbContext, a.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
+	ret := C.tiledb_serialize_array_non_empty_domain_all_dimensions(a.context.tiledbContext.Get(), a.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array nonempty domain: %w", a.context.LastError())
 	}
@@ -288,7 +288,7 @@ func SerializeArrayNonEmptyDomainAllDimensions(a *Array, serializationType Seria
 func DeserializeArrayNonEmptyDomainAllDimensions(a *Array, buffer *Buffer, serializationType SerializationType) error {
 
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
-	ret := C.tiledb_deserialize_array_non_empty_domain_all_dimensions(a.context.tiledbContext, a.tiledbArray.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide)
+	ret := C.tiledb_deserialize_array_non_empty_domain_all_dimensions(a.context.tiledbContext.Get(), a.tiledbArray.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide)
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
@@ -308,7 +308,7 @@ func SerializeQuery(query *Query, serializationType SerializationType, clientSid
 	}
 
 	var bufferListPtr *C.tiledb_buffer_list_t
-	ret := C.tiledb_serialize_query(query.context.tiledbContext, query.tiledbQuery, C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferListPtr)
+	ret := C.tiledb_serialize_query(query.context.tiledbContext.Get(), query.tiledbQuery, C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferListPtr)
 	runtime.KeepAlive(query)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing query: %w", query.context.LastError())
@@ -326,7 +326,7 @@ func DeserializeQuery(query *Query, buffer *Buffer, serializationType Serializat
 		cClientSide = 0
 	}
 
-	ret := C.tiledb_deserialize_query(query.context.tiledbContext, buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, query.tiledbQuery)
+	ret := C.tiledb_deserialize_query(query.context.tiledbContext.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, query.tiledbQuery)
 	runtime.KeepAlive(query)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
@@ -339,7 +339,7 @@ func DeserializeQuery(query *Query, buffer *Buffer, serializationType Serializat
 // SerializeArrayMetadataToBuffer gets and serializes the array metadata and returns a Buffer object containing the payload.
 func SerializeArrayMetadataToBuffer(a *Array, serializationType SerializationType) (*Buffer, error) {
 	var bufferPtr *C.tiledb_buffer_t
-	ret := C.tiledb_serialize_array_metadata(a.context.tiledbContext, a.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType), &bufferPtr)
+	ret := C.tiledb_serialize_array_metadata(a.context.tiledbContext.Get(), a.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType), &bufferPtr)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array metadata: %w", a.context.LastError())
@@ -362,7 +362,7 @@ func SerializeArrayMetadata(a *Array, serializationType SerializationType) ([]by
 
 // DeserializeArrayMetadata deserializes array metadata.
 func DeserializeArrayMetadata(a *Array, buffer *Buffer, serializationType SerializationType) error {
-	ret := C.tiledb_deserialize_array_metadata(a.context.tiledbContext, a.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer.Get())
+	ret := C.tiledb_deserialize_array_metadata(a.context.tiledbContext.Get(), a.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer.Get())
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
@@ -381,7 +381,7 @@ func SerializeQueryEstResultSizesToBuffer(q *Query, serializationType Serializat
 	}
 
 	var bufferPtr *C.tiledb_buffer_t
-	ret := C.tiledb_serialize_query_est_result_sizes(q.context.tiledbContext, q.tiledbQuery, C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
+	ret := C.tiledb_serialize_query_est_result_sizes(q.context.tiledbContext.Get(), q.tiledbQuery, C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
 	runtime.KeepAlive(q)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing query est buffer sizes: %w", q.context.LastError())
@@ -411,7 +411,7 @@ func DeserializeQueryEstResultSizes(q *Query, buffer *Buffer, serializationType 
 		cClientSide = 0
 	}
 
-	ret := C.tiledb_deserialize_query_est_result_sizes(q.context.tiledbContext, q.tiledbQuery, C.tiledb_serialization_type_t(serializationType), cClientSide, buffer.tiledbBuffer.Get())
+	ret := C.tiledb_deserialize_query_est_result_sizes(q.context.tiledbContext.Get(), q.tiledbQuery, C.tiledb_serialization_type_t(serializationType), cClientSide, buffer.tiledbBuffer.Get())
 	runtime.KeepAlive(q)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
@@ -430,7 +430,7 @@ func SerializeArrayToBuffer(array *Array, serializationType SerializationType, c
 	}
 
 	var bufferPtr *C.tiledb_buffer_t
-	ret := C.tiledb_serialize_array(array.context.tiledbContext, array.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
+	ret := C.tiledb_serialize_array(array.context.tiledbContext.Get(), array.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
 	runtime.KeepAlive(array)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array: %w", array.context.LastError())
@@ -464,7 +464,7 @@ func DeserializeArray(buffer *Buffer, serializationType SerializationType, clien
 	defer C.free(unsafe.Pointer(cArrayURI))
 
 	var arrayPtr *C.tiledb_array_t
-	ret := C.tiledb_deserialize_array(buffer.context.tiledbContext, buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, cArrayURI, &arrayPtr)
+	ret := C.tiledb_deserialize_array(buffer.context.tiledbContext.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, cArrayURI, &arrayPtr)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error deserializing array: %w", buffer.context.LastError())
@@ -483,7 +483,7 @@ func SerializeFragmentInfoToBuffer(fragmentInfo *FragmentInfo, serializationType
 	}
 
 	var bufferPtr *C.tiledb_buffer_t
-	ret := C.tiledb_serialize_fragment_info(fragmentInfo.context.tiledbContext, fragmentInfo.tiledbFragmentInfo, C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
+	ret := C.tiledb_serialize_fragment_info(fragmentInfo.context.tiledbContext.Get(), fragmentInfo.tiledbFragmentInfo, C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
 	runtime.KeepAlive(fragmentInfo)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array: %w", fragmentInfo.context.LastError())
@@ -516,7 +516,7 @@ func DeserializeFragmentInfo(fragmentInfo FragmentInfo, buffer *Buffer, arrayURI
 	cArrayURI := C.CString(arrayURI)
 	defer C.free(unsafe.Pointer(cArrayURI))
 
-	ret := C.tiledb_deserialize_fragment_info(fragmentInfo.context.tiledbContext, buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cArrayURI, cClientSide, fragmentInfo.tiledbFragmentInfo)
+	ret := C.tiledb_deserialize_fragment_info(fragmentInfo.context.tiledbContext.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cArrayURI, cClientSide, fragmentInfo.tiledbFragmentInfo)
 	runtime.KeepAlive(fragmentInfo)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
@@ -536,7 +536,7 @@ func SerializeFragmentInfoRequestToBuffer(fragmentInfo *FragmentInfo, serializat
 	}
 
 	var bufferPtr *C.tiledb_buffer_t
-	ret := C.tiledb_serialize_fragment_info_request(fragmentInfo.context.tiledbContext, fragmentInfo.tiledbFragmentInfo, C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
+	ret := C.tiledb_serialize_fragment_info_request(fragmentInfo.context.tiledbContext.Get(), fragmentInfo.tiledbFragmentInfo, C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
 	runtime.KeepAlive(fragmentInfo)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array: %w", fragmentInfo.context.LastError())
@@ -566,7 +566,7 @@ func DeserializeFragmentInfoRequest(fragmentInfo FragmentInfo, buffer *Buffer, s
 		cClientSide = 0
 	}
 
-	ret := C.tiledb_deserialize_fragment_info_request(fragmentInfo.context.tiledbContext, buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, fragmentInfo.tiledbFragmentInfo)
+	ret := C.tiledb_deserialize_fragment_info_request(fragmentInfo.context.tiledbContext.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, fragmentInfo.tiledbFragmentInfo)
 	runtime.KeepAlive(fragmentInfo)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
@@ -592,7 +592,7 @@ func DeserializeQueryAndArray(context *Context, buffer *Buffer, serializationTyp
 	}
 
 	var arrayPtr *C.tiledb_array_t
-	ret := C.tiledb_deserialize_query_and_array(context.tiledbContext, buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, cArrayURI, &query.tiledbQuery, &arrayPtr)
+	ret := C.tiledb_deserialize_query_and_array(context.tiledbContext.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, cArrayURI, &query.tiledbQuery, &arrayPtr)
 	if ret != C.TILEDB_OK {
 		return nil, nil, fmt.Errorf("error deserializing query: %w", context.LastError())
 	}
@@ -611,7 +611,7 @@ func DeserializeQueryAndArray(context *Context, buffer *Buffer, serializationTyp
 // SerializeGroupMetadata gets and serializes the group metadata and returns a Buffer object containing the payload
 func SerializeGroupMetadataToBuffer(g *Group, serializationType SerializationType) (*Buffer, error) {
 	var bufferPtr *C.tiledb_buffer_t
-	ret := C.tiledb_serialize_group_metadata(g.context.tiledbContext, g.group, C.tiledb_serialization_type_t(serializationType), &bufferPtr)
+	ret := C.tiledb_serialize_group_metadata(g.context.tiledbContext.Get(), g.group, C.tiledb_serialization_type_t(serializationType), &bufferPtr)
 	runtime.KeepAlive(g)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing group metadata: %w", g.context.LastError())
@@ -643,7 +643,7 @@ func DeserializeGroupMetadata(g *Group, buffer *Buffer, serializationType Serial
 		return errors.New("failed to add null terminator to buffer")
 	}
 
-	ret := C.tiledb_deserialize_group_metadata(g.context.tiledbContext, g.group, C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer.Get())
+	ret := C.tiledb_deserialize_group_metadata(g.context.tiledbContext.Get(), g.group, C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer.Get())
 	runtime.KeepAlive(g)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
@@ -672,7 +672,7 @@ func (g *Group) Deserialize(buffer *Buffer, serializationType SerializationType,
 		return errors.New("failed to add null terminator to buffer")
 	}
 
-	ret := C.tiledb_deserialize_group(g.context.tiledbContext, buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, g.group)
+	ret := C.tiledb_deserialize_group(g.context.tiledbContext.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, g.group)
 	runtime.KeepAlive(g)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
@@ -691,7 +691,7 @@ func HandleLoadArraySchemaRequest(array *Array, request *Buffer, serializationTy
 		return nil, fmt.Errorf("error creating LoadArraySchemaResponse buffer: %w", array.context.LastError())
 	}
 
-	ret := C.tiledb_handle_load_array_schema_request(array.context.tiledbContext, array.tiledbArray.Get(),
+	ret := C.tiledb_handle_load_array_schema_request(array.context.tiledbContext.Get(), array.tiledbArray.Get(),
 		C.tiledb_serialization_type_t(serializationType), request.tiledbBuffer.Get(), response.tiledbBuffer.Get())
 	runtime.KeepAlive(array)
 	runtime.KeepAlive(request)
@@ -704,7 +704,7 @@ func HandleLoadArraySchemaRequest(array *Array, request *Buffer, serializationTy
 
 // HandleArrayDeleteFragmentsTimestampsRequest is used by TileDB cloud to handle DeleteFragments with tiledb:// uris.
 func HandleArrayDeleteFragmentsTimestampsRequest(context *Context, array *Array, buffer *Buffer, serializationType SerializationType) error {
-	ret := C.tiledb_handle_array_delete_fragments_timestamps_request(context.tiledbContext, array.tiledbArray.Get(),
+	ret := C.tiledb_handle_array_delete_fragments_timestamps_request(context.tiledbContext.Get(), array.tiledbArray.Get(),
 		C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer.Get())
 	runtime.KeepAlive(array)
 	runtime.KeepAlive(buffer)
@@ -717,7 +717,7 @@ func HandleArrayDeleteFragmentsTimestampsRequest(context *Context, array *Array,
 
 // HandleArrayDeleteFragmentsListRequest is used by TileDB cloud to handle DeleteFragmentsList with tiledb:// uris.
 func HandleArrayDeleteFragmentsListRequest(context *Context, array *Array, buffer *Buffer, serializationType SerializationType) error {
-	ret := C.tiledb_handle_array_delete_fragments_list_request(context.tiledbContext, array.tiledbArray.Get(),
+	ret := C.tiledb_handle_array_delete_fragments_list_request(context.tiledbContext.Get(), array.tiledbArray.Get(),
 		C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer.Get())
 	runtime.KeepAlive(array)
 	runtime.KeepAlive(buffer)
@@ -738,7 +738,7 @@ func HandleQueryPlanRequest(array *Array, serializationType SerializationType, r
 		return nil, fmt.Errorf("error allocating tiledb buffer: %w", opContext.LastError())
 	}
 
-	ret := C.tiledb_handle_query_plan_request(opContext.tiledbContext, array.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType),
+	ret := C.tiledb_handle_query_plan_request(opContext.tiledbContext.Get(), array.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType),
 		request.tiledbBuffer.Get(), response.tiledbBuffer.Get())
 	runtime.KeepAlive(array)
 	runtime.KeepAlive(request)
@@ -759,7 +759,7 @@ func HandleConsolidationPlanRequest(array *Array, serializationType Serializatio
 		return nil, fmt.Errorf("error allocating tiledb buffer: %w", opContext.LastError())
 	}
 
-	ret := C.tiledb_handle_consolidation_plan_request(opContext.tiledbContext, array.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType),
+	ret := C.tiledb_handle_consolidation_plan_request(opContext.tiledbContext.Get(), array.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType),
 		request.tiledbBuffer.Get(), response.tiledbBuffer.Get())
 	runtime.KeepAlive(array)
 	runtime.KeepAlive(request)
@@ -777,7 +777,7 @@ func DeserializeLoadEnumerationsRequest(array *Array, serializationType Serializ
 		return nil, fmt.Errorf("error deserializing load enumerations request: %w", array.context.LastError())
 	}
 
-	ret := C.tiledb_handle_load_enumerations_request(array.context.tiledbContext, array.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType),
+	ret := C.tiledb_handle_load_enumerations_request(array.context.tiledbContext.Get(), array.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType),
 		request.tiledbBuffer.Get(), response.tiledbBuffer.Get())
 	runtime.KeepAlive(array)
 	runtime.KeepAlive(request)

--- a/serialize.go
+++ b/serialize.go
@@ -598,7 +598,7 @@ func DeserializeQueryAndArray(context *Context, buffer *Buffer, serializationTyp
 	return array, query, nil
 }
 
-// SerializeGroupMetadata gets and serializes the group metadata and returns a Buffer object containing the payload
+// SerializeGroupMetadataToBuffer gets and serializes the group metadata and returns a Buffer object containing the payload
 func SerializeGroupMetadataToBuffer(g *Group, serializationType SerializationType) (*Buffer, error) {
 	var bufferPtr *C.tiledb_buffer_t
 	ret := C.tiledb_serialize_group_metadata(g.context.tiledbContext.Get(), g.group.Get(), C.tiledb_serialization_type_t(serializationType), &bufferPtr)

--- a/serialize.go
+++ b/serialize.go
@@ -480,7 +480,7 @@ func SerializeFragmentInfoToBuffer(fragmentInfo *FragmentInfo, serializationType
 	}
 
 	var bufferPtr *C.tiledb_buffer_t
-	ret := C.tiledb_serialize_fragment_info(fragmentInfo.context.tiledbContext.Get(), fragmentInfo.tiledbFragmentInfo, C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
+	ret := C.tiledb_serialize_fragment_info(fragmentInfo.context.tiledbContext.Get(), fragmentInfo.tiledbFragmentInfo.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
 	runtime.KeepAlive(fragmentInfo)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array: %w", fragmentInfo.context.LastError())
@@ -513,7 +513,7 @@ func DeserializeFragmentInfo(fragmentInfo FragmentInfo, buffer *Buffer, arrayURI
 	cArrayURI := C.CString(arrayURI)
 	defer C.free(unsafe.Pointer(cArrayURI))
 
-	ret := C.tiledb_deserialize_fragment_info(fragmentInfo.context.tiledbContext.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cArrayURI, cClientSide, fragmentInfo.tiledbFragmentInfo)
+	ret := C.tiledb_deserialize_fragment_info(fragmentInfo.context.tiledbContext.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cArrayURI, cClientSide, fragmentInfo.tiledbFragmentInfo.Get())
 	runtime.KeepAlive(fragmentInfo)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
@@ -533,7 +533,7 @@ func SerializeFragmentInfoRequestToBuffer(fragmentInfo *FragmentInfo, serializat
 	}
 
 	var bufferPtr *C.tiledb_buffer_t
-	ret := C.tiledb_serialize_fragment_info_request(fragmentInfo.context.tiledbContext.Get(), fragmentInfo.tiledbFragmentInfo, C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
+	ret := C.tiledb_serialize_fragment_info_request(fragmentInfo.context.tiledbContext.Get(), fragmentInfo.tiledbFragmentInfo.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
 	runtime.KeepAlive(fragmentInfo)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array: %w", fragmentInfo.context.LastError())
@@ -563,7 +563,7 @@ func DeserializeFragmentInfoRequest(fragmentInfo FragmentInfo, buffer *Buffer, s
 		cClientSide = 0
 	}
 
-	ret := C.tiledb_deserialize_fragment_info_request(fragmentInfo.context.tiledbContext.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, fragmentInfo.tiledbFragmentInfo)
+	ret := C.tiledb_deserialize_fragment_info_request(fragmentInfo.context.tiledbContext.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, fragmentInfo.tiledbFragmentInfo.Get())
 	runtime.KeepAlive(fragmentInfo)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
@@ -608,7 +608,7 @@ func DeserializeQueryAndArray(context *Context, buffer *Buffer, serializationTyp
 // SerializeGroupMetadata gets and serializes the group metadata and returns a Buffer object containing the payload
 func SerializeGroupMetadataToBuffer(g *Group, serializationType SerializationType) (*Buffer, error) {
 	var bufferPtr *C.tiledb_buffer_t
-	ret := C.tiledb_serialize_group_metadata(g.context.tiledbContext.Get(), g.group, C.tiledb_serialization_type_t(serializationType), &bufferPtr)
+	ret := C.tiledb_serialize_group_metadata(g.context.tiledbContext.Get(), g.group.Get(), C.tiledb_serialization_type_t(serializationType), &bufferPtr)
 	runtime.KeepAlive(g)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing group metadata: %w", g.context.LastError())
@@ -640,7 +640,7 @@ func DeserializeGroupMetadata(g *Group, buffer *Buffer, serializationType Serial
 		return errors.New("failed to add null terminator to buffer")
 	}
 
-	ret := C.tiledb_deserialize_group_metadata(g.context.tiledbContext.Get(), g.group, C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer.Get())
+	ret := C.tiledb_deserialize_group_metadata(g.context.tiledbContext.Get(), g.group.Get(), C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer.Get())
 	runtime.KeepAlive(g)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
@@ -669,7 +669,7 @@ func (g *Group) Deserialize(buffer *Buffer, serializationType SerializationType,
 		return errors.New("failed to add null terminator to buffer")
 	}
 
-	ret := C.tiledb_deserialize_group(g.context.tiledbContext.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, g.group)
+	ret := C.tiledb_deserialize_group(g.context.tiledbContext.Get(), buffer.tiledbBuffer.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, g.group.Get())
 	runtime.KeepAlive(g)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {

--- a/serialize.go
+++ b/serialize.go
@@ -161,7 +161,7 @@ func SerializeArrayNonEmptyDomainToBuffer(a *Array, serializationType Serializat
 
 	var isEmpty C.int32_t
 	tmpDomain := make([]uint8, subarraySize)
-	ret := C.tiledb_array_get_non_empty_domain(a.context.tiledbContext, a.tiledbArray, slicePtr(tmpDomain), &isEmpty)
+	ret := C.tiledb_array_get_non_empty_domain(a.context.tiledbContext, a.tiledbArray.Get(), slicePtr(tmpDomain), &isEmpty)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array nonempty domain: %w", a.context.LastError())
 	}
@@ -170,7 +170,7 @@ func SerializeArrayNonEmptyDomainToBuffer(a *Array, serializationType Serializat
 	freeOnGC(&buffer)
 
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
-	ret = C.tiledb_serialize_array_nonempty_domain(a.context.tiledbContext, a.tiledbArray, slicePtr(tmpDomain), isEmpty, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
+	ret = C.tiledb_serialize_array_nonempty_domain(a.context.tiledbContext, a.tiledbArray.Get(), slicePtr(tmpDomain), isEmpty, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array nonempty domain: %w", a.context.LastError())
 	}
@@ -217,7 +217,7 @@ func DeserializeArrayNonEmptyDomain(a *Array, buffer *Buffer, serializationType 
 
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
 	var isEmpty C.int32_t
-	ret := C.tiledb_deserialize_array_nonempty_domain(a.context.tiledbContext, a.tiledbArray, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, tmpDomainPtr, &isEmpty)
+	ret := C.tiledb_deserialize_array_nonempty_domain(a.context.tiledbContext, a.tiledbArray.Get(), buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, tmpDomainPtr, &isEmpty)
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
@@ -282,7 +282,7 @@ func SerializeArrayNonEmptyDomainAllDimensionsToBuffer(a *Array, serializationTy
 	freeOnGC(&buffer)
 
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
-	ret := C.tiledb_serialize_array_non_empty_domain_all_dimensions(a.context.tiledbContext, a.tiledbArray, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
+	ret := C.tiledb_serialize_array_non_empty_domain_all_dimensions(a.context.tiledbContext, a.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array nonempty domain: %w", a.context.LastError())
 	}
@@ -306,7 +306,7 @@ func SerializeArrayNonEmptyDomainAllDimensions(a *Array, serializationType Seria
 func DeserializeArrayNonEmptyDomainAllDimensions(a *Array, buffer *Buffer, serializationType SerializationType) error {
 
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
-	ret := C.tiledb_deserialize_array_non_empty_domain_all_dimensions(a.context.tiledbContext, a.tiledbArray, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide)
+	ret := C.tiledb_deserialize_array_non_empty_domain_all_dimensions(a.context.tiledbContext, a.tiledbArray.Get(), buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide)
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
@@ -361,7 +361,7 @@ func SerializeArrayMetadataToBuffer(a *Array, serializationType SerializationTyp
 	buffer := Buffer{context: a.context}
 	freeOnGC(&buffer)
 
-	ret := C.tiledb_serialize_array_metadata(a.context.tiledbContext, a.tiledbArray, C.tiledb_serialization_type_t(serializationType), &buffer.tiledbBuffer)
+	ret := C.tiledb_serialize_array_metadata(a.context.tiledbContext, a.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType), &buffer.tiledbBuffer)
 	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error serializing array metadata: %w", a.context.LastError())
@@ -384,7 +384,7 @@ func SerializeArrayMetadata(a *Array, serializationType SerializationType) ([]by
 
 // DeserializeArrayMetadata deserializes array metadata.
 func DeserializeArrayMetadata(a *Array, buffer *Buffer, serializationType SerializationType) error {
-	ret := C.tiledb_deserialize_array_metadata(a.context.tiledbContext, a.tiledbArray, C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer)
+	ret := C.tiledb_deserialize_array_metadata(a.context.tiledbContext, a.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer)
 	runtime.KeepAlive(a)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
@@ -457,7 +457,7 @@ func SerializeArrayToBuffer(array *Array, serializationType SerializationType, c
 	// Set finalizer for free C pointer on gc
 	freeOnGC(&buffer)
 
-	ret := C.tiledb_serialize_array(array.context.tiledbContext, array.tiledbArray, C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
+	ret := C.tiledb_serialize_array(array.context.tiledbContext, array.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType), cClientSide, &buffer.tiledbBuffer)
 	runtime.KeepAlive(array)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
@@ -481,8 +481,6 @@ func SerializeArray(array *Array, serializationType SerializationType, clientSid
 
 // DeserializeArray deserializes a new array from the given buffer.
 func DeserializeArray(buffer *Buffer, serializationType SerializationType, clientSide bool, arrayURI string) (*Array, error) {
-	array := Array{context: buffer.context}
-
 	var cClientSide C.int32_t
 	if clientSide {
 		cClientSide = 1
@@ -493,19 +491,14 @@ func DeserializeArray(buffer *Buffer, serializationType SerializationType, clien
 	cArrayURI := C.CString(arrayURI)
 	defer C.free(unsafe.Pointer(cArrayURI))
 
-	ret := C.tiledb_deserialize_array(array.context.tiledbContext, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, cArrayURI, &array.tiledbArray)
+	var arrayPtr *C.tiledb_array_t
+	ret := C.tiledb_deserialize_array(buffer.context.tiledbContext, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, cArrayURI, &arrayPtr)
 	runtime.KeepAlive(buffer)
 	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error deserializing array: %w", array.context.LastError())
+		return nil, fmt.Errorf("error deserializing array: %w", buffer.context.LastError())
 	}
 
-	// Set finalizer for free C pointer on gc
-	// This needs to happen *after* the tiledb_deserialize_array call
-	// because that may leave the array with a non-nil pointer
-	// to already-freed memory.
-	freeOnGC(&array)
-
-	return &array, nil
+	return newArrayFromHandle(buffer.context, newArrayHandle(arrayPtr)), nil
 }
 
 // SerializeFragmentInfoToBuffer serializes fragment info and returns a Buffer object containing the payload.
@@ -628,21 +621,18 @@ func DeserializeQueryAndArray(context *Context, buffer *Buffer, serializationTyp
 	cArrayURI := C.CString(arrayURI)
 	defer C.free(unsafe.Pointer(cArrayURI))
 
-	array := &Array{
-		context: context,
-	}
-
 	query := &Query{
 		context: context,
-		array:   array,
 	}
 
-	ret := C.tiledb_deserialize_query_and_array(context.tiledbContext, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, cArrayURI, &query.tiledbQuery, &array.tiledbArray)
+	var arrayPtr *C.tiledb_array_t
+	ret := C.tiledb_deserialize_query_and_array(context.tiledbContext, buffer.tiledbBuffer, C.tiledb_serialization_type_t(serializationType), cClientSide, cArrayURI, &query.tiledbQuery, &arrayPtr)
 	if ret != C.TILEDB_OK {
 		return nil, nil, fmt.Errorf("error deserializing query: %w", context.LastError())
 	}
 
-	freeOnGC(array)
+	array := newArrayFromHandle(context, newArrayHandle(arrayPtr))
+	query.array = array
 	freeOnGC(query)
 
 	query.resultBufferElements = make(map[string][3]*uint64)
@@ -737,7 +727,7 @@ func HandleLoadArraySchemaRequest(array *Array, request *Buffer, serializationTy
 		return nil, fmt.Errorf("error creating LoadArraySchemaResponse buffer: %w", array.context.LastError())
 	}
 
-	ret := C.tiledb_handle_load_array_schema_request(array.context.tiledbContext, array.tiledbArray, C.tiledb_serialization_type_t(serializationType), request.tiledbBuffer, response.tiledbBuffer)
+	ret := C.tiledb_handle_load_array_schema_request(array.context.tiledbContext, array.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType), request.tiledbBuffer, response.tiledbBuffer)
 	runtime.KeepAlive(array)
 	runtime.KeepAlive(request)
 	if ret != C.TILEDB_OK {
@@ -749,7 +739,7 @@ func HandleLoadArraySchemaRequest(array *Array, request *Buffer, serializationTy
 
 // HandleArrayDeleteFragmentsTimestampsRequest is used by TileDB cloud to handle DeleteFragments with tiledb:// uris.
 func HandleArrayDeleteFragmentsTimestampsRequest(context *Context, array *Array, buffer *Buffer, serializationType SerializationType) error {
-	ret := C.tiledb_handle_array_delete_fragments_timestamps_request(context.tiledbContext, array.tiledbArray,
+	ret := C.tiledb_handle_array_delete_fragments_timestamps_request(context.tiledbContext, array.tiledbArray.Get(),
 		C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer)
 	runtime.KeepAlive(array)
 	runtime.KeepAlive(buffer)
@@ -762,7 +752,7 @@ func HandleArrayDeleteFragmentsTimestampsRequest(context *Context, array *Array,
 
 // HandleArrayDeleteFragmentsListRequest is used by TileDB cloud to handle DeleteFragmentsList with tiledb:// uris.
 func HandleArrayDeleteFragmentsListRequest(context *Context, array *Array, buffer *Buffer, serializationType SerializationType) error {
-	ret := C.tiledb_handle_array_delete_fragments_list_request(context.tiledbContext, array.tiledbArray,
+	ret := C.tiledb_handle_array_delete_fragments_list_request(context.tiledbContext, array.tiledbArray.Get(),
 		C.tiledb_serialization_type_t(serializationType), buffer.tiledbBuffer)
 	runtime.KeepAlive(array)
 	runtime.KeepAlive(buffer)
@@ -783,7 +773,7 @@ func HandleQueryPlanRequest(array *Array, serializationType SerializationType, r
 		return nil, fmt.Errorf("error allocating tiledb buffer: %w", opContext.LastError())
 	}
 
-	ret := C.tiledb_handle_query_plan_request(opContext.tiledbContext, array.tiledbArray, C.tiledb_serialization_type_t(serializationType),
+	ret := C.tiledb_handle_query_plan_request(opContext.tiledbContext, array.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType),
 		request.tiledbBuffer, response.tiledbBuffer)
 	runtime.KeepAlive(array)
 	runtime.KeepAlive(request)
@@ -804,7 +794,7 @@ func HandleConsolidationPlanRequest(array *Array, serializationType Serializatio
 		return nil, fmt.Errorf("error allocating tiledb buffer: %w", opContext.LastError())
 	}
 
-	ret := C.tiledb_handle_consolidation_plan_request(opContext.tiledbContext, array.tiledbArray, C.tiledb_serialization_type_t(serializationType),
+	ret := C.tiledb_handle_consolidation_plan_request(opContext.tiledbContext, array.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType),
 		request.tiledbBuffer, response.tiledbBuffer)
 	runtime.KeepAlive(array)
 	runtime.KeepAlive(request)
@@ -822,7 +812,7 @@ func DeserializeLoadEnumerationsRequest(array *Array, serializationType Serializ
 		return nil, fmt.Errorf("error deserializing load enumerations request: %w", array.context.LastError())
 	}
 
-	ret := C.tiledb_handle_load_enumerations_request(array.context.tiledbContext, array.tiledbArray, C.tiledb_serialization_type_t(serializationType),
+	ret := C.tiledb_handle_load_enumerations_request(array.context.tiledbContext, array.tiledbArray.Get(), C.tiledb_serialization_type_t(serializationType),
 		request.tiledbBuffer, response.tiledbBuffer)
 	runtime.KeepAlive(array)
 	runtime.KeepAlive(request)

--- a/serialize.go
+++ b/serialize.go
@@ -150,9 +150,6 @@ func SerializeArrayNonEmptyDomainToBuffer(a *Array, serializationType Serializat
 		return nil, fmt.Errorf("error serializing array nonempty domain: %w", a.context.LastError())
 	}
 
-	buffer := Buffer{context: schema.context}
-	freeOnGC(&buffer)
-
 	var cClientSide = C.int32_t(0) // Currently this parameter is unused in libtiledb
 	var bufferPtr *C.tiledb_buffer_t
 	ret = C.tiledb_serialize_array_nonempty_domain(a.context.tiledbContext.Get(), a.tiledbArray.Get(), slicePtr(tmpDomain), isEmpty, C.tiledb_serialization_type_t(serializationType), cClientSide, &bufferPtr)
@@ -161,7 +158,7 @@ func SerializeArrayNonEmptyDomainToBuffer(a *Array, serializationType Serializat
 	}
 
 	runtime.KeepAlive(a)
-	return &buffer, nil
+	return newBufferFromHandle(a.context, newBufferHandle(bufferPtr)), nil
 }
 
 // SerializeArrayNonEmptyDomain gets and serializes the array nonempty domain.

--- a/subarray.go
+++ b/subarray.go
@@ -36,7 +36,7 @@ func (a *Array) NewSubarray() (*Subarray, error) {
 
 // SetConfig sets the subarray config. Currently it overrides only sm.read_range_oob.
 func (sa *Subarray) SetConfig(cfg *Config) error {
-	ret := C.tiledb_subarray_set_config(sa.context.tiledbContext, sa.subarray, cfg.tiledbConfig)
+	ret := C.tiledb_subarray_set_config(sa.context.tiledbContext, sa.subarray, cfg.tiledbConfig.Get())
 	runtime.KeepAlive(sa)
 	runtime.KeepAlive(cfg)
 	if ret != C.TILEDB_OK {

--- a/subarray.go
+++ b/subarray.go
@@ -23,7 +23,7 @@ type Subarray struct {
 func (a *Array) NewSubarray() (*Subarray, error) {
 	var sa *C.tiledb_subarray_t
 
-	ret := C.tiledb_subarray_alloc(a.context.tiledbContext, a.tiledbArray.Get(), &sa)
+	ret := C.tiledb_subarray_alloc(a.context.tiledbContext.Get(), a.tiledbArray.Get(), &sa)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating Subarray: %w", a.context.LastError())
 	}
@@ -36,7 +36,7 @@ func (a *Array) NewSubarray() (*Subarray, error) {
 
 // SetConfig sets the subarray config. Currently it overrides only sm.read_range_oob.
 func (sa *Subarray) SetConfig(cfg *Config) error {
-	ret := C.tiledb_subarray_set_config(sa.context.tiledbContext, sa.subarray, cfg.tiledbConfig.Get())
+	ret := C.tiledb_subarray_set_config(sa.context.tiledbContext.Get(), sa.subarray, cfg.tiledbConfig.Get())
 	runtime.KeepAlive(sa)
 	runtime.KeepAlive(cfg)
 	if ret != C.TILEDB_OK {
@@ -144,7 +144,7 @@ func (sa *Subarray) SetSubArray(subArray interface{}) error {
 		return fmt.Errorf("unrecognized subArray type passed: %s", subArrayType.String())
 	}
 
-	ret := C.tiledb_subarray_set_subarray(sa.context.tiledbContext, sa.subarray, csubArray)
+	ret := C.tiledb_subarray_set_subarray(sa.context.tiledbContext.Get(), sa.subarray, csubArray)
 	runtime.KeepAlive(sa)
 	// csubarray is being kept alive by passing it to cgo call.
 	if ret != C.TILEDB_OK {
@@ -161,7 +161,7 @@ func (sa *Subarray) SetCoalesceRanges(b bool) error {
 		coalesce = 1
 	}
 
-	ret := C.tiledb_subarray_set_coalesce_ranges(sa.context.tiledbContext, sa.subarray, coalesce)
+	ret := C.tiledb_subarray_set_coalesce_ranges(sa.context.tiledbContext.Get(), sa.subarray, coalesce)
 	runtime.KeepAlive(sa)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error setting coalesce ranges on subarray: %w", sa.context.LastError())
@@ -185,12 +185,12 @@ func (sa *Subarray) AddRange(dimIdx uint32, r Range) error {
 	if isVar {
 		startSlice := []byte(r.start.(string))
 		endSlice := []byte(r.end.(string))
-		ret = C.tiledb_subarray_add_range_var(sa.context.tiledbContext, sa.subarray, C.uint32_t(dimIdx),
+		ret = C.tiledb_subarray_add_range_var(sa.context.tiledbContext.Get(), sa.subarray, C.uint32_t(dimIdx),
 			slicePtr(startSlice), C.uint64_t(len(startSlice)), slicePtr(endSlice), C.uint64_t(len(endSlice)))
 	} else {
 		startValue := addressableValue(r.start)
 		endValue := addressableValue(r.end)
-		ret = C.tiledb_subarray_add_range(sa.context.tiledbContext, sa.subarray, C.uint32_t(dimIdx),
+		ret = C.tiledb_subarray_add_range(sa.context.tiledbContext.Get(), sa.subarray, C.uint32_t(dimIdx),
 			startValue.UnsafePointer(), endValue.UnsafePointer(), nil)
 	}
 	runtime.KeepAlive(sa)
@@ -220,12 +220,12 @@ func (sa *Subarray) AddRangeByName(dimName string, r Range) error {
 	if isVar {
 		startSlice := []byte(r.start.(string))
 		endSlice := []byte(r.end.(string))
-		ret = C.tiledb_subarray_add_range_var_by_name(sa.context.tiledbContext, sa.subarray, cDimName,
+		ret = C.tiledb_subarray_add_range_var_by_name(sa.context.tiledbContext.Get(), sa.subarray, cDimName,
 			slicePtr(startSlice), C.uint64_t(len(startSlice)), slicePtr(endSlice), C.uint64_t(len(endSlice)))
 	} else {
 		startValue := addressableValue(r.start)
 		endValue := addressableValue(r.end)
-		ret = C.tiledb_subarray_add_range_by_name(sa.context.tiledbContext, sa.subarray, cDimName,
+		ret = C.tiledb_subarray_add_range_by_name(sa.context.tiledbContext.Get(), sa.subarray, cDimName,
 			startValue.UnsafePointer(), endValue.UnsafePointer(), nil)
 	}
 	runtime.KeepAlive(sa)
@@ -241,7 +241,7 @@ func (sa *Subarray) AddRangeByName(dimName string, r Range) error {
 func (sa *Subarray) GetRangeNum(dimIdx uint32) (uint64, error) {
 	var rangeNum uint64
 
-	ret := C.tiledb_subarray_get_range_num(sa.context.tiledbContext, sa.subarray, C.uint32_t(dimIdx), (*C.uint64_t)(unsafe.Pointer(&rangeNum)))
+	ret := C.tiledb_subarray_get_range_num(sa.context.tiledbContext.Get(), sa.subarray, C.uint32_t(dimIdx), (*C.uint64_t)(unsafe.Pointer(&rangeNum)))
 	runtime.KeepAlive(sa)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error retrieving subarray range num: %w", sa.context.LastError())
@@ -257,7 +257,7 @@ func (sa *Subarray) GetRangeNumFromName(dimName string) (uint64, error) {
 	cDimName := C.CString(dimName)
 	defer C.free(unsafe.Pointer(cDimName))
 
-	ret := C.tiledb_subarray_get_range_num_from_name(sa.context.tiledbContext, sa.subarray, cDimName, (*C.uint64_t)(unsafe.Pointer(&rangeNum)))
+	ret := C.tiledb_subarray_get_range_num_from_name(sa.context.tiledbContext.Get(), sa.subarray, cDimName, (*C.uint64_t)(unsafe.Pointer(&rangeNum)))
 	runtime.KeepAlive(sa)
 	if ret != C.TILEDB_OK {
 		return 0, fmt.Errorf("error retrieving subarray range num: %w", sa.context.LastError())
@@ -351,7 +351,7 @@ func (sa *Subarray) GetRange(dimIdx uint32, rangeNum uint64) (Range, error) {
 	var ret C.int32_t
 	if isVar {
 		var startSize, endSize uint64
-		ret = C.tiledb_subarray_get_range_var_size(sa.context.tiledbContext, sa.subarray, C.uint32_t(dimIdx), C.uint64_t(rangeNum),
+		ret = C.tiledb_subarray_get_range_var_size(sa.context.tiledbContext.Get(), sa.subarray, C.uint32_t(dimIdx), C.uint64_t(rangeNum),
 			(*C.uint64_t)(unsafe.Pointer(&startSize)), (*C.uint64_t)(unsafe.Pointer(&endSize)))
 		if startSize == 0 && endSize == 0 {
 			r.start = ""
@@ -362,7 +362,7 @@ func (sa *Subarray) GetRange(dimIdx uint32, rangeNum uint64) (Range, error) {
 			endData := make([]byte, int(endSize))
 			ep := slicePtr(endData)
 
-			ret = C.tiledb_subarray_get_range_var(sa.context.tiledbContext, sa.subarray,
+			ret = C.tiledb_subarray_get_range_var(sa.context.tiledbContext.Get(), sa.subarray,
 				C.uint32_t(dimIdx), C.uint64_t(rangeNum), sp, ep)
 			if ret == C.TILEDB_OK {
 				r.start = string(startData)
@@ -371,7 +371,7 @@ func (sa *Subarray) GetRange(dimIdx uint32, rangeNum uint64) (Range, error) {
 		}
 	} else {
 		var startPointer, endPointer, stridePointer unsafe.Pointer
-		ret = C.tiledb_subarray_get_range(sa.context.tiledbContext, sa.subarray,
+		ret = C.tiledb_subarray_get_range(sa.context.tiledbContext.Get(), sa.subarray,
 			C.uint32_t(dimIdx), C.uint64_t(rangeNum), &startPointer, &endPointer, &stridePointer)
 		typ := dt.ReflectType()
 		if ret == C.TILEDB_OK {
@@ -401,7 +401,7 @@ func (sa *Subarray) GetRangeFromName(dimName string, rangeNum uint64) (Range, er
 	var ret C.int32_t
 	if isVar {
 		var startSize, endSize uint64
-		ret = C.tiledb_subarray_get_range_var_size_from_name(sa.context.tiledbContext, sa.subarray, cDimName, C.uint64_t(rangeNum),
+		ret = C.tiledb_subarray_get_range_var_size_from_name(sa.context.tiledbContext.Get(), sa.subarray, cDimName, C.uint64_t(rangeNum),
 			(*C.uint64_t)(unsafe.Pointer(&startSize)), (*C.uint64_t)(unsafe.Pointer(&endSize)))
 		if startSize == 0 && endSize == 0 {
 			r.start = ""
@@ -412,7 +412,7 @@ func (sa *Subarray) GetRangeFromName(dimName string, rangeNum uint64) (Range, er
 			endData := make([]byte, int(endSize))
 			ep := slicePtr(endData)
 
-			ret = C.tiledb_subarray_get_range_var_from_name(sa.context.tiledbContext, sa.subarray,
+			ret = C.tiledb_subarray_get_range_var_from_name(sa.context.tiledbContext.Get(), sa.subarray,
 				cDimName, C.uint64_t(rangeNum), sp, ep)
 			// startData and endData are being kept alive by passing them to the cgo call.
 			if ret == C.TILEDB_OK {
@@ -422,7 +422,7 @@ func (sa *Subarray) GetRangeFromName(dimName string, rangeNum uint64) (Range, er
 		}
 	} else {
 		var startPointer, endPointer, stridePointer unsafe.Pointer // sa must be kept alive while these pointers are being accessed.
-		ret = C.tiledb_subarray_get_range_from_name(sa.context.tiledbContext, sa.subarray,
+		ret = C.tiledb_subarray_get_range_from_name(sa.context.tiledbContext.Get(), sa.subarray,
 			cDimName, C.uint64_t(rangeNum), &startPointer, &endPointer, &stridePointer)
 		typ := dt.ReflectType()
 		if ret == C.TILEDB_OK {

--- a/subarray.go
+++ b/subarray.go
@@ -23,7 +23,7 @@ type Subarray struct {
 func (a *Array) NewSubarray() (*Subarray, error) {
 	var sa *C.tiledb_subarray_t
 
-	ret := C.tiledb_subarray_alloc(a.context.tiledbContext, a.tiledbArray, &sa)
+	ret := C.tiledb_subarray_alloc(a.context.tiledbContext, a.tiledbArray.Get(), &sa)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating Subarray: %w", a.context.LastError())
 	}

--- a/vfs.go
+++ b/vfs.go
@@ -52,7 +52,7 @@ func (v *VFSfh) Context() *Context {
 func (v *VFSfh) IsClosed() (bool, error) {
 	var isClosed C.int32_t
 
-	ret := C.tiledb_vfs_fh_is_closed(v.context.tiledbContext, v.tiledbVFSfh, &isClosed)
+	ret := C.tiledb_vfs_fh_is_closed(v.context.tiledbContext.Get(), v.tiledbVFSfh, &isClosed)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -79,7 +79,7 @@ type VFS struct {
 // garbage collection
 func NewVFS(context *Context, config *Config) (*VFS, error) {
 	vfs := VFS{context: context}
-	ret := C.tiledb_vfs_alloc(context.tiledbContext, config.tiledbConfig.Get(), &vfs.tiledbVFS)
+	ret := C.tiledb_vfs_alloc(context.tiledbContext.Get(), config.tiledbConfig.Get(), &vfs.tiledbVFS)
 	runtime.KeepAlive(context)
 	runtime.KeepAlive(config)
 	if ret != C.TILEDB_OK {
@@ -109,7 +109,7 @@ func (v *VFS) Context() *Context {
 // Config retrieves a copy of the config from vfs.
 func (v *VFS) Config() (*Config, error) {
 	var configPtr *C.tiledb_config_t
-	ret := C.tiledb_vfs_get_config(v.context.tiledbContext, v.tiledbVFS,
+	ret := C.tiledb_vfs_get_config(v.context.tiledbContext.Get(), v.tiledbVFS,
 		&configPtr)
 
 	if ret == C.TILEDB_OOM {
@@ -125,7 +125,7 @@ func (v *VFS) Config() (*Config, error) {
 func (v *VFS) CreateBucket(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_create_bucket(v.context.tiledbContext, v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_create_bucket(v.context.tiledbContext.Get(), v.tiledbVFS, curi)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -139,7 +139,7 @@ func (v *VFS) CreateBucket(uri string) error {
 func (v *VFS) RemoveBucket(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_remove_bucket(v.context.tiledbContext, v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_remove_bucket(v.context.tiledbContext.Get(), v.tiledbVFS, curi)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -153,7 +153,7 @@ func (v *VFS) RemoveBucket(uri string) error {
 func (v *VFS) EmptyBucket(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_empty_bucket(v.context.tiledbContext, v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_empty_bucket(v.context.tiledbContext.Get(), v.tiledbVFS, curi)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -168,7 +168,7 @@ func (v *VFS) IsEmptyBucket(uri string) (bool, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var isEmpty C.int32_t
-	ret := C.tiledb_vfs_is_empty_bucket(v.context.tiledbContext, v.tiledbVFS, curi, &isEmpty)
+	ret := C.tiledb_vfs_is_empty_bucket(v.context.tiledbContext.Get(), v.tiledbVFS, curi, &isEmpty)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -187,7 +187,7 @@ func (v *VFS) IsBucket(uri string) (bool, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var isBucket C.int32_t
-	ret := C.tiledb_vfs_is_bucket(v.context.tiledbContext, v.tiledbVFS, curi, &isBucket)
+	ret := C.tiledb_vfs_is_bucket(v.context.tiledbContext.Get(), v.tiledbVFS, curi, &isBucket)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -205,7 +205,7 @@ func (v *VFS) IsBucket(uri string) (bool, error) {
 func (v *VFS) CreateDir(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_create_dir(v.context.tiledbContext, v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_create_dir(v.context.tiledbContext.Get(), v.tiledbVFS, curi)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -220,7 +220,7 @@ func (v *VFS) IsDir(uri string) (bool, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var isDir C.int32_t
-	ret := C.tiledb_vfs_is_dir(v.context.tiledbContext, v.tiledbVFS, curi, &isDir)
+	ret := C.tiledb_vfs_is_dir(v.context.tiledbContext.Get(), v.tiledbVFS, curi, &isDir)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -238,7 +238,7 @@ func (v *VFS) IsDir(uri string) (bool, error) {
 func (v *VFS) RemoveDir(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_remove_dir(v.context.tiledbContext, v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_remove_dir(v.context.tiledbContext.Get(), v.tiledbVFS, curi)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -253,7 +253,7 @@ func (v *VFS) IsFile(uri string) (bool, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var isFile C.int32_t
-	ret := C.tiledb_vfs_is_file(v.context.tiledbContext, v.tiledbVFS, curi, &isFile)
+	ret := C.tiledb_vfs_is_file(v.context.tiledbContext.Get(), v.tiledbVFS, curi, &isFile)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -271,7 +271,7 @@ func (v *VFS) IsFile(uri string) (bool, error) {
 func (v *VFS) RemoveFile(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_remove_file(v.context.tiledbContext, v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_remove_file(v.context.tiledbContext.Get(), v.tiledbVFS, curi)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -286,7 +286,7 @@ func (v *VFS) FileSize(uri string) (uint64, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var cfsize C.uint64_t
-	ret := C.tiledb_vfs_file_size(v.context.tiledbContext, v.tiledbVFS, curi, &cfsize)
+	ret := C.tiledb_vfs_file_size(v.context.tiledbContext.Get(), v.tiledbVFS, curi, &cfsize)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -303,7 +303,7 @@ func (v *VFS) MoveFile(oldURI string, newURI string) error {
 	cNewURI := C.CString(newURI)
 	defer C.free(unsafe.Pointer(cNewURI))
 
-	ret := C.tiledb_vfs_move_file(v.context.tiledbContext, v.tiledbVFS, cOldURI, cNewURI)
+	ret := C.tiledb_vfs_move_file(v.context.tiledbContext.Get(), v.tiledbVFS, cOldURI, cNewURI)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -320,7 +320,7 @@ func (v *VFS) CopyFile(oldURI string, newURI string) error {
 	cNewURI := C.CString(newURI)
 	defer C.free(unsafe.Pointer(cNewURI))
 
-	ret := C.tiledb_vfs_copy_file(v.context.tiledbContext, v.tiledbVFS, cOldURI, cNewURI)
+	ret := C.tiledb_vfs_copy_file(v.context.tiledbContext.Get(), v.tiledbVFS, cOldURI, cNewURI)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -337,7 +337,7 @@ func (v *VFS) MoveDir(oldURI string, newURI string) error {
 	cNewURI := C.CString(newURI)
 	defer C.free(unsafe.Pointer(cNewURI))
 
-	ret := C.tiledb_vfs_move_dir(v.context.tiledbContext, v.tiledbVFS, cOldURI, cNewURI)
+	ret := C.tiledb_vfs_move_dir(v.context.tiledbContext.Get(), v.tiledbVFS, cOldURI, cNewURI)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -354,7 +354,7 @@ func (v *VFS) Open(uri string, mode VFSMode) (*VFSfh, error) {
 	fh := &VFSfh{context: v.context, uri: uri, vfs: v}
 	freeOnGC(fh)
 
-	ret := C.tiledb_vfs_open(v.context.tiledbContext, v.tiledbVFS, curi, C.tiledb_vfs_mode_t(mode), &fh.tiledbVFSfh)
+	ret := C.tiledb_vfs_open(v.context.tiledbContext.Get(), v.tiledbVFS, curi, C.tiledb_vfs_mode_t(mode), &fh.tiledbVFSfh)
 	runtime.KeepAlive(v)
 
 	if ret == C.TILEDB_OOM {
@@ -370,7 +370,7 @@ func (v *VFS) Open(uri string, mode VFSMode) (*VFSfh, error) {
 // was opened in write (or append) mode. It is particularly important to be
 // called after S3 writes, as otherwise the writes will not take effect.
 func (v *VFS) Close(fh *VFSfh) error {
-	ret := C.tiledb_vfs_close(v.context.tiledbContext, fh.tiledbVFSfh)
+	ret := C.tiledb_vfs_close(v.context.tiledbContext.Get(), fh.tiledbVFSfh)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -385,7 +385,7 @@ func (v *VFS) Close(fh *VFSfh) error {
 func (v *VFS) Read(fh *VFSfh, offset uint64, nbytes uint64) ([]byte, error) {
 	bytes := make([]byte, nbytes)
 	cbuffer := slicePtr(bytes)
-	ret := C.tiledb_vfs_read(v.context.tiledbContext, fh.tiledbVFSfh, C.uint64_t(offset), cbuffer, C.uint64_t(nbytes))
+	ret := C.tiledb_vfs_read(v.context.tiledbContext.Get(), fh.tiledbVFSfh, C.uint64_t(offset), cbuffer, C.uint64_t(nbytes))
 	runtime.KeepAlive(v)
 	runtime.KeepAlive(fh)
 
@@ -402,7 +402,7 @@ func (v *VFS) Read(fh *VFSfh, offset uint64, nbytes uint64) ([]byte, error) {
 func (v *VFS) Write(fh *VFSfh, bytes []byte) error {
 	cbuffer := slicePtr(bytes)
 	defer runtime.KeepAlive(bytes)
-	ret := C.tiledb_vfs_write(v.context.tiledbContext, fh.tiledbVFSfh, cbuffer, C.uint64_t(len(bytes)))
+	ret := C.tiledb_vfs_write(v.context.tiledbContext.Get(), fh.tiledbVFSfh, cbuffer, C.uint64_t(len(bytes)))
 	runtime.KeepAlive(v)
 	runtime.KeepAlive(fh)
 
@@ -415,7 +415,7 @@ func (v *VFS) Write(fh *VFSfh, bytes []byte) error {
 
 // Sync flushes a file.
 func (v *VFS) Sync(fh *VFSfh) error {
-	ret := C.tiledb_vfs_sync(v.context.tiledbContext, fh.tiledbVFSfh)
+	ret := C.tiledb_vfs_sync(v.context.tiledbContext.Get(), fh.tiledbVFSfh)
 	runtime.KeepAlive(v)
 	runtime.KeepAlive(fh)
 
@@ -430,7 +430,7 @@ func (v *VFS) Sync(fh *VFSfh) error {
 func (v *VFS) Touch(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_touch(v.context.tiledbContext, v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_touch(v.context.tiledbContext.Get(), v.tiledbVFS, curi)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -445,7 +445,7 @@ func (v *VFS) DirSize(uri string) (uint64, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var cfsize C.uint64_t
-	ret := C.tiledb_vfs_dir_size(v.context.tiledbContext, v.tiledbVFS, curi, &cfsize)
+	ret := C.tiledb_vfs_dir_size(v.context.tiledbContext.Get(), v.tiledbVFS, curi, &cfsize)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -491,7 +491,7 @@ func (v *VFS) NumOfFragmentsInPath(path string) (int, error) {
 	data := pointer.Save(&numOfFragmentsData)
 	defer pointer.Unref(data)
 
-	ret := C._num_of_folders_in_path(v.context.tiledbContext, v.tiledbVFS, cpath, data)
+	ret := C._num_of_folders_in_path(v.context.tiledbContext.Get(), v.tiledbVFS, cpath, data)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -506,7 +506,7 @@ func (v *VFS) NumOfFragmentsInPath(path string) (int, error) {
 // called after S3 writes, as otherwise the writes will not take effect.
 func (v *VFSfh) Close() error {
 
-	ret := C.tiledb_vfs_close(v.context.tiledbContext, v.tiledbVFSfh)
+	ret := C.tiledb_vfs_close(v.context.tiledbContext.Get(), v.tiledbVFSfh)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -539,7 +539,7 @@ func (v *VFSfh) Read(p []byte) (int, error) {
 	}
 
 	cbuffer := slicePtr(p)
-	ret := C.tiledb_vfs_read(v.context.tiledbContext, v.tiledbVFSfh, C.uint64_t(v.offset), cbuffer, C.uint64_t(nbytes))
+	ret := C.tiledb_vfs_read(v.context.tiledbContext.Get(), v.tiledbVFSfh, C.uint64_t(v.offset), cbuffer, C.uint64_t(nbytes))
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -582,7 +582,7 @@ func (v *VFSfh) ReadAt(p []byte, off int64) (int, error) {
 	}
 
 	cbuffer := slicePtr(p)
-	ret := C.tiledb_vfs_read(v.context.tiledbContext, v.tiledbVFSfh, C.uint64_t(off), cbuffer, C.uint64_t(nbytes))
+	ret := C.tiledb_vfs_read(v.context.tiledbContext.Get(), v.tiledbVFSfh, C.uint64_t(off), cbuffer, C.uint64_t(nbytes))
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -600,7 +600,7 @@ func (v *VFSfh) Write(bytes []byte) (int, error) {
 		return 0, nil
 	}
 	cbuffer := slicePtr(bytes)
-	ret := C.tiledb_vfs_write(v.context.tiledbContext, v.tiledbVFSfh, cbuffer, C.uint64_t(len(bytes)))
+	ret := C.tiledb_vfs_write(v.context.tiledbContext.Get(), v.tiledbVFSfh, cbuffer, C.uint64_t(len(bytes)))
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -612,7 +612,7 @@ func (v *VFSfh) Write(bytes []byte) (int, error) {
 
 // Sync flushes a file.
 func (v *VFSfh) Sync() error {
-	ret := C.tiledb_vfs_sync(v.context.tiledbContext, v.tiledbVFSfh)
+	ret := C.tiledb_vfs_sync(v.context.tiledbContext.Get(), v.tiledbVFSfh)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -709,7 +709,7 @@ func (v *VFS) List(path string) ([]string, []string, error) {
 	data := pointer.Save(&folderData)
 	defer pointer.Unref(data)
 
-	ret := C._vfs_ls(v.context.tiledbContext, v.tiledbVFS, cpath, data)
+	ret := C._vfs_ls(v.context.tiledbContext.Get(), v.tiledbVFS, cpath, data)
 	runtime.KeepAlive(v)
 	if ret != C.TILEDB_OK {
 		return nil, nil, fmt.Errorf("error in getting path listing %s: %w", path, v.context.LastError())
@@ -762,7 +762,7 @@ func (v *VFS) VisitRecursive(path string, callback VisitRecursiveCallback) error
 	data := pointer.Save(state)
 	defer pointer.Unref(data)
 
-	ret := C._vfs_ls_recursive(v.context.tiledbContext, v.tiledbVFS, cpath, data)
+	ret := C._vfs_ls_recursive(v.context.tiledbContext.Get(), v.tiledbVFS, cpath, data)
 	runtime.KeepAlive(v)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error in recursively listing path %s: %w", path, v.context.LastError())

--- a/vfs.go
+++ b/vfs.go
@@ -21,14 +21,32 @@ import (
 
 const arrayMetadataFolderName = "__meta"
 
+type vfsFhHandle struct{ *capiHandle }
+
+func freeCapiVfsFh(c unsafe.Pointer) {
+	C.tiledb_vfs_fh_free((**C.tiledb_vfs_fh_t)(unsafe.Pointer(&c)))
+}
+
+func newVfsFhHandle(ptr *C.tiledb_vfs_fh_t) vfsFhHandle {
+	return vfsFhHandle{newCapiHandle(unsafe.Pointer(ptr), freeCapiVfsFh)}
+}
+
+func (x vfsFhHandle) Get() *C.tiledb_vfs_fh_t {
+	return (*C.tiledb_vfs_fh_t)(x.capiHandle.Get())
+}
+
 // VFSfh is a virtual file system file handler
 type VFSfh struct {
 	vfs         *VFS
-	tiledbVFSfh *C.tiledb_vfs_fh_t
+	tiledbVFSfh vfsFhHandle
 	context     *Context
 	offset      uint64
 	size        *uint64
 	uri         string
+}
+
+func newVfsFhFromHandle(context *Context, vfs *VFS, uri string, handle vfsFhHandle) *VFSfh {
+	return &VFSfh{vfs: vfs, tiledbVFSfh: handle, context: context, uri: uri}
 }
 
 // Free releases the internal TileDB core data that was allocated on the C heap.
@@ -37,9 +55,7 @@ type VFSfh struct {
 // can safely be called many times on the same object; if it has already
 // been freed, it will not be freed again.
 func (v *VFSfh) Free() {
-	if v.tiledbVFSfh != nil {
-		C.tiledb_vfs_fh_free(&v.tiledbVFSfh)
-	}
+	v.tiledbVFSfh.Free()
 }
 
 // Context exposes the internal TileDB context used to initialize the vfsh.
@@ -52,7 +68,7 @@ func (v *VFSfh) Context() *Context {
 func (v *VFSfh) IsClosed() (bool, error) {
 	var isClosed C.int32_t
 
-	ret := C.tiledb_vfs_fh_is_closed(v.context.tiledbContext.Get(), v.tiledbVFSfh, &isClosed)
+	ret := C.tiledb_vfs_fh_is_closed(v.context.tiledbContext.Get(), v.tiledbVFSfh.Get(), &isClosed)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -66,28 +82,45 @@ func (v *VFSfh) IsClosed() (bool, error) {
 	return false, nil
 }
 
+type vfsHandle struct{ *capiHandle }
+
+func freeCapiVfs(c unsafe.Pointer) {
+	C.tiledb_vfs_free((**C.tiledb_vfs_t)(unsafe.Pointer(&c)))
+}
+
+func newVfsHandle(ptr *C.tiledb_vfs_t) vfsHandle {
+	return vfsHandle{newCapiHandle(unsafe.Pointer(ptr), freeCapiVfs)}
+}
+
+func (x vfsHandle) Get() *C.tiledb_vfs_t {
+	return (*C.tiledb_vfs_t)(x.capiHandle.Get())
+}
+
 // VFS Implements a virtual filesystem that enables performing directory/file
 // operations with a unified API on different filesystems, such as local
 // posix/windows, HDFS, AWS S3, etc.
 type VFS struct {
-	tiledbVFS *C.tiledb_vfs_t
+	tiledbVFS vfsHandle
 	context   *Context
+}
+
+func newVfsFromHandle(context *Context, handle vfsHandle) *VFS {
+	return &VFS{context: context, tiledbVFS: handle}
 }
 
 // NewVFS alloc a new context using tiledb_vfs_alloc. This also registers the
 // `runtime.SetFinalizer` for handling the free'ing of the c data structure on
 // garbage collection
 func NewVFS(context *Context, config *Config) (*VFS, error) {
-	vfs := VFS{context: context}
-	ret := C.tiledb_vfs_alloc(context.tiledbContext.Get(), config.tiledbConfig.Get(), &vfs.tiledbVFS)
+	var vfsPtr *C.tiledb_vfs_t
+	ret := C.tiledb_vfs_alloc(context.tiledbContext.Get(), config.tiledbConfig.Get(), &vfsPtr)
 	runtime.KeepAlive(context)
 	runtime.KeepAlive(config)
 	if ret != C.TILEDB_OK {
 		return nil, fmt.Errorf("error creating tiledb VFS: %w", context.LastError())
 	}
-	freeOnGC(&vfs)
 
-	return &vfs, nil
+	return newVfsFromHandle(context, newVfsHandle(vfsPtr)), nil
 }
 
 // Free releases the internal TileDB core data that was allocated on the C heap.
@@ -96,9 +129,7 @@ func NewVFS(context *Context, config *Config) (*VFS, error) {
 // can safely be called many times on the same object; if it has already
 // been freed, it will not be freed again.
 func (v *VFS) Free() {
-	if v.tiledbVFS != nil {
-		C.tiledb_vfs_free(&v.tiledbVFS)
-	}
+	v.tiledbVFS.Free()
 }
 
 // Context exposes the internal TileDB context used to initialize the vfs.
@@ -109,7 +140,7 @@ func (v *VFS) Context() *Context {
 // Config retrieves a copy of the config from vfs.
 func (v *VFS) Config() (*Config, error) {
 	var configPtr *C.tiledb_config_t
-	ret := C.tiledb_vfs_get_config(v.context.tiledbContext.Get(), v.tiledbVFS,
+	ret := C.tiledb_vfs_get_config(v.context.tiledbContext.Get(), v.tiledbVFS.Get(),
 		&configPtr)
 
 	if ret == C.TILEDB_OOM {
@@ -125,7 +156,7 @@ func (v *VFS) Config() (*Config, error) {
 func (v *VFS) CreateBucket(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_create_bucket(v.context.tiledbContext.Get(), v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_create_bucket(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), curi)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -139,7 +170,7 @@ func (v *VFS) CreateBucket(uri string) error {
 func (v *VFS) RemoveBucket(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_remove_bucket(v.context.tiledbContext.Get(), v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_remove_bucket(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), curi)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -153,7 +184,7 @@ func (v *VFS) RemoveBucket(uri string) error {
 func (v *VFS) EmptyBucket(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_empty_bucket(v.context.tiledbContext.Get(), v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_empty_bucket(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), curi)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -168,7 +199,7 @@ func (v *VFS) IsEmptyBucket(uri string) (bool, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var isEmpty C.int32_t
-	ret := C.tiledb_vfs_is_empty_bucket(v.context.tiledbContext.Get(), v.tiledbVFS, curi, &isEmpty)
+	ret := C.tiledb_vfs_is_empty_bucket(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), curi, &isEmpty)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -187,7 +218,7 @@ func (v *VFS) IsBucket(uri string) (bool, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var isBucket C.int32_t
-	ret := C.tiledb_vfs_is_bucket(v.context.tiledbContext.Get(), v.tiledbVFS, curi, &isBucket)
+	ret := C.tiledb_vfs_is_bucket(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), curi, &isBucket)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -205,7 +236,7 @@ func (v *VFS) IsBucket(uri string) (bool, error) {
 func (v *VFS) CreateDir(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_create_dir(v.context.tiledbContext.Get(), v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_create_dir(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), curi)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -220,7 +251,7 @@ func (v *VFS) IsDir(uri string) (bool, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var isDir C.int32_t
-	ret := C.tiledb_vfs_is_dir(v.context.tiledbContext.Get(), v.tiledbVFS, curi, &isDir)
+	ret := C.tiledb_vfs_is_dir(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), curi, &isDir)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -238,7 +269,7 @@ func (v *VFS) IsDir(uri string) (bool, error) {
 func (v *VFS) RemoveDir(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_remove_dir(v.context.tiledbContext.Get(), v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_remove_dir(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), curi)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -253,7 +284,7 @@ func (v *VFS) IsFile(uri string) (bool, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var isFile C.int32_t
-	ret := C.tiledb_vfs_is_file(v.context.tiledbContext.Get(), v.tiledbVFS, curi, &isFile)
+	ret := C.tiledb_vfs_is_file(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), curi, &isFile)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -271,7 +302,7 @@ func (v *VFS) IsFile(uri string) (bool, error) {
 func (v *VFS) RemoveFile(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_remove_file(v.context.tiledbContext.Get(), v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_remove_file(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), curi)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -286,7 +317,7 @@ func (v *VFS) FileSize(uri string) (uint64, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var cfsize C.uint64_t
-	ret := C.tiledb_vfs_file_size(v.context.tiledbContext.Get(), v.tiledbVFS, curi, &cfsize)
+	ret := C.tiledb_vfs_file_size(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), curi, &cfsize)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -303,7 +334,7 @@ func (v *VFS) MoveFile(oldURI string, newURI string) error {
 	cNewURI := C.CString(newURI)
 	defer C.free(unsafe.Pointer(cNewURI))
 
-	ret := C.tiledb_vfs_move_file(v.context.tiledbContext.Get(), v.tiledbVFS, cOldURI, cNewURI)
+	ret := C.tiledb_vfs_move_file(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), cOldURI, cNewURI)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -320,7 +351,7 @@ func (v *VFS) CopyFile(oldURI string, newURI string) error {
 	cNewURI := C.CString(newURI)
 	defer C.free(unsafe.Pointer(cNewURI))
 
-	ret := C.tiledb_vfs_copy_file(v.context.tiledbContext.Get(), v.tiledbVFS, cOldURI, cNewURI)
+	ret := C.tiledb_vfs_copy_file(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), cOldURI, cNewURI)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -337,7 +368,7 @@ func (v *VFS) MoveDir(oldURI string, newURI string) error {
 	cNewURI := C.CString(newURI)
 	defer C.free(unsafe.Pointer(cNewURI))
 
-	ret := C.tiledb_vfs_move_dir(v.context.tiledbContext.Get(), v.tiledbVFS, cOldURI, cNewURI)
+	ret := C.tiledb_vfs_move_dir(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), cOldURI, cNewURI)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -351,10 +382,9 @@ func (v *VFS) MoveDir(oldURI string, newURI string) error {
 func (v *VFS) Open(uri string, mode VFSMode) (*VFSfh, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	fh := &VFSfh{context: v.context, uri: uri, vfs: v}
-	freeOnGC(fh)
 
-	ret := C.tiledb_vfs_open(v.context.tiledbContext.Get(), v.tiledbVFS, curi, C.tiledb_vfs_mode_t(mode), &fh.tiledbVFSfh)
+	var fhPtr *C.tiledb_vfs_fh_t
+	ret := C.tiledb_vfs_open(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), curi, C.tiledb_vfs_mode_t(mode), &fhPtr)
 	runtime.KeepAlive(v)
 
 	if ret == C.TILEDB_OOM {
@@ -363,14 +393,14 @@ func (v *VFS) Open(uri string, mode VFSMode) (*VFSfh, error) {
 		return nil, fmt.Errorf("unknown error in VFS.Open: %w", v.context.LastError())
 	}
 
-	return fh, nil
+	return newVfsFhFromHandle(v.context, v, uri, newVfsFhHandle(fhPtr)), nil
 }
 
 // Close closes a file. This is flushes the buffered data into the file when the file
 // was opened in write (or append) mode. It is particularly important to be
 // called after S3 writes, as otherwise the writes will not take effect.
 func (v *VFS) Close(fh *VFSfh) error {
-	ret := C.tiledb_vfs_close(v.context.tiledbContext.Get(), fh.tiledbVFSfh)
+	ret := C.tiledb_vfs_close(v.context.tiledbContext.Get(), fh.tiledbVFSfh.Get())
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -385,7 +415,7 @@ func (v *VFS) Close(fh *VFSfh) error {
 func (v *VFS) Read(fh *VFSfh, offset uint64, nbytes uint64) ([]byte, error) {
 	bytes := make([]byte, nbytes)
 	cbuffer := slicePtr(bytes)
-	ret := C.tiledb_vfs_read(v.context.tiledbContext.Get(), fh.tiledbVFSfh, C.uint64_t(offset), cbuffer, C.uint64_t(nbytes))
+	ret := C.tiledb_vfs_read(v.context.tiledbContext.Get(), fh.tiledbVFSfh.Get(), C.uint64_t(offset), cbuffer, C.uint64_t(nbytes))
 	runtime.KeepAlive(v)
 	runtime.KeepAlive(fh)
 
@@ -402,7 +432,7 @@ func (v *VFS) Read(fh *VFSfh, offset uint64, nbytes uint64) ([]byte, error) {
 func (v *VFS) Write(fh *VFSfh, bytes []byte) error {
 	cbuffer := slicePtr(bytes)
 	defer runtime.KeepAlive(bytes)
-	ret := C.tiledb_vfs_write(v.context.tiledbContext.Get(), fh.tiledbVFSfh, cbuffer, C.uint64_t(len(bytes)))
+	ret := C.tiledb_vfs_write(v.context.tiledbContext.Get(), fh.tiledbVFSfh.Get(), cbuffer, C.uint64_t(len(bytes)))
 	runtime.KeepAlive(v)
 	runtime.KeepAlive(fh)
 
@@ -415,7 +445,7 @@ func (v *VFS) Write(fh *VFSfh, bytes []byte) error {
 
 // Sync flushes a file.
 func (v *VFS) Sync(fh *VFSfh) error {
-	ret := C.tiledb_vfs_sync(v.context.tiledbContext.Get(), fh.tiledbVFSfh)
+	ret := C.tiledb_vfs_sync(v.context.tiledbContext.Get(), fh.tiledbVFSfh.Get())
 	runtime.KeepAlive(v)
 	runtime.KeepAlive(fh)
 
@@ -430,7 +460,7 @@ func (v *VFS) Sync(fh *VFSfh) error {
 func (v *VFS) Touch(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
-	ret := C.tiledb_vfs_touch(v.context.tiledbContext.Get(), v.tiledbVFS, curi)
+	ret := C.tiledb_vfs_touch(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), curi)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -445,7 +475,7 @@ func (v *VFS) DirSize(uri string) (uint64, error) {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))
 	var cfsize C.uint64_t
-	ret := C.tiledb_vfs_dir_size(v.context.tiledbContext.Get(), v.tiledbVFS, curi, &cfsize)
+	ret := C.tiledb_vfs_dir_size(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), curi, &cfsize)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -491,7 +521,7 @@ func (v *VFS) NumOfFragmentsInPath(path string) (int, error) {
 	data := pointer.Save(&numOfFragmentsData)
 	defer pointer.Unref(data)
 
-	ret := C._num_of_folders_in_path(v.context.tiledbContext.Get(), v.tiledbVFS, cpath, data)
+	ret := C._num_of_folders_in_path(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), cpath, data)
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -506,7 +536,7 @@ func (v *VFS) NumOfFragmentsInPath(path string) (int, error) {
 // called after S3 writes, as otherwise the writes will not take effect.
 func (v *VFSfh) Close() error {
 
-	ret := C.tiledb_vfs_close(v.context.tiledbContext.Get(), v.tiledbVFSfh)
+	ret := C.tiledb_vfs_close(v.context.tiledbContext.Get(), v.tiledbVFSfh.Get())
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -539,7 +569,7 @@ func (v *VFSfh) Read(p []byte) (int, error) {
 	}
 
 	cbuffer := slicePtr(p)
-	ret := C.tiledb_vfs_read(v.context.tiledbContext.Get(), v.tiledbVFSfh, C.uint64_t(v.offset), cbuffer, C.uint64_t(nbytes))
+	ret := C.tiledb_vfs_read(v.context.tiledbContext.Get(), v.tiledbVFSfh.Get(), C.uint64_t(v.offset), cbuffer, C.uint64_t(nbytes))
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -582,7 +612,7 @@ func (v *VFSfh) ReadAt(p []byte, off int64) (int, error) {
 	}
 
 	cbuffer := slicePtr(p)
-	ret := C.tiledb_vfs_read(v.context.tiledbContext.Get(), v.tiledbVFSfh, C.uint64_t(off), cbuffer, C.uint64_t(nbytes))
+	ret := C.tiledb_vfs_read(v.context.tiledbContext.Get(), v.tiledbVFSfh.Get(), C.uint64_t(off), cbuffer, C.uint64_t(nbytes))
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -600,7 +630,7 @@ func (v *VFSfh) Write(bytes []byte) (int, error) {
 		return 0, nil
 	}
 	cbuffer := slicePtr(bytes)
-	ret := C.tiledb_vfs_write(v.context.tiledbContext.Get(), v.tiledbVFSfh, cbuffer, C.uint64_t(len(bytes)))
+	ret := C.tiledb_vfs_write(v.context.tiledbContext.Get(), v.tiledbVFSfh.Get(), cbuffer, C.uint64_t(len(bytes)))
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -612,7 +642,7 @@ func (v *VFSfh) Write(bytes []byte) (int, error) {
 
 // Sync flushes a file.
 func (v *VFSfh) Sync() error {
-	ret := C.tiledb_vfs_sync(v.context.tiledbContext.Get(), v.tiledbVFSfh)
+	ret := C.tiledb_vfs_sync(v.context.tiledbContext.Get(), v.tiledbVFSfh.Get())
 	runtime.KeepAlive(v)
 
 	if ret != C.TILEDB_OK {
@@ -709,7 +739,7 @@ func (v *VFS) List(path string) ([]string, []string, error) {
 	data := pointer.Save(&folderData)
 	defer pointer.Unref(data)
 
-	ret := C._vfs_ls(v.context.tiledbContext.Get(), v.tiledbVFS, cpath, data)
+	ret := C._vfs_ls(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), cpath, data)
 	runtime.KeepAlive(v)
 	if ret != C.TILEDB_OK {
 		return nil, nil, fmt.Errorf("error in getting path listing %s: %w", path, v.context.LastError())
@@ -762,7 +792,7 @@ func (v *VFS) VisitRecursive(path string, callback VisitRecursiveCallback) error
 	data := pointer.Save(state)
 	defer pointer.Unref(data)
 
-	ret := C._vfs_ls_recursive(v.context.tiledbContext.Get(), v.tiledbVFS, cpath, data)
+	ret := C._vfs_ls_recursive(v.context.tiledbContext.Get(), v.tiledbVFS.Get(), cpath, data)
 	runtime.KeepAlive(v)
 	if ret != C.TILEDB_OK {
 		return fmt.Errorf("error in recursively listing path %s: %w", path, v.context.LastError())


### PR DESCRIPTION
[SC-64250](https://app.shortcut.com/tiledb-inc/story/64250)

This PR refactors the intrastructure managing the lifetime of native C API handles. The goals are the following:

1. Use Go 1.24's improved finalizer API.
2. Deregister the finalizer if the user manually calls `Free` on an object.
3. Improve safety.
4. Minimize the amount of added boilerplate.
5. Maintain compatibility with previous Go versions.

We introduce a new type, `capiHandle` which is responsible for managing the lifetime of the native handles. When creating an object, we now register the finalizer on the `*capiHandle` instead of the returned pointer. By the use of this extra level of indirection and atomic operations, we prevent double-frees and use-after-frees, including if you accidentally copy an object like we do in https://github.com/TileDB-Inc/TileDB-Go/pull/366#discussion_r1956703094. To provide type safety, we introduce specific handle types that embed a `*capiHandle`.

There are two mostly identical implementations of `capiHandle`; for Go versions before and since 1.24. Once Go 1.23 goes out of support, we should remove the downlevel implemenation.