### PR TITLE
Update to TileDB 2.28.0

### DIFF
--- a/.github/workflows/tiledb-go.yml
+++ b/.github/workflows/tiledb-go.yml
@@ -10,9 +10,9 @@ on:
 
 env:
   # The version of TileDB to test against.
-  CORE_VERSION: "2.27.2"
+  CORE_VERSION: "2.28.0"
   # The abbreviated git commit hash to use.
-  CORE_HASH: "1757013"
+  CORE_HASH: "4764907"
 
 jobs:
   golangci:

--- a/README.md
+++ b/README.md
@@ -139,3 +139,10 @@ TileDB 2.27.0.
 `Array.Create` is deprecated in favor of `CreateArray`.
 `Array.Consolidate` is deprecated in favor of `ConsolidateArray`.
 `Array.Vacuum` is deprecated in favor of `VacuumArray`.
+
+## Breaking Changes
+
+### 0.36.0
+
+`Free` will no longer call `Close` for `Group` and `Array` objects.
+The caller is responsible for closing the `Array` or `Group` after operations such as writing metadata or modifying group members.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ as such the below table reference which versions are compatible.
 | 0.32.0            | 2.26.X         |
 | 0.33.0            | 2.26.X         |
 | 0.34.0            | 2.27.X         |
+| 0.35.0            | 2.27.X         |
+| 0.36.0            | 2.28.X         |
 
 
 ## Deprecated Functionality
@@ -131,3 +133,9 @@ the following TileDB release.
 
 `SerializeArrayMaxBufferSizes` is removed as the underlying core method `tiledb_serialize_array_max_buffer_sizes` is deprecated in
 TileDB 2.27.0.
+
+### 0.36.0
+
+`Array.Create` is deprecated in favor of `CreateArray`.
+`Array.Consolidate` is deprecated in favor of `ConsolidateArray`.
+`Array.Vacuum` is deprecated in favor of `VacuumArray`.

