### PR TITLE
Fix error when a member (optional) name is empty

### DIFF
--- a/group.go
+++ b/group.go
@@ -290,6 +290,7 @@ func (g *Group) GetMemberFromIndex(index uint64) (string, string, ObjectTypeEnum
 	if cname != nil {
 		defer C.tiledb_string_free(&cname)
 
+		var err error
 		name, err = stringHandleToString(cname)
 		if err != nil {
 			return "", "", TILEDB_INVALID, err

--- a/group.go
+++ b/group.go
@@ -285,14 +285,18 @@ func (g *Group) GetMemberFromIndex(index uint64) (string, string, ObjectTypeEnum
 		return "", "", TILEDB_INVALID, fmt.Errorf("error getting member by index for group: %w", g.context.LastError())
 	}
 	defer C.tiledb_string_free(&curi)
-	defer C.tiledb_string_free(&cname)
 
-	uri, err := stringHandleToString(curi)
-	if err != nil {
-		return "", "", TILEDB_INVALID, err
+	var name string
+	if cname != nil {
+		defer C.tiledb_string_free(&cname)
+
+		name, err = stringHandleToString(cname)
+		if err != nil {
+			return "", "", TILEDB_INVALID, err
+		}
 	}
 
-	name, err := stringHandleToString(cname)
+	uri, err := stringHandleToString(curi)
 	if err != nil {
 		return "", "", TILEDB_INVALID, err
 	}


### PR DESCRIPTION
A group might have a name specified or not and we shouldn't fail if the name returned by `tiledb_group_get_member_by_index_v2` is `nil`.