### PR TITLE
add group metadata functions with similar pattern that arrays use

### DIFF
--- a/array.go
+++ b/array.go
@@ -154,7 +154,7 @@ func (a *Array) Free() {
 	a.tiledbArray.Free()
 }
 
-// Context exposes the internal TileDB context used to initialize the array.
+// Context returns the TileDB context used to initialize the array.
 func (a *Array) Context() *Context {
 	return a.context
 }
@@ -1151,18 +1151,14 @@ func (a *Array) GetMetadataFromIndexWithValueLimit(index uint64, limit *uint) (*
 	return &arrayMetadata, nil
 }
 
-// GetMetadataMap returns a map[string]*ArrayMetadata where key is the key of
-// each metadata added and value is an ArrayMetadata struct. The map contains
-// all array metadata previously added.
+// GetMetadataMap returns a map with the array's metadata, indexed by their key.
 func (a *Array) GetMetadataMap() (map[string]*ArrayMetadata, error) {
 	return a.GetMetadataMapWithValueLimit(nil)
 }
 
-// GetMetadataMapWithValueLimit returns a map[string]*ArrayMetadata where key is the key of
-// each metadata added and value is an ArrayMetadata struct. The map contains
-// all array metadata previously added.
-// The limit parameter limits the number of values returned if string or array.
-// This is helpful for pushdown of limitting metadata. If nil, value is returned
+// GetMetadataMapWithValueLimit returns a map with the array's metadata, indexed by their key.
+// The limit parameter limits the size of values returned if string or array.
+// This is helpful for pushdown of limiting metadata. If nil, value is returned
 // in full.
 func (a *Array) GetMetadataMapWithValueLimit(limit *uint) (map[string]*ArrayMetadata, error) {
 	metadataMap := make(map[string]*ArrayMetadata)

--- a/group.go
+++ b/group.go
@@ -35,7 +35,7 @@ type Group struct {
 	context *Context
 }
 
-// Context exposes the internal TileDB context used to initialize the group.
+// Context returns the TileDB context used to initialize the group.
 func (g *Group) Context() *Context {
 	return g.context
 }
@@ -354,17 +354,13 @@ func (g *Group) GetMetadata(key string) (Datatype, uint, interface{}, error) {
 	return datatype, valueNum, value, nil
 }
 
-// GetMetadataMap returns a map[string]*GroupMetadata where key is the key of
-// each metadata added and value is an GroupMetadata struct. The map contains
-// all group metadata previously added.
+// GetMetadataMap returns a map with the group's metadata, indexed by their key.
 func (g *Group) GetMetadataMap() (map[string]*GroupMetadata, error) {
 	return g.GetMetadataMapWithValueLimit(nil)
 }
 
-// GetMetadataMapWithValueLimit returns a map[string]*GroupMetadata where key is the key of
-// each metadata added and value is an GroupMetadata struct. The map contains
-// all group metadata previously added.
-// The limit parameter limits the number of values returned if string or group.
+// GetMetadataMapWithValueLimit returns a map with the group's metadata, indexed by their key.
+// The limit parameter limits the size of values returned if string or array.
 // This is helpful for pushdown of limiting metadata. If nil, value is returned
 // in full.
 func (g *Group) GetMetadataMapWithValueLimit(limit *uint) (map[string]*GroupMetadata, error) {

--- a/group_test.go
+++ b/group_test.go
@@ -87,10 +87,12 @@ func TestGroups_Metadata(t *testing.T) {
 	require.NoError(t, group.Close())
 
 	// Verify fetching metadata with metadata map
+	require.NoError(t, group.Open(TILEDB_READ))
 	gmd, err := group.GetMetadataMap()
 	require.NoError(t, err)
 	require.Lenf(t, gmd, 1, "expected metadata map")
 	require.Equal(t, gmd["key"], "value")
+	require.NoError(t, group.Close())
 
 	// =========================================================================
 	// Remove it

--- a/group_test.go
+++ b/group_test.go
@@ -95,6 +95,7 @@ func TestGroups_Metadata(t *testing.T) {
 	require.NotNil(t, md)
 	require.Equal(t, TILEDB_STRING_UTF8, md.Datatype)
 	require.Equal(t, "value", md.Value)
+	require.NoError(t, group.Close())
 
 	// =========================================================================
 	// Remove it

--- a/group_test.go
+++ b/group_test.go
@@ -91,8 +91,10 @@ func TestGroups_Metadata(t *testing.T) {
 	gmd, err := group.GetMetadataMap()
 	require.NoError(t, err)
 	require.Lenf(t, gmd, 1, "expected metadata map")
-	require.Equal(t, gmd["key"], "value")
-	require.NoError(t, group.Close())
+	md := gmd["key"]
+	require.NotNil(t, md)
+	require.Equal(t, TILEDB_STRING_UTF8, md.Datatype)
+	require.Equal(t, "value", md.Value)
 
 	// =========================================================================
 	// Remove it

--- a/group_test.go
+++ b/group_test.go
@@ -86,6 +86,12 @@ func TestGroups_Metadata(t *testing.T) {
 	assert.EqualValues(t, val, "value")
 	require.NoError(t, group.Close())
 
+	// Verify fetching metadata with metadata map
+	gmd, err := group.GetMetadataMap()
+	require.NoError(t, err)
+	require.Lenf(t, gmd, 1, "expected metadata map")
+	require.Equal(t, gmd["key"], "value")
+
 	// =========================================================================
 	// Remove it
 	require.NoError(t, setConfigForWrite(group, 1))


### PR DESCRIPTION
This PR fixes [ENG-98](https://linear.app/tiledb/issue/ENG-98/add-support-for-group-metadata-in-tiledb-go).

While working with asset metadata and specifically group metadata i noticed that we could add some functions in `group.go` so that we can have a similar pattern on how to interact with core metadata with arrays and groups. All the infra and core support is there we were just missing the functions from this PR.