--- a/array_schema_experimental.go
+++ b/array_schema_experimental.go
@@ -1,0 +1,41 @@
+package tiledb
+
+/*
+#include <tiledb/tiledb.h>
+#include <tiledb/tiledb_experimental.h>
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+// NewArraySchemaAtTime allocates a new ArraySchema at the provided createTime.
+func NewArraySchemaAtTime(tdbCtx *Context, arrayType ArrayType, createTime time.Time) (*ArraySchema, error) {
+	return NewArraySchemaAtTimestamp(tdbCtx, arrayType, uint64(createTime.UnixMilli()))
+}
+
+// NewArraySchemaAtTimestamp allocates a new ArraySchema at the provided timestamp.
+func NewArraySchemaAtTimestamp(tdbCtx *Context, arrayType ArrayType, timestamp uint64) (*ArraySchema, error) {
+	var arraySchemaPtr *C.tiledb_array_schema_t
+	var cTimestamp C.uint64_t = C.uint64_t(timestamp)
+	ret := C.tiledb_array_schema_alloc_at_timestamp(tdbCtx.tiledbContext.Get(), C.tiledb_array_type_t(arrayType),
+		cTimestamp, &arraySchemaPtr)
+	runtime.KeepAlive(tdbCtx)
+	if ret != C.TILEDB_OK {
+		return nil, fmt.Errorf("error creating tiledb arraySchema: %w", tdbCtx.LastError())
+	}
+	return newArraySchemaFromHandle(tdbCtx, newArraySchemaHandle(arraySchemaPtr)), nil
+}
+
+func (a *ArraySchema) TimestampRange() (uint64, uint64, error) {
+	var lo C.uint64_t
+	var hi C.uint64_t
+	ret := C.tiledb_array_schema_timestamp_range(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &lo, &hi)
+	if ret != C.TILEDB_OK {
+		return 0, 0, fmt.Errorf("error getting timestamp range: %w", a.context.LastError())
+	}
+	return uint64(lo), uint64(hi), nil
+}

--- a/array_schema_experimental.go
+++ b/array_schema_experimental.go
@@ -9,26 +9,7 @@ import "C"
 import (
 	"fmt"
 	"runtime"
-	"time"
 )
-
-// NewArraySchemaAtTime allocates a new ArraySchema at the provided createTime.
-func NewArraySchemaAtTime(tdbCtx *Context, arrayType ArrayType, createTime time.Time) (*ArraySchema, error) {
-	return NewArraySchemaAtTimestamp(tdbCtx, arrayType, uint64(createTime.UnixMilli()))
-}
-
-// NewArraySchemaAtTimestamp allocates a new ArraySchema at the provided timestamp.
-func NewArraySchemaAtTimestamp(tdbCtx *Context, arrayType ArrayType, timestamp uint64) (*ArraySchema, error) {
-	var arraySchemaPtr *C.tiledb_array_schema_t
-	var cTimestamp C.uint64_t = C.uint64_t(timestamp)
-	ret := C.tiledb_array_schema_alloc_at_timestamp(tdbCtx.tiledbContext.Get(), C.tiledb_array_type_t(arrayType),
-		cTimestamp, &arraySchemaPtr)
-	runtime.KeepAlive(tdbCtx)
-	if ret != C.TILEDB_OK {
-		return nil, fmt.Errorf("error creating tiledb arraySchema: %w", tdbCtx.LastError())
-	}
-	return newArraySchemaFromHandle(tdbCtx, newArraySchemaHandle(arraySchemaPtr)), nil
-}
 
 // TimestampRange gets the timestamp range for the array schema.
 func (a *ArraySchema) TimestampRange() (uint64, uint64, error) {

--- a/array_schema_experimental.go
+++ b/array_schema_experimental.go
@@ -30,10 +30,12 @@ func NewArraySchemaAtTimestamp(tdbCtx *Context, arrayType ArrayType, timestamp u
 	return newArraySchemaFromHandle(tdbCtx, newArraySchemaHandle(arraySchemaPtr)), nil
 }
 
+// TimestampRange gets the timestamp range for the array schema.
 func (a *ArraySchema) TimestampRange() (uint64, uint64, error) {
 	var lo C.uint64_t
 	var hi C.uint64_t
 	ret := C.tiledb_array_schema_timestamp_range(a.context.tiledbContext.Get(), a.tiledbArraySchema.Get(), &lo, &hi)
+	runtime.KeepAlive(a)
 	if ret != C.TILEDB_OK {
 		return 0, 0, fmt.Errorf("error getting timestamp range: %w", a.context.LastError())
 	}

--- a/array_schema_experimental_test.go
+++ b/array_schema_experimental_test.go
@@ -2,7 +2,6 @@ package tiledb
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,19 +15,45 @@ func TestArraySchemaAtTime(t *testing.T) {
 	context, err := NewContext(config)
 	require.NoError(t, err)
 
-	// Cannot create array schema at timestamp 0.
-	arraySchema, err := NewArraySchemaAtTimestamp(context, TILEDB_DENSE, 0)
-	require.Error(t, err)
-	require.Nil(t, arraySchema)
-
-	createTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
-	arraySchema, err = NewArraySchemaAtTime(context, TILEDB_DENSE, createTime)
+	arraySchema, err := NewArraySchema(context, TILEDB_DENSE)
 	require.NoError(t, err)
 	assert.NotNil(t, arraySchema)
 
 	lo, hi, err := arraySchema.TimestampRange()
 	require.NoError(t, err)
 
-	require.EqualValues(t, lo, createTime.UnixMilli())
-	require.EqualValues(t, hi, createTime.UnixMilli())
+	domain, err := NewDomain(context)
+	require.NoError(t, err)
+	assert.NotNil(t, domain)
+	dimension, err := NewDimension(context, "d1", TILEDB_UINT8, []uint8{1, 10}, uint8(5))
+	require.NoError(t, err)
+	assert.NotNil(t, dimension)
+	require.NoError(t, domain.AddDimensions(dimension))
+
+	attr, err := NewAttribute(context, "a1", TILEDB_UINT8)
+	require.NoError(t, err)
+	assert.NotNil(t, attr)
+
+	require.NoError(t, arraySchema.SetDomain(domain))
+	require.NoError(t, arraySchema.AddAttributes(attr))
+
+	tempDir := t.TempDir()
+	err = CreateArray(context, tempDir, arraySchema)
+	require.NoError(t, err)
+
+	arr, err := NewArray(context, tempDir)
+	require.NoError(t, err)
+	require.NotNil(t, arr)
+
+	// Test we can open the array with timestamps given by ArraySchema.TimestampRange
+	err = arr.OpenWithOptions(TILEDB_READ, WithStartTimestamp(lo), WithEndTimestamp(hi))
+	require.NoError(t, err)
+
+	// Opened Start and End timestamps should be equal to TimestampRange values.
+	start, err := arr.OpenStartTimestamp()
+	require.NoError(t, err)
+	end, err := arr.OpenEndTimestamp()
+	require.NoError(t, err)
+	require.EqualValues(t, lo, start)
+	require.EqualValues(t, hi, end)
 }

--- a/array_schema_experimental_test.go
+++ b/array_schema_experimental_test.go
@@ -1,0 +1,33 @@
+package tiledb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestArraySchemaAtTime tests creating an array schema at a provided timestamp.
+func TestArraySchemaAtTime(t *testing.T) {
+	config, err := NewConfig()
+	require.NoError(t, err)
+
+	context, err := NewContext(config)
+	require.NoError(t, err)
+
+	// Cannot create array schema at timestamp 0.
+	arraySchema, err := NewArraySchemaAtTimestamp(context, TILEDB_DENSE, 0)
+	require.Error(t, err)
+
+	createTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	arraySchema, err = NewArraySchemaAtTime(context, TILEDB_DENSE, createTime)
+	require.NoError(t, err)
+	assert.NotNil(t, arraySchema)
+
+	lo, hi, err := arraySchema.TimestampRange()
+	require.NoError(t, err)
+
+	require.EqualValues(t, lo, createTime.UnixMilli())
+	require.EqualValues(t, hi, createTime.UnixMilli())
+}

--- a/array_schema_experimental_test.go
+++ b/array_schema_experimental_test.go
@@ -19,6 +19,7 @@ func TestArraySchemaAtTime(t *testing.T) {
 	// Cannot create array schema at timestamp 0.
 	arraySchema, err := NewArraySchemaAtTimestamp(context, TILEDB_DENSE, 0)
 	require.Error(t, err)
+	require.Nil(t, arraySchema)
 
 	createTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 	arraySchema, err = NewArraySchemaAtTime(context, TILEDB_DENSE, createTime)

--- a/range.go
+++ b/range.go
@@ -47,7 +47,7 @@ func ExtractRange[T DimensionType](r Range) ([]T, error) {
 }
 
 // Endpoints returns the endpoint of the range. This is useful
-// to print the range or serialize it, without infering the type first.
+// to print the range or serialize it, without inferring the type first.
 func (r Range) Endpoints() (start, end any) {
 	return r.start, r.end
 }

--- a/stats.go
+++ b/stats.go
@@ -150,3 +150,13 @@ func StatsRaw() (string, error) {
 
 	return s, nil
 }
+
+// StatsIsEnabled returns whether stats are enabled or not
+func StatsIsEnabled() (bool, error) {
+	var isEnabled C.uint8_t
+	ret := C.tiledb_stats_is_enabled(&isEnabled)
+	if ret != C.TILEDB_OK {
+		return false, errors.New("error checking if stats is enabled")
+	}
+	return isEnabled > 0, nil
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -60,9 +60,17 @@ func TestStats(t *testing.T) {
 
 // Test statistics
 func TestStatsRaw(t *testing.T) {
-	// Enable statistics
-	err := StatsEnable()
+	// Check statistics are not enabled
+	isEnabled, err := StatsIsEnabled()
 	require.NoError(t, err)
+	require.EqualValues(t, false, isEnabled)
+
+	// Enable statistics
+	err = StatsEnable()
+	require.NoError(t, err)
+	isEnabled, err = StatsIsEnabled()
+	require.NoError(t, err)
+	require.EqualValues(t, true, isEnabled)
 
 	// Reset all internal counters to 0
 	require.NoError(t, StatsReset())

--- a/vfs.go
+++ b/vfs.go
@@ -456,7 +456,7 @@ func (v *VFS) Sync(fh *VFSfh) error {
 	return nil
 }
 
-// Touch touches a file, i.e., creates a new empty file.
+// Touch touches a file, i.e., creates a new empty file. Existing files will not be overwritten.
 func (v *VFS) Touch(uri string) error {
 	curi := C.CString(uri)
 	defer C.free(unsafe.Pointer(curi))

--- a/vfs_test.go
+++ b/vfs_test.go
@@ -55,14 +55,21 @@ func TestVFS(t *testing.T) {
 
 	// Copy file
 	require.NoError(t, vfs.CopyFile(tmpFilePath, dstTmpFilePath))
-	_, err = os.Stat(dstTmpFilePath)
+	srcStat, err := os.Stat(tmpFilePath)
 	require.NoError(t, err)
-	if err == nil {
-		os.Remove(dstTmpFilePath)
-	}
+	dstStat, err := os.Stat(dstTmpFilePath)
+	require.NoError(t, err)
+	require.EqualValues(t, srcStat.Size(), dstStat.Size())
 
-	// Remove File
+	// Touch should not overwrite existing files.
+	require.NoError(t, vfs.Touch(dstTmpFilePath))
+	dstStatTouch, err := os.Stat(dstTmpFilePath)
+	require.NoError(t, err)
+	require.EqualValues(t, dstStat.Size(), dstStatTouch.Size())
+
+	// Remove Files
 	require.NoError(t, vfs.RemoveFile(tmpFilePath))
+	require.NoError(t, vfs.RemoveFile(dstTmpFilePath))
 
 	// Remove directory
 	require.NoError(t, vfs.RemoveDir(tmpPath))


### PR DESCRIPTION
This updates to TileDB 2.28.0 and wraps new APIs added for this release.