### PR TITLE
Close array and group on Free.

### DIFF
--- a/array.go
+++ b/array.go
@@ -151,6 +151,7 @@ func NewArray(tdbCtx *Context, uri string) (*Array, error) {
 // can safely be called many times on the same object; if it has already
 // been freed, it will not be freed again.
 func (a *Array) Free() {
+	a.Close()
 	a.tiledbArray.Free()
 }
 

--- a/array.go
+++ b/array.go
@@ -159,7 +159,7 @@ func (a *Array) Context() *Context {
 	return a.context
 }
 
-// ArrayOpenOptions defines the flexible parameters in which arrays can be opened with.
+// ArrayOpenOption defines the flexible parameters in which arrays can be opened with.
 type ArrayOpenOption func(tdbArray *Array) error
 
 // WithEndTime sets the subsequent Open call to use the given time

--- a/array_test.go
+++ b/array_test.go
@@ -421,6 +421,7 @@ func TestArray_Metadata(t *testing.T) {
 
 		// Add some metadata in the future
 		tempArray, err := NewArray(nil, a.uri)
+		require.NoError(t, err)
 		futureTimestamp := uint64(time.Date(time.Now().Year()+1, 1, 1, 0, 0, 0, 0, time.UTC).UnixMilli())
 		require.NoError(t, tempArray.OpenWithOptions(TILEDB_WRITE, WithEndTimestamp(futureTimestamp)))
 		futureKey, futureValue := "future_key", "future_value"
@@ -431,6 +432,7 @@ func TestArray_Metadata(t *testing.T) {
 		// Make sure the metadata is available at the initial timestamp.
 		require.NoError(t, a.OpenWithOptions(TILEDB_READ, WithEndTimestamp(timestamp)))
 		num, err := a.GetMetadataNum()
+		require.NoError(t, err)
 		require.EqualValues(t, 1, num)
 		dataType, valNum, value, err := a.GetMetadata(pastKey)
 		require.NoError(t, err)
@@ -442,6 +444,7 @@ func TestArray_Metadata(t *testing.T) {
 		// Make sure both metadata fields are available at the future timestamp.
 		require.NoError(t, a.OpenWithOptions(TILEDB_READ, WithEndTimestamp(futureTimestamp)))
 		num, err = a.GetMetadataNum()
+		require.NoError(t, err)
 		require.EqualValues(t, 2, num)
 		dataType, valNum, value, err = a.GetMetadata(pastKey)
 		require.NoError(t, err)

--- a/group.go
+++ b/group.go
@@ -82,6 +82,7 @@ func (g *Group) Open(queryType QueryType) error {
 }
 
 func (g *Group) Free() {
+	g.Close()
 	g.group.Free()
 }
 

--- a/group_test.go
+++ b/group_test.go
@@ -92,11 +92,11 @@ func TestGroups_Metadata(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, uint64(1), num)
 	// The future_metadata should not exist at this timestamp.
-	dType, valNum, val, err := group.GetMetadata(futureKey)
+	_, valNum, _, err := group.GetMetadata(futureKey)
 	require.Error(t, err)
 	require.EqualValues(t, 0, valNum)
 
-	dType, valNum, val, err = group.GetMetadata("key")
+	dType, valNum, val, err := group.GetMetadata("key")
 	require.NoError(t, err)
 	assert.EqualValues(t, dType, TILEDB_STRING_UTF8)
 	assert.EqualValues(t, val, "value")
@@ -114,6 +114,8 @@ func TestGroups_Metadata(t *testing.T) {
 
 	dType, valNum, val, err = group.GetMetadata(futureKey)
 	require.NoError(t, err)
+	require.EqualValues(t, dType, TILEDB_STRING_UTF8)
+	require.EqualValues(t, val, val.(string))
 	require.EqualValues(t, len(futureValue), valNum)
 	require.NoError(t, group.Close())
 


### PR DESCRIPTION
#370 removed closing of the array and group when `Free` is called which failed some release testing for TileDB 2.28 in [CORE-18](https://linear.app/tiledb/issue/CORE-18/test-tiledb-2280-rc0-in-tiledb-go-tiledb-cloud-rest-tiledb-server). This ensures we close the array / group when Free is called and adds some unit tests to catch this in the future.